### PR TITLE
Added rowIndex as 4th parameter to ImportAttributeDefinition.setValue().

### DIFF
--- a/CoreImportExport/src/au/gov/asd/tac/constellation/importexport/delimited/ImportAttributeDefinition.java
+++ b/CoreImportExport/src/au/gov/asd/tac/constellation/importexport/delimited/ImportAttributeDefinition.java
@@ -37,6 +37,7 @@ public class ImportAttributeDefinition {
     private final PluginParameters parameters;
 
     private static int ATTRIBUTE_NOT_DEFINED = -93459;
+    private static int ROWID_COLUMN_INDEX = -1;
 
     /**
      * Immutable attributes are defined in {@code ImportController} as mockup
@@ -138,12 +139,14 @@ public class ImportAttributeDefinition {
         this.overriddenAttributeId = overriddenAttributeId;
     }
 
-    public void setValue(GraphWriteMethods graph, int elementId, String[] row) {
+    public void setValue(GraphWriteMethods graph, int elementId, String[] row, int rowIndex) {
         if (columnIndex == ImportDelimitedPlugin.ATTRIBUTE_NOT_ASSIGNED_TO_COLUMN && defaultValue != null) {
             graph.setStringValue(getOverriddenAttributeId(), elementId, translator.translate(defaultValue, parameters));
         } else if (columnIndex >= 0) {
             final String cell = columnIndex < row.length ? row[columnIndex] : "";
             graph.setStringValue(getOverriddenAttributeId(), elementId, translator.translate(cell, parameters));
+        } else if (columnIndex == ROWID_COLUMN_INDEX) {
+            graph.setStringValue(getOverriddenAttributeId(), elementId, Integer.toString(rowIndex));
         }
     }
 

--- a/CoreImportExport/src/au/gov/asd/tac/constellation/importexport/delimited/ImportDelimitedPlugin.java
+++ b/CoreImportExport/src/au/gov/asd/tac/constellation/importexport/delimited/ImportDelimitedPlugin.java
@@ -180,7 +180,7 @@ public class ImportDelimitedPlugin extends SimpleEditPlugin {
                 newVertices.add(vertexId);
 
                 for (final ImportAttributeDefinition attributeDefinition : attributeDefinitions) {
-                    attributeDefinition.setValue(graph, vertexId, row);
+                    attributeDefinition.setValue(graph, vertexId, row, (i - 1));
                 }
 
                 if (initialiseWithSchema && graph.getSchema() != null) {
@@ -220,7 +220,7 @@ public class ImportDelimitedPlugin extends SimpleEditPlugin {
             if (filter == null || filter.passesFilter(i, row)) {
                 final int sourceVertexId = graph.addVertex();
                 for (final ImportAttributeDefinition attributeDefinition : sourceVertexDefinitions) {
-                    attributeDefinition.setValue(graph, sourceVertexId, row);
+                    attributeDefinition.setValue(graph, sourceVertexId, row, (i - 1));
                 }
                 if (initialiseWithSchema && graph.getSchema() != null) {
                     graph.getSchema().completeVertex(graph, sourceVertexId);
@@ -228,7 +228,7 @@ public class ImportDelimitedPlugin extends SimpleEditPlugin {
 
                 final int destinationVertexId = graph.addVertex();
                 for (final ImportAttributeDefinition attributeDefinition : destinationVertexDefinitions) {
-                    attributeDefinition.setValue(graph, destinationVertexId, row);
+                    attributeDefinition.setValue(graph, destinationVertexId, row, (i - 1));
                 }
                 if (initialiseWithSchema && graph.getSchema() != null) {
                     graph.getSchema().completeVertex(graph, destinationVertexId);
@@ -238,7 +238,7 @@ public class ImportDelimitedPlugin extends SimpleEditPlugin {
                 final int transactionId = graph.addTransaction(sourceVertexId, destinationVertexId, isDirected);
                 for (final ImportAttributeDefinition attributeDefinition : transactionDefinitions) {
                     if (attributeDefinition.getOverriddenAttributeId() != Graph.NOT_FOUND) {
-                        attributeDefinition.setValue(graph, transactionId, row);
+                        attributeDefinition.setValue(graph, transactionId, row, (i - 1));
                     }
                 }
                 if (initialiseWithSchema && graph.getSchema() != null) {


### PR DESCRIPTION
Use rowIndex as attribute value if attributes selected column = -1.
Update all calls to ImportAttributeDefinition.setValue() to use rowIndex.

<!--

### Requirements

* Filling out the template is required. Any pull request that does not include 
enough information to be reviewed in a timely manner may be closed at the 
maintainers' discretion.
* All new code requires unit tests to ensure they work as expected and will 
continue to work as new code is added in the future (regression testing).
* Have you read Constellation's Code of Conduct? By filing an issue, you are 
expected to comply with it, including treating everyone with respect: 
https://github.com/constellation-app/constellation/blob/master/CODE_OF_CONDUCT.md

-->

### Description of the Change
- Update ImportAttributeDefinition.setValue() to accept a rowIndex parameter. This parameter will be used in cases where an import uses the **Row** column, as this column has index -1 and is not currently handled by logic. We need to pass this index in as the supplied parameters do not provide enough information to determne it.
- The 4 existing calls to ImportAttributeDefinition.setValue() are all made from loops iterating over rows and creating attributes, as such, modify the calls to also send the row index.

### Alternate Designs
Considered passing in value as extra columns of the row parameter, but this required a little extra refactoring and would be less efficient performance wise.


### Why Should This Be In Core?

Bug fix of existing core code.

### Benefits

Ability to map attributes to the row index of source csv data.

### Possible Drawbacks

N/A

### Verification Process

Performed a series of imports of new CSV data, focussed on cases where we use the Row column as either:
a) the identifier
b) a value other than identifier
In each case confirm that the correct attribute is updated in attribute editor and visually on grapg.

In terms of verifying nothing has been broken, the change was made in code that was only executed in error condition, so both the above tests, and visual inspectionw ere used.

### Applicable Issues

N/A
