### PR TITLE
:sparkles: Add a REST endpoint to get all of the attributes on the gr…

### DIFF
--- a/CoreWebServer/src/au/gov/asd/tac/constellation/filetransport/FileListener.java
+++ b/CoreWebServer/src/au/gov/asd/tac/constellation/filetransport/FileListener.java
@@ -223,6 +223,11 @@ public class FileListener implements Runnable {
                 switch (verb) {
                     case "get":
                         switch (path) {
+                            case "getattrs":
+                                try (final OutputStream out = outStream(restPath, CONTENT_OUT)) {
+                                    GraphImpl.get_attributes(graphId, out);
+                                }
+                                break;
                             case "get":
                                 try (final OutputStream out = outStream(restPath, CONTENT_OUT)) {
                                     GraphImpl.get_get(graphId, out);

--- a/CoreWebServer/src/au/gov/asd/tac/constellation/webserver/api/GraphServlet.java
+++ b/CoreWebServer/src/au/gov/asd/tac/constellation/webserver/api/GraphServlet.java
@@ -44,8 +44,16 @@ public class GraphServlet extends ConstellationApiServlet {
         final String graphId = request.getParameter("graph_id");
 
         switch (request.getPathInfo()) {
+            case "/getattrs": {
+                // Return the graph, vertex, and transaction attributes as a map.
+                GraphImpl.get_attributes(graphId, response.getOutputStream());
+
+                response.setContentType("application/json");
+                response.setStatus(HttpServletResponse.SC_OK);
+                break;
+            }
             case "/get": {
-                // Return the graph attributes in DataFrame format.
+                // Return the graph attribute values in DataFrame format.
                 GraphImpl.get_get(graphId, response.getOutputStream());
 
                 response.setContentType("application/json");

--- a/CoreWebServer/src/au/gov/asd/tac/constellation/webserver/api/swagger/constellation.json
+++ b/CoreWebServer/src/au/gov/asd/tac/constellation/webserver/api/swagger/constellation.json
@@ -77,10 +77,33 @@
                 ]
             }
         },
+        "/v1/graph/getattrs": {
+            "get": {
+                "tags": ["graph"],
+                "description": "The graph, vertex, and transaction attributes.",
+                "produces": ["application/json"],
+                "parameters": [
+                    {
+                        "name": "graph_id",
+                        "in": "query",
+                        "type": "string",
+                        "description": "The id of the associated graph",
+                        "required": false
+                    },
+                    {
+                        "name": "X-CONSTELLATION-SECRET",
+                        "in": "header",
+                        "type": "string",
+                        "description": "CONSTELLATION secret (from ~/.CONSTELLATION/rest.json)",
+                        "required": true
+                    }
+                ]
+            }
+        },
         "/v1/graph/get": {
             "get": {
                 "tags": ["graph"],
-                "description": "The graph attributes.",
+                "description": "The graph attribute values.",
                 "produces": ["application/json"],
                 "parameters": [
                     {

--- a/CoreWebServer/src/au/gov/asd/tac/constellation/webserver/constellation_client.py
+++ b/CoreWebServer/src/au/gov/asd/tac/constellation/webserver/constellation_client.py
@@ -463,8 +463,23 @@ class Constellation:
         j = df.to_json(orient='split', date_format='iso')
         self.rest_request(verb='post', endpoint='/v1/recordstore', path='add', data=j.encode('utf-8'), params=params)
 
+    def get_attributes(self, graph_id=None):
+        """Get the graph, node, and transaction attributes of the current or specified graph.
+
+        :param graph_id: If specified, the id of the graph from which to get the
+            attributes.
+        """
+
+        params = {}
+        if graph_id:
+            params = {'graph_id':graph_id}
+
+        r = self.rest_request(endpoint='/v1/graph', path='getattrs', params=params)
+
+        return r.json()
+
     def get_graph_attributes(self, graph_id=None):
-        """Get the graph attributes."""
+        """Get the graph attribute values."""
 
         params = {}
         if graph_id:

--- a/CoreWebServer/src/au/gov/asd/tac/constellation/webserver/impl/GraphImpl.java
+++ b/CoreWebServer/src/au/gov/asd/tac/constellation/webserver/impl/GraphImpl.java
@@ -65,7 +65,53 @@ public class GraphImpl {
     private static final String IMAGE_TYPE = "png";
 
     /**
-     * Return the graph attributes in DataFrame format.
+     * Return the graph, vertex, and transaction attributes as a map of
+     * name:type items.
+     * <p>
+     * Names are prefixed with "graph.", "source.", or "transaction".
+     */
+    public static void get_attributes(final String graphId, final OutputStream out) throws IOException {
+        final Graph graph = graphId==null ? RestUtilities.getActiveGraph() : GraphNode.getGraph(graphId);
+        final ObjectMapper mapper = new ObjectMapper();
+        final ObjectNode root = mapper.createObjectNode();
+
+        final ReadableGraph rg = graph.getReadableGraph();
+        try {
+            final int gCount = rg.getAttributeCount(GraphElementType.GRAPH);
+            for (int i = 0; i < gCount; i++) {
+                final int attrId = rg.getAttribute(GraphElementType.GRAPH, i);
+                final String type = rg.getAttributeType(attrId);
+                final String label = rg.getAttributeName(attrId);
+
+                root.put(String.format("graph.%s", label), type);
+            }
+
+            final int vCount = rg.getAttributeCount(GraphElementType.VERTEX);
+            for (int i = 0; i < vCount; i++) {
+                final int attrId = rg.getAttribute(GraphElementType.VERTEX, i);
+                final String type = rg.getAttributeType(attrId);
+                final String label = rg.getAttributeName(attrId);
+
+                root.put(String.format("source.%s", label), type);
+            }
+
+            final int tCount = rg.getAttributeCount(GraphElementType.TRANSACTION);
+            for (int i = 0; i < tCount; i++) {
+                final int attrId = rg.getAttribute(GraphElementType.TRANSACTION, i);
+                final String type = rg.getAttributeType(attrId);
+                final String label = rg.getAttributeName(attrId);
+
+                root.put(String.format("transaction.%s", label), type);
+            }
+        } finally {
+            rg.release();
+        }
+
+        mapper.writeValue(out, root);
+    }
+
+    /**
+     * Return the graph attribute values in DataFrame format.
      *
      * @param out An OutputStream to write the response to.
      *


### PR DESCRIPTION
### Description of the Change

Add a REST endpoint to discover graph, node, transaction attributes as described in issue #144.

### Why Should This Be In Core?

This is basic functionality related to the other REST endpoints.

### Benefits

REST clients can discover the graph, node, transcation attributes.

### Possible Drawbacks

None. This is additional functionality.

### Verification Process

The notebooks_and_constellation notebook has been update to demonstrate the new functionality.

### Applicable Issues

#144
