### PR TITLE
Use VisualConcept.VertexAttribute(X,Y,Z) rather than magic strings.

### DIFF
--- a/CoreImportExport/src/au/gov/asd/tac/constellation/importexport/delimited/ImportDelimitedPlugin.java
+++ b/CoreImportExport/src/au/gov/asd/tac/constellation/importexport/delimited/ImportDelimitedPlugin.java
@@ -184,7 +184,7 @@ public class ImportDelimitedPlugin extends SimpleEditPlugin {
             return true;
         }
         // Check if destAttributeDefintions contain positional attributes
-        return destAttributeDefinitions.stream().map((attribute) -> attribute.getAttribute().getName()).anyMatch((name) -> ("x".equals(name) || "y".equals(name) || "z".equals(name)));
+        return destAttributeDefinitions.stream().map((attribute) -> attribute.getAttribute().getName()).anyMatch((name) -> (VisualConcept.VertexAttribute.X.getName().equals(name) || VisualConcept.VertexAttribute.Y.getName().equals(name) || VisualConcept.VertexAttribute.Z.getName().equals(name)));
     }
 
     private static void processVertices(ImportDefinition definition, GraphWriteMethods graph, List<String[]> data, AttributeType attributeType, boolean initialiseWithSchema, PluginInteraction interaction, String source, final List<Integer> newVertices) throws InterruptedException {


### PR DESCRIPTION
### Description of the Change

Check import definitions and if positional values are found (ie: x, y, z) then prevent auto arrangers kicking in. If no positional information exists, then allow auto arrangers to operate.

THIS PULL REQUEST ADDS UPDATE TO DESTINATION MISSED IN #173

### Alternate Designs

Considered where check for position should be made - however found this to be the only real option.

### Why Should This Be In Core?

Requested bug fix

### Benefits

Allow positional values imported be used to render node positions

### Possible Drawbacks

If a user imports nodes with positional data but then imports transactions with no positional information, the auto arranger kicks in. This has been agreed with @arcturus2  as acceptable.

### Verification Process

Imported nodes with no positions - confirmed auto arranger kicked in.
Imported nodes with just X set - confirmed a horizontal line of nodes displayed.
Imported nodes with just Y set - confirmed a horizontal line of nodes displayed.
Imported nodes with just Z set - confirmed nodes stacked back in the Z dimension and can be seen when middle click panning.
Imported nodes with full X, Y - confirmed nodes displayed at correct locations.
Imported transactions with no positions - confirmed auto arranger kicked in and redrew all of graph.
Imported transactions with positions - nodes displayed at correct locations.

### Applicable Issues

See above.
