### PR TITLE
#1 removed unused dependency jar files from build.xml file

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -61,16 +61,12 @@
         <mkdir dir="${ivy.lib.dir}"/>
         <echo message="installing netbeans help files..."/>
         <get src="https://github.com/rsabhi/NBhelp/raw/master/org-netbeans-modules-javahelp.jar"
-             dest="${ivy.lib.dir}" usetimestamp="true"/>
-        <get src="https://github.com/rsabhi/NBhelp/raw/master/org-netbeans-modules-javahelp.jar"
              dest="${nbplatform.default.netbeans.dest.dir}/platform/modules/" usetimestamp="true"/>
     </target>
     
     <target name="-download-javahelp-indexfile" >
         <mkdir dir="${ivy.lib.dir}"/>
         <echo message="installing netbeans help index files..."/>
-        <get src="https://github.com/rsabhi/NBhelp/raw/master/jhall-2.0_05.jar"
-             dest="${ivy.lib.dir}" usetimestamp="true"/>
         <get src="https://github.com/rsabhi/NBhelp/raw/master/jhall-2.0_05.jar"
              dest="${nbplatform.default.netbeans.dest.dir}/platform/modules/ext/" usetimestamp="true"/>
     </target>


### PR DESCRIPTION
### Requirements
As part of Netbeans11-JDK11 migration,  2 dependent jar files for help (jhall-2.0_05.jar, org-netbeans-modules-javahelp.jar) are included in the core dependencies module. This need to be removed

### Description of the Change
Unused jar files (jhall-2.0_05.jar, org-netbeans-modules-javahelp.jar) downloaded to core dependeciy module are now removed from build.xml file.

### Steps to Reproduce
<!--[First Step][Second Step][and so on...]
Expected behaviour: [What you expect to happen]Actual behaviour: [What actually happens]Reproduces how often: [What percentage of the time does it reproduce?]Additional InformationAny additional information, configuration or data that might be necessary to reproduce the issue.
<!--
--




### Alternate Designs

<!-- 

Explain what other alternates were considered and why the proposed version was 
selected.

-->

### Why Should This Be In Core?

<!--

Explain why this functionality should be in Constellation Core as opposed to a 
different module suite.

-->

### Benefits

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process

<!--

What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (e.g., buttons you clicked, text you typed, 
commands you ran, etc.), and describe the results you observed.

-->

### Applicable Issues

<!-- Enter any applicable Issues here -->
