### PR TITLE
skip sonar-scanner for forks

### DIFF
--- a/.travis/sonar.sh
+++ b/.travis/sonar.sh
@@ -1,12 +1,16 @@
 #!/usr/bin/env sh
 
 if [ "${TRAVIS_PULL_REQUEST}" != "false" ]; then
-  SONAR_PULLREQUEST_BRANCH="$(echo ${TRAVIS_PULL_REQUEST_SLUG} | awk '{split($0,a,"/"); print a[1]}')/${TRAVIS_PULL_REQUEST_BRANCH}"
-  sonar-scanner \
-    -Dsonar.login="${SONAR_TOKEN}" \
-    -Dsonar.pullrequest.key="${TRAVIS_PULL_REQUEST}" \
-    -Dsonar.pullrequest.branch="${SONAR_PULLREQUEST_BRANCH}" \
-    -Dsonar.pullrequest.base="${TRAVIS_BRANCH}"
+  if [ "${TRAVIS_PULL_REQUEST_SLUG}" != "constellation-app/constellation" ]; then
+    echo "skipping sonar-scanner"
+  else
+    SONAR_PULLREQUEST_BRANCH="$(echo "${TRAVIS_PULL_REQUEST_SLUG}" | awk '{split($0,a,"/"); print a[1]}')/${TRAVIS_PULL_REQUEST_BRANCH}"
+    sonar-scanner \
+      -Dsonar.login="${SONAR_TOKEN}" \
+      -Dsonar.pullrequest.key="${TRAVIS_PULL_REQUEST}" \
+      -Dsonar.pullrequest.branch="${SONAR_PULLREQUEST_BRANCH}" \
+      -Dsonar.pullrequest.base="${TRAVIS_BRANCH}"
+  fi
 else
   sonar-scanner \
     -Dsonar.login="${SONAR_TOKEN}" \

--- a/.travis/sonar.sh
+++ b/.travis/sonar.sh
@@ -2,7 +2,7 @@
 
 if [ "${TRAVIS_PULL_REQUEST}" != "false" ]; then
   if [ "${TRAVIS_PULL_REQUEST_SLUG}" != "constellation-app/constellation" ]; then
-    echo "skipping sonar-scanner"
+    echo "skipping running sonar-scanner"
   else
     SONAR_PULLREQUEST_BRANCH="$(echo "${TRAVIS_PULL_REQUEST_SLUG}" | awk '{split($0,a,"/"); print a[1]}')/${TRAVIS_PULL_REQUEST_BRANCH}"
     sonar-scanner \


### PR DESCRIPTION
PR adds skipping of running `sonar-scanner` for forks since the secret key is not injected in forks [for security](https://docs.travis-ci.com/user/pull-requests/#pull-requests-and-security-restrictions). 