### PR TITLE
DAV graph creation issue#158

### DIFF
--- a/CoreDataAccessView/src/au/gov/asd/tac/constellation/views/dataaccess/panes/DataAccessPane.java
+++ b/CoreDataAccessView/src/au/gov/asd/tac/constellation/views/dataaccess/panes/DataAccessPane.java
@@ -17,6 +17,7 @@ package au.gov.asd.tac.constellation.views.dataaccess.panes;
 
 import au.gov.asd.tac.constellation.graph.Graph;
 import au.gov.asd.tac.constellation.graph.manager.GraphManager;
+import au.gov.asd.tac.constellation.graph.node.NewDefaultSchemaGraphAction;
 import au.gov.asd.tac.constellation.pluginframework.Plugin;
 import au.gov.asd.tac.constellation.pluginframework.PluginException;
 import au.gov.asd.tac.constellation.pluginframework.PluginExecution;
@@ -783,7 +784,18 @@ public class DataAccessPane extends AnchorPane implements PluginParametersPaneLi
         }
 
         final boolean queryIsRunning = currentGraphState != null && currentGraphState.queriesRunning;
-
+        /**
+         * TODO: The below IF statement should be removed upon implementation of
+         * a translucent view guiding the user towards the issue found
+         * Related to Issue Comment https://github.com/constellation-app/constellation/issues/158#issuecomment-566027132 
+         */
+        
+        // When there is not a graph, and a plugin selected with valid parameters, create a new graph
+        // Enhancement following : https://github.com/constellation-app/constellation/issues/158
+        if (!graphPresent && pluginSelected && selectedPluginsValid){
+            NewDefaultSchemaGraphAction graphAction = new NewDefaultSchemaGraphAction();
+            graphAction.actionPerformed(null);
+        }
         // The button cannot be disabled if a query is running.
         // Otherwise, disable if there is no graph, no selected plugin, an invalid time range, or the selected plugins contain invalid parameter values.
         final boolean disable = !queryIsRunning && (!graphPresent || !pluginSelected || !validTimeRange || !selectedPluginsValid);


### PR DESCRIPTION
<!--

### Requirements

* Filling out the template is required. Any pull request that does not include 
enough information to be reviewed in a timely manner may be closed at the 
maintainers' discretion.
* All new code requires unit tests to ensure they work as expected and will 
continue to work as new code is added in the future (regression testing).
* Have you read Constellation's Code of Conduct? By filing an issue, you are 
expected to comply with it, including treating everyone with respect: 
https://github.com/constellation-app/constellation/blob/master/CODE_OF_CONDUCT.md

-->

### Description of the Change
The change handles the case where a user opens constellation, and launches the Data Access View (DAV). The Execute button (GO) is disabled. The change allows the user to select a plugin to run, and a default graph be launched upon selection. this allows the user to still utilise Constellation to its full effect, as well as add significant UX improvement. This is more effective than showing the user an error message and them have to manually correct the issue.
The code checks if there is a graph currently open, if a plugin is selected and if that plugin's parameters are valid. Once a graph is not present, but all other conditions are met, a new default graph is launched, allowing the user to proceed to click the go button and run the plugin.

<!--

We must be able to understand the design of your change from this description. 
If we can't get a good idea of what the code will be doing from the description 
here, the pull request may be closed at the maintainers' discretion. Keep in 
mind that the maintainer reviewing this PR may not be familiar with or have 
worked with the code here recently, so please walk us through the concepts.

-->

### Alternate Designs
Add checking to the update method within DataAccessPane, where the execute button is enabled. This was not suffice as it was called upon multiple times during execution. 
The proposed solution makes the most sence as it is handled within the same section as other checks for graph status are made.

<!-- 

Explain what other alternates were considered and why the proposed version was 
selected.

-->

### Why Should This Be In Core?
This enhancement allows the user to navigate the detailed plugin menu (DAV) more efficiently and user friendly. It avoids error states being presented to the user as none are entered or introduced.
<!--

Explain why this functionality should be in Constellation Core as opposed to a 
different module suite.

-->

### Benefits
A more intuitive UI is presented to the user, with the Execute button being enabled at almost all times when a graph plugin can be ran. The user will not run into an error state that will cause confusion during use.
<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks
Slight delay caused by creating a graph on selection of a plugin. This can be eventually sped up by increasing the performance of graph launching in the future.
<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process
- Ran all test suites provided
- Multiple runs of Constellation to ensure no precondition occurs that will error the introduced code
- Clicked DAV, clicked each single plugin, clicked run = runs the plugin
- Clicked DAV, clicked multiple plugins, clicked run = runs the plugin
- Clicked DAV, clicked single plugin, clicked new graph, clicked run = runs the plugin
- Clicked DAV, clicked single plugin, clicked new graph, clicked close graph, clicked extra single plugin, clicked run = runs the plugin

<!--

What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (e.g., buttons you clicked, text you typed, 
commands you ran, etc.), and describe the results you observed.

-->

### Applicable Issues
N/A
<!-- Enter any applicable Issues here -->
