### PR TITLE
:sparkles: Add RotateCamera plugin.

### DIFF
--- a/CoreFunctionality/src/au/gov/asd/tac/constellation/functionality/CorePluginRegistry.java
+++ b/CoreFunctionality/src/au/gov/asd/tac/constellation/functionality/CorePluginRegistry.java
@@ -71,6 +71,7 @@ import au.gov.asd.tac.constellation.functionality.select.structure.SelectSinksPl
 import au.gov.asd.tac.constellation.functionality.select.structure.SelectSourcesPlugin;
 import au.gov.asd.tac.constellation.functionality.zoom.PreviousViewPlugin;
 import au.gov.asd.tac.constellation.functionality.zoom.ResetViewPlugin;
+import au.gov.asd.tac.constellation.functionality.zoom.RotateCameraPlugin;
 import au.gov.asd.tac.constellation.functionality.zoom.ZoomToSelectionPlugin;
 import au.gov.asd.tac.constellation.functionality.zoom.ZoomToVerticesPlugin;
 
@@ -113,6 +114,7 @@ public final class CorePluginRegistry {
     public static final String PREVIOUS_VIEW = PreviousViewPlugin.class.getName();
     public static final String REMOVE_BLAZE = RemoveBlazePlugin.class.getName();
     public static final String RESET = ResetViewPlugin.class.getName();
+    public static final String ROTATE_GRAPH = RotateCameraPlugin.class.getName();
     public static final String SAVE_GRAPH = SaveGraphPlugin.class.getName();
     public static final String SELECT_ALL = SelectAllPlugin.class.getName();
     public static final String SELECT_BACKBONE = SelectBackbonePlugin.class.getName();

--- a/CoreFunctionality/src/au/gov/asd/tac/constellation/functionality/zoom/RotateCameraPlugin.java
+++ b/CoreFunctionality/src/au/gov/asd/tac/constellation/functionality/zoom/RotateCameraPlugin.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2010-2019 Australian Signals Directorate
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package au.gov.asd.tac.constellation.functionality.zoom;
+
+import au.gov.asd.tac.constellation.graph.Graph;
+import au.gov.asd.tac.constellation.graph.GraphWriteMethods;
+import au.gov.asd.tac.constellation.graph.interaction.animation.Animation;
+import au.gov.asd.tac.constellation.graph.interaction.animation.PanAnimation;
+import au.gov.asd.tac.constellation.graph.visual.camera.CameraUtilities;
+import au.gov.asd.tac.constellation.graph.visual.concept.VisualConcept;
+import au.gov.asd.tac.constellation.pluginframework.Plugin;
+import au.gov.asd.tac.constellation.pluginframework.PluginException;
+import au.gov.asd.tac.constellation.pluginframework.PluginInfo;
+import au.gov.asd.tac.constellation.pluginframework.PluginInteraction;
+import au.gov.asd.tac.constellation.pluginframework.PluginType;
+import au.gov.asd.tac.constellation.pluginframework.parameters.PluginParameter;
+import au.gov.asd.tac.constellation.pluginframework.parameters.PluginParameters;
+import au.gov.asd.tac.constellation.pluginframework.parameters.types.BooleanParameterType;
+import au.gov.asd.tac.constellation.pluginframework.parameters.types.BooleanParameterType.BooleanParameterValue;
+import au.gov.asd.tac.constellation.pluginframework.parameters.types.FloatParameterType;
+import au.gov.asd.tac.constellation.pluginframework.parameters.types.FloatParameterType.FloatParameterValue;
+import au.gov.asd.tac.constellation.pluginframework.templates.SimpleEditPlugin;
+import au.gov.asd.tac.constellation.visual.camera.Camera;
+import org.openide.util.NbBundle.Messages;
+import org.openide.util.lookup.ServiceProvider;
+
+/**
+ * Rotate the camera.
+ *
+ * @author algol
+ */
+@ServiceProvider(service = Plugin.class)
+@PluginInfo(minLogInterval = 5000, pluginType = PluginType.DISPLAY, tags = {"LOW LEVEL"})
+@Messages("RotateCameraPlugin=Rotate Camera")
+public final class RotateCameraPlugin extends SimpleEditPlugin {
+
+    public static final String X_PARAMETER_ID = PluginParameter.buildId(RotateCameraPlugin.class, "x");
+    public static final String Y_PARAMETER_ID = PluginParameter.buildId(RotateCameraPlugin.class, "y");
+    public static final String Z_PARAMETER_ID = PluginParameter.buildId(RotateCameraPlugin.class, "z");
+    public static final String ANIMATE_PARAMETER_ID = PluginParameter.buildId(RotateCameraPlugin.class, "animate");
+
+    @Override
+    public String getDescription() {
+        return "Spins the camera.";
+    }
+
+    @Override
+    public PluginParameters createParameters() {
+        final PluginParameters parameters = new PluginParameters();
+
+        final PluginParameter<FloatParameterValue> xaxisParam = FloatParameterType.build(X_PARAMETER_ID);
+        xaxisParam.setName("xAxis");
+        xaxisParam.setDescription("Rotation in degrees around the x axis");
+        xaxisParam.setFloatValue(0f);
+        parameters.addParameter(xaxisParam);
+
+        final PluginParameter<FloatParameterValue> yaxisParam = FloatParameterType.build(Y_PARAMETER_ID);
+        yaxisParam.setName("yAxis");
+        yaxisParam.setDescription("Rotation in degrees around the y axis");
+        yaxisParam.setFloatValue(0f);
+        parameters.addParameter(yaxisParam);
+
+        final PluginParameter<FloatParameterValue> zaxisParam = FloatParameterType.build(Z_PARAMETER_ID);
+        zaxisParam.setName("zAxis");
+        zaxisParam.setDescription("Rotation in degrees around the z axis");
+        zaxisParam.setFloatValue(0f);
+        parameters.addParameter(zaxisParam);
+
+        final PluginParameter<BooleanParameterValue> animateParam = BooleanParameterType.build(ANIMATE_PARAMETER_ID);
+        animateParam.setName("animate");
+        animateParam.setDescription("Animate the rotation asynchronously");
+        animateParam.setBooleanValue(false);
+        parameters.addParameter(animateParam);
+
+        return parameters;
+    }
+
+    @Override
+    public void edit(final GraphWriteMethods graph, final PluginInteraction interaction, final PluginParameters parameters) throws InterruptedException, PluginException {
+
+        final float xrot = parameters.getFloatValue(X_PARAMETER_ID);
+        final float yrot = parameters.getFloatValue(Y_PARAMETER_ID);
+        final float zrot = parameters.getFloatValue(Z_PARAMETER_ID);
+        final boolean animate = parameters.getBooleanValue(ANIMATE_PARAMETER_ID);
+
+        // Get a copy of the graph's current camera.
+        //
+        final int cameraAttribute = VisualConcept.GraphAttribute.CAMERA.get(graph);
+        if (cameraAttribute != Graph.NOT_FOUND) {
+            final Camera oldCamera = graph.getObjectValue(cameraAttribute, 0);
+            final Camera camera = new Camera(oldCamera);
+
+            CameraUtilities.rotate(camera, xrot, yrot, zrot);
+
+            if(animate) {
+                    Animation.startAnimation(new PanAnimation("Rotate camera", oldCamera, camera, true));
+            } else {
+                // Don't do an animation; we don't want to be asynchronous.
+                // Just set the camera value back on the graph.
+                //
+                graph.setObjectValue(cameraAttribute, 0, camera);
+            }
+        }
+    }
+}

--- a/CoreVisualGraph/src/au/gov/asd/tac/constellation/graph/visual/camera/CameraUtilities.java
+++ b/CoreVisualGraph/src/au/gov/asd/tac/constellation/graph/visual/camera/CameraUtilities.java
@@ -165,7 +165,7 @@ public class CameraUtilities {
         rotate(camera, xDegrees, yDegrees, 0);
     }
 
-    private static void rotate(final Camera camera, final float xDegrees, final float yDegrees, final float zDegrees) {
+    public static void rotate(final Camera camera, final float xDegrees, final float yDegrees, final float zDegrees) {
         // Use a frame to move the eye and centre relative to the rotation point.
         Frame frame = new Frame(camera.lookAtEye, camera.lookAtCentre, camera.lookAtUp);
         frame.setOrigin(camera.lookAtRotation);


### PR DESCRIPTION
### Description of the Change

Adds a plugin to rotate the camera programmatically.

### Why Should This Be In Core?

This is basic functionality.

### Benefits

The camera can be manipulated from a REST client.

### Possible Drawbacks

None.

### Verification Process

The plugin was run from a Python client to verify the functionality.

### Applicable Issues

N/A
