### PR TITLE
issue-228

### DIFF
--- a/CoreDataAccessView/src/au/gov/asd/tac/constellation/views/dataaccess/plugins/importing/ExtractTypesFromTextPlugin.java
+++ b/CoreDataAccessView/src/au/gov/asd/tac/constellation/views/dataaccess/plugins/importing/ExtractTypesFromTextPlugin.java
@@ -23,8 +23,10 @@ import au.gov.asd.tac.constellation.graph.schema.SchemaVertexTypeUtilities;
 import au.gov.asd.tac.constellation.graph.schema.SchemaVertexTypeUtilities.ExtractedVertexType;
 import au.gov.asd.tac.constellation.graph.visual.concept.VisualConcept;
 import au.gov.asd.tac.constellation.pluginframework.Plugin;
+import au.gov.asd.tac.constellation.pluginframework.PluginException;
 import au.gov.asd.tac.constellation.pluginframework.PluginInfo;
 import au.gov.asd.tac.constellation.pluginframework.PluginInteraction;
+import au.gov.asd.tac.constellation.pluginframework.PluginNotificationLevel;
 import au.gov.asd.tac.constellation.pluginframework.PluginType;
 import au.gov.asd.tac.constellation.pluginframework.logging.ConstellationLoggerHelper;
 import au.gov.asd.tac.constellation.pluginframework.parameters.PluginParameter;
@@ -87,13 +89,17 @@ public class ExtractTypesFromTextPlugin extends RecordStoreQueryPlugin implement
     }
 
     @Override
-    protected RecordStore query(final RecordStore query, final PluginInteraction interaction, final PluginParameters parameters) throws InterruptedException {
+    protected RecordStore query(final RecordStore query, final PluginInteraction interaction, final PluginParameters parameters) throws InterruptedException, PluginException {
         final RecordStore result = new GraphRecordStore();
 
         interaction.setProgress(0, 0, "Importing...", true);
 
         final Map<String, PluginParameter<?>> extractEntityParameters = parameters.getParameters();
         final String text = extractEntityParameters.get(TEXT_PARAMETER_ID).getStringValue();
+        
+        if (text == null) {
+            throw new PluginException(PluginNotificationLevel.ERROR, "No text provided from which to extract types.");
+        }
 
         final List<ExtractedVertexType> extractedTypes = SchemaVertexTypeUtilities.extractVertexTypes(text);
 

--- a/CoreGraph/src/au/gov/asd/tac/constellation/graph/schema/SchemaVertexTypeUtilities.java
+++ b/CoreGraph/src/au/gov/asd/tac/constellation/graph/schema/SchemaVertexTypeUtilities.java
@@ -306,7 +306,7 @@ public class SchemaVertexTypeUtilities {
 
         getTypes().forEach(schemaVertexType -> {
             final Pattern regex = schemaVertexType.getDetectionRegex();
-            if (regex != null) {
+            if (regex != null && text != null) {
                 final Matcher matcher = regex.matcher(text);
                 while (matcher.find()) {
                     final String identifier = matcher.group();


### PR DESCRIPTION
:bug: added checks for null text in SchemaVertexTypeUtilities and ExtractTypesFromTextPlugin

### Description of the Change

Null checks to prevent NPE's.

### Alternate Designs

N/A

### Why Should This Be In Core?

Because nobody likes bugs.

### Benefits

One less NPE, replaced instead with a helpful error message.

### Possible Drawbacks

N/A

### Verification Process

Manual testing of the plugin.

### Applicable Issues

https://github.com/constellation-app/constellation/issues/228
