### PR TITLE
Add SetCameraVisibilityRange plugin.

### DIFF
--- a/CoreFunctionality/src/au/gov/asd/tac/constellation/functionality/CorePluginRegistry.java
+++ b/CoreFunctionality/src/au/gov/asd/tac/constellation/functionality/CorePluginRegistry.java
@@ -73,6 +73,7 @@ import au.gov.asd.tac.constellation.functionality.select.structure.SelectSources
 import au.gov.asd.tac.constellation.functionality.zoom.PreviousViewPlugin;
 import au.gov.asd.tac.constellation.functionality.zoom.ResetViewPlugin;
 import au.gov.asd.tac.constellation.functionality.zoom.RotateCameraPlugin;
+import au.gov.asd.tac.constellation.functionality.zoom.SetCameraVisibilityRange;
 import au.gov.asd.tac.constellation.functionality.zoom.ZoomToSelectionPlugin;
 import au.gov.asd.tac.constellation.functionality.zoom.ZoomToVerticesPlugin;
 
@@ -132,6 +133,7 @@ public final class CorePluginRegistry {
     public static final String SELECT_SOURCES = SelectSourcesPlugin.class.getName();
     public static final String SELECT_UNDIMMED = SelectUndimmedPlugin.class.getName();
     public static final String SEND_TO_EMAIL_CLIENT = SendToEmailClientPlugin.class.getName();
+    public static final String SET_CAMERA_VISIBILITY_RANGE = SetCameraVisibilityRange.class.getName();
     public static final String SET_CONNECTION_MODE = SetConnectionModePlugin.class.getName();
     public static final String SET_DRAW_FLAG = SetDrawFlagPlugin.class.getName();
     public static final String SET_VISIBLE_ABOVE_THRESHOLD = SetVisibleAboveThresholdPlugin.class.getName();

--- a/CoreFunctionality/src/au/gov/asd/tac/constellation/functionality/zoom/SetCameraVisibilityRange.java
+++ b/CoreFunctionality/src/au/gov/asd/tac/constellation/functionality/zoom/SetCameraVisibilityRange.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2010-2019 Australian Signals Directorate
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package au.gov.asd.tac.constellation.functionality.zoom;
+
+import au.gov.asd.tac.constellation.graph.Graph;
+import au.gov.asd.tac.constellation.graph.GraphWriteMethods;
+import au.gov.asd.tac.constellation.graph.visual.concept.VisualConcept;
+import au.gov.asd.tac.constellation.pluginframework.Plugin;
+import au.gov.asd.tac.constellation.pluginframework.PluginException;
+import au.gov.asd.tac.constellation.pluginframework.PluginInfo;
+import au.gov.asd.tac.constellation.pluginframework.PluginInteraction;
+import au.gov.asd.tac.constellation.pluginframework.PluginType;
+import au.gov.asd.tac.constellation.pluginframework.parameters.PluginParameter;
+import au.gov.asd.tac.constellation.pluginframework.parameters.PluginParameters;
+import au.gov.asd.tac.constellation.pluginframework.parameters.types.FloatParameterType;
+import au.gov.asd.tac.constellation.pluginframework.parameters.types.FloatParameterType.FloatParameterValue;
+import au.gov.asd.tac.constellation.pluginframework.templates.SimpleEditPlugin;
+import au.gov.asd.tac.constellation.visual.camera.Camera;
+import org.openide.util.NbBundle.Messages;
+import org.openide.util.lookup.ServiceProvider;
+
+/**
+ * Set the camera low and high visibility range.
+ *
+ * @author algol
+ */
+@ServiceProvider(service = Plugin.class)
+@PluginInfo(minLogInterval = 5000, pluginType = PluginType.DISPLAY, tags = {"LOW LEVEL"})
+@Messages("SetCameraVisibilityRange=Set Camera Visibility Range")
+public final class SetCameraVisibilityRange extends SimpleEditPlugin {
+
+    public static final String VISIBILITY_LOW_ID = PluginParameter.buildId(SetCameraVisibilityRange.class, "visibilityLow");
+    public static final String VISIBILITY_HIGH_ID = PluginParameter.buildId(SetCameraVisibilityRange.class, "visibilityHigh");
+
+    @Override
+    public String getDescription() {
+        return "Sets the camera low and high visibility range.";
+    }
+
+    @Override
+    public PluginParameters createParameters() {
+        final PluginParameters parameters = new PluginParameters();
+
+        final PluginParameter<FloatParameterValue> visibilityLowParam = FloatParameterType.build(VISIBILITY_LOW_ID);
+        visibilityLowParam.setName("visibilityLow");
+        visibilityLowParam.setDescription("Low boundary of visibility");
+        visibilityLowParam.setFloatValue(0f);
+        parameters.addParameter(visibilityLowParam);
+
+        final PluginParameter<FloatParameterValue> visibilityHighParam = FloatParameterType.build(VISIBILITY_HIGH_ID);
+        visibilityHighParam.setName("visibilityHigh");
+        visibilityHighParam.setDescription("High boundary of visibility");
+        visibilityHighParam.setFloatValue(1f);
+        parameters.addParameter(visibilityHighParam);
+
+        return parameters;
+    }
+
+    @Override
+    public void edit(final GraphWriteMethods graph, final PluginInteraction interaction, final PluginParameters parameters) throws InterruptedException, PluginException {
+
+        final float visibilityLow = parameters.getFloatValue(VISIBILITY_LOW_ID);
+        final float visibilityHigh = parameters.getFloatValue(VISIBILITY_HIGH_ID);
+
+        // Get a copy of the graph's current camera.
+        //
+        final int cameraAttribute = VisualConcept.GraphAttribute.CAMERA.get(graph);
+        if (cameraAttribute != Graph.NOT_FOUND) {
+            final Camera oldCamera = graph.getObjectValue(cameraAttribute, 0);
+            final Camera camera = new Camera(oldCamera);
+
+            camera.visibilityLow = visibilityLow;
+            camera.visibilityHigh = visibilityHigh;
+            graph.setObjectValue(cameraAttribute, 0, camera);
+        }
+    }
+}


### PR DESCRIPTION
### Description of the Change

This plugin enables access to the camera's visibilityLow and
visibilityHigh variables.

### Alternate Designs

None.

### Why Should This Be In Core?

The plugin provides access to the renderer's camera, which is in core.

### Benefits

The ability to use existing but unexposed functionality.

### Possible Drawbacks

None.

### Verification Process

Tested from a Jupyter notebook.

### Applicable Issues

None.