### PR TITLE
Changed texture2D to texture as the new method works on both MacOS an…

### DIFF
--- a/CoreOpenGLDisplay/src/au/gov/asd/tac/constellation/visual/opengl/renderer/shaders/Graph.fs
+++ b/CoreOpenGLDisplay/src/au/gov/asd/tac/constellation/visual/opengl/renderer/shaders/Graph.fs
@@ -6,5 +6,5 @@ uniform sampler2D graphTexture;
 out vec4 fragColor;
 
 void main(void) {
-    fragColor = texture2D(graphTexture, textureCoordinate) /*vec4(0.0, 1.0, 1.0, 1.0)*/;
+    fragColor = texture(graphTexture, textureCoordinate) /*vec4(0.0, 1.0, 1.0, 1.0)*/;
 }

--- a/CoreOpenGLDisplay/src/au/gov/asd/tac/constellation/visual/opengl/renderer/shaders/Graph.vs
+++ b/CoreOpenGLDisplay/src/au/gov/asd/tac/constellation/visual/opengl/renderer/shaders/Graph.vs
@@ -9,5 +9,5 @@ uniform sampler2D depthTexture;
 
 void main(void) {
     textureCoordinate = inputTextureCoordinates.xy;
-    gl_Position = position; /*vec4(position.xy, texture2D(graphTexture, textureCoordinate));*/
+    gl_Position = position; /*vec4(position.xy, texture(graphTexture, textureCoordinate));*/
 }


### PR DESCRIPTION
…d Windows/Linux

### Description of the Change
Changed two files to use another method from OpenGL, this method is valid for both Windows and MacOS OpenGL libraries. 

### Why Should This Be In Core?
This change will enable further development for the Mac platform

### Benefits
Constellation will open on a Mac

### Possible Drawbacks

None

### Verification Process
I have tested this on a Mac, Windows and Linux (CentOS and Ubuntu) platform. The software works as before on Windows and Linux. 

### Applicable Issues

On Mac there is an issue where the Graph interaction is offset from where the mouse is.