### PR TITLE
:bug: Fix issue #133 - do not infer column types.

### DIFF
--- a/CoreWebServer/src/au/gov/asd/tac/constellation/webserver/constellation_client.py
+++ b/CoreWebServer/src/au/gov/asd/tac/constellation/webserver/constellation_client.py
@@ -415,7 +415,7 @@ class Constellation:
         # We can't create a DataFrame if there is no data.
         #
         if data:
-            df = pd.read_json(data, orient='split', convert_dates=False)
+            df = pd.read_json(data, orient='split', dtype=False, convert_dates=False)
 
             self.types = self._fix_types(df)
             return df
@@ -466,7 +466,7 @@ class Constellation:
 
         r = self.rest_request(endpoint='/v1/graph', path='get')
 
-        df = pd.read_json(r.text, orient='split', convert_dates=False)
+        df = pd.read_json(r.text, orient='split', dtype=False, convert_dates=False)
 
         self._fix_types(df)
 


### PR DESCRIPTION
Add the `dtype=False` parameter to calls to pandas.read_json() in get_dataframe() and get_graph_attributes().
This stops pandas from inferring types based on the column values.

### Description of the Change

Add `dtype=False` to the `pandas.read_json()` calls in `constellation_client.py`.

This is done according to the pandas documentation at https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.read_json.html?highlight=read_json#pandas.read_json: if dtype is False, then don’t infer dtypes at all.

### Benefits

The client dataframe will contain correctly typed columns.

### Possible Drawbacks

There should be no negative impacts.

### Verification Process

Rerun the example in the issue description to see that the column types are correct and the values have not been modified.

### Applicable Issues

Issue #133.
