### PR TITLE
changed http to https for Maven central

### DIFF
--- a/CoreDependencies/src/ivysettings.xml
+++ b/CoreDependencies/src/ivysettings.xml
@@ -2,7 +2,7 @@
     <settings defaultResolver="chain"/>
     <resolvers>
         <chain name="chain">
-            <ibiblio name="central.maven.org" m2compatible="true" root="http://central.maven.org/maven2"/>
+            <ibiblio name="central.maven.org" m2compatible="true" root="https://repo1.maven.org/maven2"/>
             <ibiblio name="repo.boundlessgeo.com" m2compatible="true" root="https://repo.boundlessgeo.com/main"/>
             <ibiblio name="download.osgeo.org" m2compatible="true" root="http://download.osgeo.org/webdav/geotools"/>
             <ibiblio name="maven.geomajas.org" m2compatible="true" root="http://maven.geomajas.org/nexus/content/groups/public"/>

--- a/build.xml
+++ b/build.xml
@@ -47,7 +47,7 @@
     <target name="-download-ivy" unless="ivy.skip.download" depends="-check-ivy">
         <mkdir dir="${ivy.jar.dir}"/>
         <echo message="installing ivy..."/>
-        <get src="http://repo1.maven.org/maven2/org/apache/ivy/ivy/${ivy.install.version}/ivy-${ivy.install.version}.jar"
+        <get src="https://repo1.maven.org/maven2/org/apache/ivy/ivy/${ivy.install.version}/ivy-${ivy.install.version}.jar"
              dest="${ivy.jar.file}" usetimestamp="true"/>
     </target>
 


### PR DESCRIPTION
this was previously causing a error 501 from the Maven servers

<!--

### Requirements

* Filling out the template is required. Any pull request that does not include 
enough information to be reviewed in a timely manner may be closed at the 
maintainers' discretion.
* All new code requires unit tests to ensure they work as expected and will 
continue to work as new code is added in the future (regression testing).
* Have you read Constellation's Code of Conduct? By filing an issue, you are 
expected to comply with it, including treating everyone with respect: 
https://github.com/constellation-app/constellation/blob/master/CODE_OF_CONDUCT.md

-->
Dependencies were previously done through http which Maven servers no longer except. They now recommend using the new https servers.

<!--

We must be able to understand the design of your change from this description. 
If we can't get a good idea of what the code will be doing from the description 
here, the pull request may be closed at the maintainers' discretion. Keep in 
mind that the maintainer reviewing this PR may not be familiar with or have 
worked with the code here recently, so please walk us through the concepts.

-->

### Alternate Designs
None were considered unless we really needed to pull dependencies over http for some reason.
<!-- 

Explain what other alternates were considered and why the proposed version was 
selected.

-->

### Why Should This Be In Core?

<!--

Because no body can build core if we do not fix this.

-->

### Benefits

We can now build Constellation

### Possible Drawbacks

Nothing of significance.

### Verification Process

I rebuilt and can confirm Netbeans now uses the https server.

### Applicable Issues
None
