### PR TITLE
Fix an NPE

### DIFF
--- a/CoreFunctionality/src/au/gov/asd/tac/constellation/functionality/tutorial/TutorialStartup.java
+++ b/CoreFunctionality/src/au/gov/asd/tac/constellation/functionality/tutorial/TutorialStartup.java
@@ -38,8 +38,13 @@ public class TutorialStartup implements Runnable {
         if (prefs.getBoolean(ApplicationPreferenceKeys.TUTORIAL_ON_STARTUP, ApplicationPreferenceKeys.TUTORIAL_ON_STARTUP_DEFAULT)) {
             SwingUtilities.invokeLater(() -> {
                 final TopComponent tutorial = WindowManager.getDefault().findTopComponent(TutorialTopComponent.class.getSimpleName());
-                tutorial.open();
-                tutorial.requestActive();
+                if (tutorial != null) {
+                    if (!tutorial.isOpened()) {
+                        tutorial.open();
+                    }
+                    tutorial.setEnabled(true);
+                    tutorial.requestActive();
+                }
             });
         }
     }


### PR DESCRIPTION
<!--

### Requirements

* Filling out the template is required. Any pull request that does not include 
enough information to be reviewed in a timely manner may be closed at the 
maintainers' discretion.
* All new code requires unit tests to ensure they work as expected and will 
continue to work as new code is added in the future (regression testing).
* Have you read Constellation's Code of Conduct? By filing an issue, you are 
expected to comply with it, including treating everyone with respect: 
https://github.com/constellation-app/constellation/blob/master/CODE_OF_CONDUCT.md

-->

### Description of the Change

* An NPE can sometimes occur when running unit tests which can trigger the `TutorialStartup` class to be called
* This fix also aligns this class with how other `WindowManager.getDefault().findTopComponent` calls are handled such as `KTrussAction.java`

### Alternate Designs

<!-- 

Explain what other alternates were considered and why the proposed version was 
selected.

-->

### Why Should This Be In Core?

<!--

Explain why this functionality should be in Constellation Core as opposed to a 
different module suite.

-->

### Benefits

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process

<!--

What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (e.g., buttons you clicked, text you typed, 
commands you ran, etc.), and describe the results you observed.

-->

### Applicable Issues

<!-- Enter any applicable Issues here -->
