### PR TITLE
:sparkles: Graphids

### DIFF
--- a/CoreWebServer/src/au/gov/asd/tac/constellation/filetransport/FileListener.java
+++ b/CoreWebServer/src/au/gov/asd/tac/constellation/filetransport/FileListener.java
@@ -217,6 +217,7 @@ public class FileListener implements Runnable {
      * @throws Exception because of AutoCloseable
      */
     private void parseAndExecute(final String verb, final String endpoint, final String path, final JsonNode args) throws Exception {
+        final String graphId = getString(args, "graph_id");
         switch (endpoint) {
             case "/v1/graph":
                 switch (verb) {
@@ -224,7 +225,7 @@ public class FileListener implements Runnable {
                         switch (path) {
                             case "get":
                                 try (final OutputStream out = outStream(restPath, CONTENT_OUT)) {
-                                    GraphImpl.get_get(out);
+                                    GraphImpl.get_get(graphId, out);
                                 }
                                 break;
                             case "image":
@@ -250,7 +251,7 @@ public class FileListener implements Runnable {
                         switch (path) {
                             case "set":
                                 try (final InStream in = new InStream(restPath, CONTENT_IN)) {
-                                    GraphImpl.post_set(in.in);
+                                    GraphImpl.post_set(graphId, in.in);
                                 }
                                 break;
                             case "new":
@@ -272,9 +273,9 @@ public class FileListener implements Runnable {
                     case "put":
                         switch (path) {
                             case "current":
-                                final String graphId = getString(args, "id");
-                                if (graphId != null) {
-                                    GraphImpl.put_current(graphId);
+                                final String gid = getString(args, "id");
+                                if (gid != null) {
+                                    GraphImpl.put_current(gid);
                                 } else {
                                     throw new EndpointException("Must specify id");
                                 }
@@ -338,7 +339,7 @@ public class FileListener implements Runnable {
                                 }
 
                                 try (final InStream in = new InStream(restPath, CONTENT_IN)) {
-                                    PluginImpl.post_run(pluginName, in.in);
+                                    PluginImpl.post_run(graphId, pluginName, in.in);
                                 }
                                 break;
                             default:
@@ -370,7 +371,7 @@ public class FileListener implements Runnable {
                                 }
 
                                 try (final OutputStream out = outStream(restPath, CONTENT_OUT)) {
-                                    RecordStoreImpl.get_get(vx, tx, selected, attrs, out);
+                                    RecordStoreImpl.get_get(graphId, vx, tx, selected, attrs, out);
                                 }
                                 break;
                             default:
@@ -390,7 +391,7 @@ public class FileListener implements Runnable {
                                 final boolean resetView = resetViewParam == null ? true : resetViewParam;
 
                                 try (final InStream in = new InStream(restPath, CONTENT_IN)) {
-                                    RecordStoreImpl.post_add(completeWithSchema, arrange, resetView, in.in);
+                                    RecordStoreImpl.post_add(graphId, completeWithSchema, arrange, resetView, in.in);
                                 }
                                 break;
                             default:

--- a/CoreWebServer/src/au/gov/asd/tac/constellation/webserver/api/GraphServlet.java
+++ b/CoreWebServer/src/au/gov/asd/tac/constellation/webserver/api/GraphServlet.java
@@ -131,14 +131,16 @@ public class GraphServlet extends ConstellationApiServlet {
 
     @Override
     protected void put(final HttpServletRequest request, final HttpServletResponse response) throws ServletException, IOException {
+
+        final String graphId = request.getParameter("graph_id");
+
         switch (request.getPathInfo()) {
             case "/current":
                 // Make the specified graph the current graph.
-                final String graphId = request.getParameter("id");
                 if (graphId != null) {
                     GraphImpl.put_current(graphId);
                 } else {
-                    throw new ServletException("Must specify id");
+                    throw new ServletException("Must specify graph_id");
                 }
                 break;
         }

--- a/CoreWebServer/src/au/gov/asd/tac/constellation/webserver/api/GraphServlet.java
+++ b/CoreWebServer/src/au/gov/asd/tac/constellation/webserver/api/GraphServlet.java
@@ -41,10 +41,12 @@ public class GraphServlet extends ConstellationApiServlet {
     @Override
     protected void get(final HttpServletRequest request, final HttpServletResponse response) throws ServletException, IOException {
 
+        final String graphId = request.getParameter("graph_id");
+
         switch (request.getPathInfo()) {
             case "/get": {
                 // Return the graph attributes in DataFrame format.
-                GraphImpl.get_get(response.getOutputStream());
+                GraphImpl.get_get(graphId, response.getOutputStream());
 
                 response.setContentType("application/json");
                 response.setStatus(HttpServletResponse.SC_OK);
@@ -90,6 +92,9 @@ public class GraphServlet extends ConstellationApiServlet {
 
     @Override
     protected void post(final HttpServletRequest request, final HttpServletResponse response) throws ServletException, IOException {
+
+        final String graphId = request.getParameter("graph_id");
+
         switch (request.getPathInfo()) {
             case "/set":
                 // We want to read a JSON document that looks like:
@@ -98,7 +103,7 @@ public class GraphServlet extends ConstellationApiServlet {
                 //
                 // which is what is output by pandas.to_json(..., orient="split').
                 // (We ignore the index array.)
-                GraphImpl.post_set(request.getInputStream());
+                GraphImpl.post_set(graphId, request.getInputStream());
 
                 break;
             case "/new":

--- a/CoreWebServer/src/au/gov/asd/tac/constellation/webserver/api/PluginServlet.java
+++ b/CoreWebServer/src/au/gov/asd/tac/constellation/webserver/api/PluginServlet.java
@@ -61,11 +61,18 @@ public class PluginServlet extends ConstellationApiServlet {
         switch (request.getPathInfo()) {
             case "/run":
                 // Run a plugin, optionally with parameters.
+                final String graphId = request.getParameter("graph_id");
                 final String pluginName = request.getParameter("name");
                 if (pluginName == null) {
                     throw new ServletException("No plugin specified!");
                 } else {
-                    PluginImpl.post_run(pluginName, request.getInputStream());
+                    try {
+                        PluginImpl.post_run(graphId, pluginName, request.getInputStream());
+                    }
+                    catch(final Exception ex) {
+                        ex.printStackTrace();
+                        throw new ServletException(ex);
+                    }
                 }
                 break;
             default:

--- a/CoreWebServer/src/au/gov/asd/tac/constellation/webserver/api/RecordStoreServlet.java
+++ b/CoreWebServer/src/au/gov/asd/tac/constellation/webserver/api/RecordStoreServlet.java
@@ -48,6 +48,9 @@ public class RecordStoreServlet extends ConstellationApiServlet {
         switch (request.getPathInfo()) {
             case "/get":
                 // Get (parts of) the currently active graph as a RecordStore.
+                //
+                final String graphId = request.getParameter("graph_id");
+
                 final boolean selected = Boolean.parseBoolean(request.getParameter("selected"));
                 final boolean vx = Boolean.parseBoolean(request.getParameter("vx"));
                 final boolean tx = Boolean.parseBoolean(request.getParameter("tx"));
@@ -62,7 +65,7 @@ public class RecordStoreServlet extends ConstellationApiServlet {
                     attrs.add(k);
                 }
 
-                RecordStoreImpl.get_get(vx, tx, selected, attrs, response.getOutputStream());
+                RecordStoreImpl.get_get(graphId, vx, tx, selected, attrs, response.getOutputStream());
 
                 response.setContentType("application/json");
                 response.setStatus(HttpServletResponse.SC_OK);
@@ -80,6 +83,9 @@ public class RecordStoreServlet extends ConstellationApiServlet {
             case "/add":
                 // Add data to a new store, and add the store to the graph.
                 // If any transaction does not specify a source, add our own.
+                //
+                final String graphId = request.getParameter("graph_id");
+
                 final String completeWithSchemaParam = request.getParameter("complete_with_schema");
                 final boolean completeWithSchema = completeWithSchemaParam == null ? true : Boolean.parseBoolean(completeWithSchemaParam);
 
@@ -89,7 +95,7 @@ public class RecordStoreServlet extends ConstellationApiServlet {
                 final String resetViewParam = request.getParameter("reset_view");
                 final boolean resetView = resetViewParam == null ? true : Boolean.parseBoolean(resetViewParam);
 
-                RecordStoreImpl.post_add(completeWithSchema, arrange, resetView, request.getInputStream());
+                RecordStoreImpl.post_add(graphId, completeWithSchema, arrange, resetView, request.getInputStream());
 
                 break;
             default:

--- a/CoreWebServer/src/au/gov/asd/tac/constellation/webserver/api/swagger/constellation.json
+++ b/CoreWebServer/src/au/gov/asd/tac/constellation/webserver/api/swagger/constellation.json
@@ -84,6 +84,13 @@
                 "produces": ["application/json"],
                 "parameters": [
                     {
+                        "name": "graph_id",
+                        "in": "query",
+                        "type": "string",
+                        "description": "The id of the associated graph",
+                        "required": false
+                    },
+                    {
                         "name": "X-CONSTELLATION-SECRET",
                         "in": "header",
                         "type": "string",
@@ -105,6 +112,13 @@
                         "type": "string",
                         "description": "The graph attributes to set, in the form {\"columns\": [\"COL1\",\"COL2\",\"COL3\"], \"data\": [[r1c1, r1c2, r1c3]]. This is the same as the output of pandas.DataFrame.to_json(orient='split', date_format='iso'). Note that any custom attributes will be added to as 'string' type attributes.",
                         "required": true
+                    },
+                    {
+                        "name": "graph_id",
+                        "in": "query",
+                        "type": "string",
+                        "description": "The id of the associated graph",
+                        "required": false
                     },
                     {
                         "name": "X-CONSTELLATION-SECRET",
@@ -217,6 +231,13 @@
                 "description": "Run the named plugin on the active graph. (Currently, parameters cannot be passed to the plugin.)",
                 "parameters": [
                     {
+                        "name": "graph_id",
+                        "in": "query",
+                        "type": "string",
+                        "description": "The id of the associated graph",
+                        "required": false
+                    },
+                    {
                         "name": "name",
                         "in": "query",
                         "type": "string",
@@ -278,6 +299,13 @@
                         "required": true
                     },
                     {
+                        "name": "graph_id",
+                        "in": "query",
+                        "type": "string",
+                        "description": "The id of the associated graph",
+                        "required": false
+                    },
+                    {
                         "name": "complete_with_schema",
                         "in": "query",
                         "type": "boolean",
@@ -317,6 +345,13 @@
                 "description": "Get a JSON representation of a RecordStore from the active graph.",
                 "produces": ["application/json"],
                 "parameters": [
+                    {
+                        "name": "graph_id",
+                        "in": "query",
+                        "type": "string",
+                        "description": "The id of the associated graph",
+                        "required": false
+                    },
                     {
                         "name": "selected",
                         "in": "query",

--- a/CoreWebServer/src/au/gov/asd/tac/constellation/webserver/constellation_client.py
+++ b/CoreWebServer/src/au/gov/asd/tac/constellation/webserver/constellation_client.py
@@ -373,7 +373,7 @@ class Constellation:
         return json.loads(data)
 
     def get_dataframe(self, **kwargs):
-        """Get a Pandas DataFrame from the current graph.
+        """Get a Pandas DataFrame from the current or specified graph.
 
         By default, all vertices and transactions, and all attributes
         of those elements, will be fetched. The vx and tx boolean parameters
@@ -406,6 +406,7 @@ class Constellation:
         :param tx: If True, include only transactions.
         :param attrs: A list of attribute names. If specified, only the
             listed attributes will be fetched.
+        :param graph_id: The id of the graph to get data from.
 
         :returns: A DataFrame containing the requested data.
         """
@@ -444,7 +445,7 @@ class Constellation:
         return types
 
     def put_dataframe(self, df, **params):
-        """Add the contents of a Pandas DataFrame to the current graph.
+        """Add the contents of a Pandas DataFrame to the current or specified graph.
 
         :param df: The DataFrame to send to CONSTELLATION.
         :param complete_with_schema: By default, CONSTELLATION will update
@@ -456,6 +457,7 @@ class Constellation:
         to not perform an arrangement.
         :param reset_view: By default, CONSTELLATION will reset the view.
         Specify False to not do this.
+        :param graph_id: The id of the graph to be updated.
         """
 
         j = df.to_json(orient='split', date_format='iso')
@@ -477,7 +479,11 @@ class Constellation:
         return df
 
     def set_graph_attributes(self, df, graph_id=None):
-        """Set graph attributes."""
+        """Set graph attributes.
+
+        :param graph_id: If specified, the graph to get attributes from,
+            or the active graph if not specified.
+        """
 
         params = {}
         if graph_id:
@@ -489,7 +495,7 @@ class Constellation:
     def set_current_graph(self, graph_id):
         """Make the specified graph the currently active graph."""
 
-        self.rest_request(verb='put', endpoint='/v1/graph', path='current', params={'id':graph_id})
+        self.rest_request(verb='put', endpoint='/v1/graph', path='current', params={'graph_id':graph_id})
 
     def open_graph(self, filename):
         """Open a graph from the file system"""

--- a/CoreWebServer/src/au/gov/asd/tac/constellation/webserver/impl/GraphImpl.java
+++ b/CoreWebServer/src/au/gov/asd/tac/constellation/webserver/impl/GraphImpl.java
@@ -73,7 +73,6 @@ public class GraphImpl {
      */
     public static void get_get(final String graphId, final OutputStream out) throws IOException {
         final Graph graph = graphId==null ? RestUtilities.getActiveGraph() : GraphNode.getGraph(graphId);
-        System.out.printf("GRAPHID %s %s\n", graphId, graph);
         final ObjectMapper mapper = new ObjectMapper();
         final ObjectNode root = mapper.createObjectNode();
         final ArrayNode columns = root.putArray("columns");

--- a/CoreWebServer/src/au/gov/asd/tac/constellation/webserver/impl/GraphImpl.java
+++ b/CoreWebServer/src/au/gov/asd/tac/constellation/webserver/impl/GraphImpl.java
@@ -71,8 +71,9 @@ public class GraphImpl {
      *
      * @throws IOException
      */
-    public static void get_get(final OutputStream out) throws IOException {
-        final Graph graph = GraphManager.getDefault().getActiveGraph();
+    public static void get_get(final String graphId, final OutputStream out) throws IOException {
+        final Graph graph = graphId==null ? RestUtilities.getActiveGraph() : GraphNode.getGraph(graphId);
+        System.out.printf("GRAPHID %s %s\n", graphId, graph);
         final ObjectMapper mapper = new ObjectMapper();
         final ObjectNode root = mapper.createObjectNode();
         final ArrayNode columns = root.putArray("columns");
@@ -99,6 +100,8 @@ public class GraphImpl {
 
     /**
      * Return a screenshot of the graph.
+     * <p>
+     * This must be done on the active graph, so there's no graphId parameter.
      *
      * @param out An OutputStream to write the response to.
      *
@@ -198,7 +201,7 @@ public class GraphImpl {
      *
      * @throws IOException
      */
-    public static void post_set(final InputStream in) throws IOException {
+    public static void post_set(final String graphId, final InputStream in) throws IOException {
         // We want to read a JSON document that looks like:
         //
         // {"columns":["A","B"],"data":[[1,"a"]]}
@@ -230,7 +233,7 @@ public class GraphImpl {
             throw new EndpointException("Column names do not match data row");
         }
 
-        setGraphAttributes(columns, row);
+        setGraphAttributes(graphId, columns, row);
     }
 
     /**
@@ -338,8 +341,8 @@ public class GraphImpl {
         }
     }
 
-    private static void setGraphAttributes(final ArrayNode columns, final ArrayNode row) {
-        final Graph graph = RestUtilities.getActiveGraph();
+    private static void setGraphAttributes(final String graphId, final ArrayNode columns, final ArrayNode row) {
+        final Graph graph = graphId==null ? RestUtilities.getActiveGraph() : GraphNode.getGraph(graphId);
 
         final Plugin p = new SimpleEditPlugin("Set graph attributes from REST API") {
             @Override

--- a/CoreWebServer/src/au/gov/asd/tac/constellation/webserver/impl/PluginImpl.java
+++ b/CoreWebServer/src/au/gov/asd/tac/constellation/webserver/impl/PluginImpl.java
@@ -16,6 +16,7 @@
 package au.gov.asd.tac.constellation.webserver.impl;
 
 import au.gov.asd.tac.constellation.graph.Graph;
+import au.gov.asd.tac.constellation.graph.node.GraphNode;
 import au.gov.asd.tac.constellation.pluginframework.Plugin;
 import au.gov.asd.tac.constellation.pluginframework.PluginException;
 import au.gov.asd.tac.constellation.pluginframework.PluginExecution;
@@ -70,8 +71,8 @@ public class PluginImpl {
      *
      * @throws IOException
      */
-    public static void post_run(final String pluginName, final InputStream in) throws IOException {
-        final Graph graph = RestUtilities.getActiveGraph();
+    public static void post_run(final String graphId, final String pluginName, final InputStream in) throws IOException {
+        final Graph graph = graphId==null ? RestUtilities.getActiveGraph() : GraphNode.getGraph(graphId);
         try {
             final ObjectMapper mapper = new ObjectMapper();
             final JsonNode json = mapper.readTree(in);

--- a/CoreWebServer/src/au/gov/asd/tac/constellation/webserver/impl/RecordStoreImpl.java
+++ b/CoreWebServer/src/au/gov/asd/tac/constellation/webserver/impl/RecordStoreImpl.java
@@ -79,7 +79,6 @@ public class RecordStoreImpl {
         ioph.start();
         ioph.progress("Building RecordStore...");
         final GraphRecordStore recordStore;
-//        final Graph graph = RestUtilities.getActiveGraph();
         final Graph graph = graphId==null ? RestUtilities.getActiveGraph() : GraphNode.getGraph(graphId);
         final ReadableGraph rg = graph.getReadableGraph();
         try {
@@ -180,7 +179,6 @@ public class RecordStoreImpl {
     public static void post_add(final String graphId, final boolean completeWithSchema, final String arrange, final boolean resetView, final InputStream in) throws IOException {
         // Add data to a new store, and add the store to the graph.
         // If any transaction does not specify a source, add our own.
-//        RestUtilities.getActiveGraph();
 
         final RecordStore rs = new GraphRecordStore();
         final ObjectMapper mapper = new ObjectMapper();


### PR DESCRIPTION
### Description of the Change

This PR adds graph_id as a parameter to several REST APIs to allow operations on graphs other than the currently active graph.

### Benefits

This PR makes it much easier to work with multiple graphs at once.

### Possible Drawbacks

None. The REST API with no graph_id specified still works on the currently active graph.

### Verification Process

The notebooks_and_constellation notebook still works. The new graph-ids notebook demonstrates the new API.

### Applicable Issues

Issue #142.
