### PR TITLE
issue-179

### DIFF
--- a/CoreAttributeEditor/src/au/gov/asd/tac/constellation/views/attributeeditor/editors/AbstractEditorFactory.java
+++ b/CoreAttributeEditor/src/au/gov/asd/tac/constellation/views/attributeeditor/editors/AbstractEditorFactory.java
@@ -235,6 +235,5 @@ public abstract class AbstractEditorFactory<V> {
         public String getReason() {
             return reason;
         }
-
     }
 }

--- a/CoreAttributeEditor/src/au/gov/asd/tac/constellation/views/attributeeditor/editors/AbstractEditorFactory.java
+++ b/CoreAttributeEditor/src/au/gov/asd/tac/constellation/views/attributeeditor/editors/AbstractEditorFactory.java
@@ -104,7 +104,7 @@ public abstract class AbstractEditorFactory<V> {
                     final String error = validateCurrentValue();
                     errorMessageProperty.set(error);
                     disableEditProperty.set(error != null);
-                } catch (ControlsInvalidException ex) {
+                } catch (final ControlsInvalidException ex) {
                     disableEditProperty.set(true);
                     errorMessageProperty.set(ex.getReason());
                 }

--- a/CoreAttributeEditor/src/au/gov/asd/tac/constellation/views/attributeeditor/editors/AttributeEditorFactory.java
+++ b/CoreAttributeEditor/src/au/gov/asd/tac/constellation/views/attributeeditor/editors/AttributeEditorFactory.java
@@ -71,7 +71,7 @@ public class AttributeEditorFactory extends AbstractEditorFactory<AttributeProto
             this.elementType = elementType;
         }
 
-        public void setTypeModifiable(boolean isTypeModifiable) {
+        public void setTypeModifiable(final boolean isTypeModifiable) {
             this.isTypeModifiable = isTypeModifiable;
             if (typeCombo != null) {
                 typeCombo.setDisable(!isTypeModifiable);
@@ -79,7 +79,7 @@ public class AttributeEditorFactory extends AbstractEditorFactory<AttributeProto
         }
 
         @Override
-        protected boolean canSet(AttributePrototype value) {
+        protected boolean canSet(final AttributePrototype value) {
             return value != null;
         }
 
@@ -174,6 +174,5 @@ public class AttributeEditorFactory extends AbstractEditorFactory<AttributeProto
                 dialog.showDialog();
             };
         }
-
     }
 }

--- a/CoreAttributeEditor/src/au/gov/asd/tac/constellation/views/attributeeditor/editors/AttributeValueEditorFactory.java
+++ b/CoreAttributeEditor/src/au/gov/asd/tac/constellation/views/attributeeditor/editors/AttributeValueEditorFactory.java
@@ -74,5 +74,4 @@ public abstract class AttributeValueEditorFactory<V> extends AbstractEditorFacto
 
         return chosenEditType == null ? null : typeHandlers.get(chosenEditType);
     }
-
 }

--- a/CoreAttributeEditor/src/au/gov/asd/tac/constellation/views/attributeeditor/editors/BlazeEditorFactory.java
+++ b/CoreAttributeEditor/src/au/gov/asd/tac/constellation/views/attributeeditor/editors/BlazeEditorFactory.java
@@ -87,9 +87,14 @@ public class BlazeEditorFactory extends AttributeValueEditorFactory<Blaze> {
             if (noValueCheckBox.isSelected()) {
                 return null;
             }
+            
             try {
-                return new Blaze(Integer.parseInt(angleTextField.getText()), ConstellationColor.fromFXColor(picker.getValue()));
-            } catch (NumberFormatException ex) {
+                final int angle = Integer.parseInt(angleTextField.getText());
+                if (angle >= 360) {
+                    throw new ControlsInvalidException("Blaze angle must be in range [0, 360)");
+                }
+                return new Blaze(angle, ConstellationColor.fromFXColor(picker.getValue()));
+            } catch (final NumberFormatException ex) {
                 throw new ControlsInvalidException("Blaze angle must be a number.");
             }
         }
@@ -218,6 +223,5 @@ public class BlazeEditorFactory extends AttributeValueEditorFactory<Blaze> {
             controls.addRow(5, noValueCheckBox);
             return controls;
         }
-
     }
 }

--- a/CoreAttributeEditor/src/au/gov/asd/tac/constellation/views/attributeeditor/editors/BooleanEditorFactory.java
+++ b/CoreAttributeEditor/src/au/gov/asd/tac/constellation/views/attributeeditor/editors/BooleanEditorFactory.java
@@ -51,7 +51,7 @@ public class BooleanEditorFactory extends AttributeValueEditorFactory<Boolean> {
         }
 
         @Override
-        protected boolean canSet(Boolean value) {
+        protected boolean canSet(final Boolean value) {
             // This is an editor for primitive booleans, so prevent null values being set.
             return value != null;
         }
@@ -82,6 +82,5 @@ public class BooleanEditorFactory extends AttributeValueEditorFactory<Boolean> {
 
             return controls;
         }
-
     }
 }

--- a/CoreAttributeEditor/src/au/gov/asd/tac/constellation/views/attributeeditor/editors/BooleanObjectEditorFactory.java
+++ b/CoreAttributeEditor/src/au/gov/asd/tac/constellation/views/attributeeditor/editors/BooleanObjectEditorFactory.java
@@ -87,6 +87,5 @@ public class BooleanObjectEditorFactory extends AttributeValueEditorFactory<Bool
             controls.addRow(1, noValueCheckBox);
             return controls;
         }
-
     }
 }

--- a/CoreAttributeEditor/src/au/gov/asd/tac/constellation/views/attributeeditor/editors/ColorEditorFactory.java
+++ b/CoreAttributeEditor/src/au/gov/asd/tac/constellation/views/attributeeditor/editors/ColorEditorFactory.java
@@ -152,6 +152,5 @@ public class ColorEditorFactory extends AttributeValueEditorFactory<Constellatio
             controls.addRow(2, noValueCheckBox);
             return controls;
         }
-
     }
 }

--- a/CoreAttributeEditor/src/au/gov/asd/tac/constellation/views/attributeeditor/editors/ConnectionModeEditorFactory.java
+++ b/CoreAttributeEditor/src/au/gov/asd/tac/constellation/views/attributeeditor/editors/ConnectionModeEditorFactory.java
@@ -58,7 +58,7 @@ public class ConnectionModeEditorFactory extends AttributeValueEditorFactory<Con
         }
 
         @Override
-        protected boolean canSet(ConnectionMode value) {
+        protected boolean canSet(final ConnectionMode value) {
             // As ConnectionMode is an enum, we want one of its constants, not null.
             return value != null;
         }
@@ -101,6 +101,5 @@ public class ConnectionModeEditorFactory extends AttributeValueEditorFactory<Con
             controls.addRow(0, connectionModeLabel, connectionModeComboBox);
             return controls;
         }
-
     }
 }

--- a/CoreAttributeEditor/src/au/gov/asd/tac/constellation/views/attributeeditor/editors/DateEditorFactory.java
+++ b/CoreAttributeEditor/src/au/gov/asd/tac/constellation/views/attributeeditor/editors/DateEditorFactory.java
@@ -69,8 +69,12 @@ public class DateEditorFactory extends AttributeValueEditorFactory<LocalDate> {
             if (noValueCheckBox.isSelected()) {
                 return null;
             }
-            // TODO: figure out how datePicker performs validation.
-//            throw new ControlsInvalidException("Entered value is not a date of format yyyy-mm-dd.");
+            try {
+                final String dateString = datePicker.getEditor().getText();
+                final LocalDate date = datePicker.getConverter().fromString(dateString);
+            } catch (final DateTimeParseException ex) {
+                throw new ControlsInvalidException("Entered value is not a date of format yyyy-mm-dd.");
+            }
             return datePicker.getValue();
         }
 
@@ -90,8 +94,11 @@ public class DateEditorFactory extends AttributeValueEditorFactory<LocalDate> {
             datePicker = new DatePicker();
             datePicker.setConverter(new LocalDateStringConverter(
                     TemporalFormatting.DATE_FORMATTER, TemporalFormatting.DATE_FORMATTER));
+            datePicker.getEditor().textProperty().addListener((v, o, n) -> {
+                update();
+            });
             datePicker.setValue(LocalDate.now());
-            datePicker.valueProperty().addListener((o, n, v) -> {
+            datePicker.valueProperty().addListener((v, o, n) -> {
                 update();
             });
 

--- a/CoreAttributeEditor/src/au/gov/asd/tac/constellation/views/attributeeditor/editors/DateEditorFactory.java
+++ b/CoreAttributeEditor/src/au/gov/asd/tac/constellation/views/attributeeditor/editors/DateEditorFactory.java
@@ -17,14 +17,17 @@ package au.gov.asd.tac.constellation.views.attributeeditor.editors;
 
 import au.gov.asd.tac.constellation.graph.attribute.DateAttributeDescription;
 import au.gov.asd.tac.constellation.graph.attribute.interaction.ValueValidator;
+import au.gov.asd.tac.constellation.utilities.temporal.TemporalFormatting;
 import au.gov.asd.tac.constellation.views.attributeeditor.editors.operations.DefaultGetter;
 import au.gov.asd.tac.constellation.views.attributeeditor.editors.operations.EditOperation;
 import java.time.LocalDate;
+import java.time.format.DateTimeParseException;
 import javafx.geometry.Pos;
 import javafx.scene.Node;
 import javafx.scene.control.CheckBox;
 import javafx.scene.control.DatePicker;
 import javafx.scene.layout.GridPane;
+import javafx.util.converter.LocalDateStringConverter;
 import org.openide.util.lookup.ServiceProvider;
 
 /**
@@ -66,12 +69,14 @@ public class DateEditorFactory extends AttributeValueEditorFactory<LocalDate> {
             if (noValueCheckBox.isSelected()) {
                 return null;
             }
+            // TODO: figure out how datePicker performs validation.
+//            throw new ControlsInvalidException("Entered value is not a date of format yyyy-mm-dd.");
             return datePicker.getValue();
         }
 
         @Override
         protected Node createEditorControls() {
-            GridPane controls = new GridPane();
+            final GridPane controls = new GridPane();
             controls.setAlignment(Pos.CENTER);
             controls.setVgap(CONTROLS_DEFAULT_VERTICAL_SPACING);
 
@@ -83,6 +88,8 @@ public class DateEditorFactory extends AttributeValueEditorFactory<LocalDate> {
             });
 
             datePicker = new DatePicker();
+            datePicker.setConverter(new LocalDateStringConverter(
+                    TemporalFormatting.DATE_FORMATTER, TemporalFormatting.DATE_FORMATTER));
             datePicker.setValue(LocalDate.now());
             datePicker.valueProperty().addListener((o, n, v) -> {
                 update();
@@ -92,6 +99,5 @@ public class DateEditorFactory extends AttributeValueEditorFactory<LocalDate> {
             controls.addRow(1, noValueCheckBox);
             return controls;
         }
-
     }
 }

--- a/CoreAttributeEditor/src/au/gov/asd/tac/constellation/views/attributeeditor/editors/DateTimeEditorFactory.java
+++ b/CoreAttributeEditor/src/au/gov/asd/tac/constellation/views/attributeeditor/editors/DateTimeEditorFactory.java
@@ -17,6 +17,7 @@ package au.gov.asd.tac.constellation.views.attributeeditor.editors;
 
 import au.gov.asd.tac.constellation.graph.attribute.ZonedDateTimeAttributeDescription;
 import au.gov.asd.tac.constellation.graph.attribute.interaction.ValueValidator;
+import au.gov.asd.tac.constellation.utilities.temporal.TemporalFormatting;
 import au.gov.asd.tac.constellation.utilities.temporal.TimeZoneUtilities;
 import au.gov.asd.tac.constellation.views.attributeeditor.editors.operations.DefaultGetter;
 import au.gov.asd.tac.constellation.views.attributeeditor.editors.operations.EditOperation;
@@ -45,6 +46,7 @@ import javafx.scene.layout.GridPane;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.VBox;
 import javafx.util.Callback;
+import javafx.util.converter.LocalDateStringConverter;
 import org.openide.util.lookup.ServiceProvider;
 
 /**
@@ -115,16 +117,21 @@ public class DateTimeEditorFactory extends AttributeValueEditorFactory<ZonedDate
             if (hourSpinner.getValue() == null || minSpinner.getValue() == null || secSpinner.getValue() == null || milliSpinner.getValue() == null) {
                 throw new ControlsInvalidException("Time spinners must have numeric values");
             }
+            // TODO: figure out how datePicker performs validation.
+            System.out.println("DTEF_DP_TEXT::" 
+                    + datePicker.getConverter().fromString(datePicker.getEditor().getText()));
+//            throw new ControlsInvalidException("Entered value is not a date of format yyyy-mm-dd.");
             final ZonedDateTime zdt = ZonedDateTime.of(
                     datePicker.getValue(),
-                    LocalTime.of(hourSpinner.getValue(), minSpinner.getValue(), secSpinner.getValue(), milliSpinner.getValue() * NANOSECONDS_IN_MILLISECOND),
+                    LocalTime.of(hourSpinner.getValue(), minSpinner.getValue(),
+                            secSpinner.getValue(), milliSpinner.getValue() * NANOSECONDS_IN_MILLISECOND),
                     timeZoneComboBox.getValue());
             return zdt;
         }
 
         @Override
         protected Node createEditorControls() {
-            GridPane controls = new GridPane();
+            final GridPane controls = new GridPane();
             controls.setAlignment(Pos.CENTER);
             controls.setVgap(CONTROLS_DEFAULT_VERTICAL_SPACING);
 
@@ -167,7 +174,7 @@ public class DateTimeEditorFactory extends AttributeValueEditorFactory<ZonedDate
 
             final HBox timeZoneHbox = new HBox(timeZoneComboBoxLabel, timeZoneComboBox);
             timeZoneHbox.setSpacing(5);
-            HBox timeSpinnerContainer = createTimeSpinners();
+            final HBox timeSpinnerContainer = createTimeSpinners();
 
             controls.addRow(0, timeSpinnerContainer);
             controls.addRow(1, timeZoneHbox);
@@ -184,8 +191,9 @@ public class DateTimeEditorFactory extends AttributeValueEditorFactory<ZonedDate
         }
 
         private HBox createTimeSpinners() {
-
             datePicker = new DatePicker();
+            datePicker.setConverter(new LocalDateStringConverter(
+                    TemporalFormatting.DATE_FORMATTER, TemporalFormatting.DATE_FORMATTER));
             datePicker.setValue(LocalDate.now());
             datePicker.valueProperty().addListener((v, o, n) -> {
                 update();
@@ -201,25 +209,25 @@ public class DateTimeEditorFactory extends AttributeValueEditorFactory<ZonedDate
             secSpinner.getValueFactory().setValue(LocalTime.now(ZoneOffset.UTC).getSecond());
             milliSpinner.getValueFactory().setValue(0);
 
-            HBox timeSpinnerContainer = new HBox(CONTROLS_DEFAULT_VERTICAL_SPACING);
+            final HBox timeSpinnerContainer = new HBox(CONTROLS_DEFAULT_VERTICAL_SPACING);
 
-            Label dateLabel = new Label("Date:");
+            final Label dateLabel = new Label("Date:");
             dateLabel.setId("label");
             dateLabel.setLabelFor(datePicker);
 
-            Label hourSpinnerLabel = new Label("Hour:");
+            final Label hourSpinnerLabel = new Label("Hour:");
             hourSpinnerLabel.setId("label");
             hourSpinnerLabel.setLabelFor(hourSpinner);
 
-            Label minSpinnerLabel = new Label("Minute:");
+            final Label minSpinnerLabel = new Label("Minute:");
             minSpinnerLabel.setId("label");
             minSpinnerLabel.setLabelFor(minSpinner);
 
-            Label secSpinnerLabel = new Label("Second:");
+            final Label secSpinnerLabel = new Label("Second:");
             secSpinnerLabel.setId("label");
             secSpinnerLabel.setLabelFor(secSpinner);
 
-            Label milliSpinnerLabel = new Label("Millis:");
+            final Label milliSpinnerLabel = new Label("Millis:");
             milliSpinnerLabel.setId("label");
             milliSpinnerLabel.setLabelFor(milliSpinner);
 
@@ -250,21 +258,20 @@ public class DateTimeEditorFactory extends AttributeValueEditorFactory<ZonedDate
                 updateTimeZoneList();
             });
 
-            VBox dateLabelNode = new VBox(5);
+            final VBox dateLabelNode = new VBox(5);
             dateLabelNode.getChildren().addAll(dateLabel, datePicker);
-            VBox hourLabelNode = new VBox(5);
+            final VBox hourLabelNode = new VBox(5);
             hourLabelNode.getChildren().addAll(hourSpinnerLabel, hourSpinner);
-            VBox minLabelNode = new VBox(5);
+            final VBox minLabelNode = new VBox(5);
             minLabelNode.getChildren().addAll(minSpinnerLabel, minSpinner);
-            VBox secLabelNode = new VBox(5);
+            final VBox secLabelNode = new VBox(5);
             secLabelNode.getChildren().addAll(secSpinnerLabel, secSpinner);
-            VBox milliLabelNode = new VBox(5);
+            final VBox milliLabelNode = new VBox(5);
             milliLabelNode.getChildren().addAll(milliSpinnerLabel, milliSpinner);
 
             timeSpinnerContainer.getChildren().addAll(dateLabelNode, hourLabelNode, minLabelNode, secLabelNode, milliLabelNode);
 
             return timeSpinnerContainer;
         }
-
     }
 }

--- a/CoreAttributeEditor/src/au/gov/asd/tac/constellation/views/attributeeditor/editors/DecoratorsEditorFactory.java
+++ b/CoreAttributeEditor/src/au/gov/asd/tac/constellation/views/attributeeditor/editors/DecoratorsEditorFactory.java
@@ -65,6 +65,26 @@ public class DecoratorsEditorFactory extends AttributeValueEditorFactory<Decorat
         }
 
         @Override
+        protected boolean canSet(final Decorators value) {
+            // Decorators cannot be null, so prevent null values being set.
+            return value != null;
+        }
+
+        @Override
+        public void updateControlsWithValue(final Decorators value) {
+            setDecoratorChoice(nwCombo, value.getNorthWestDecoratorAttribute());
+            setDecoratorChoice(neCombo, value.getNorthEastDecoratorAttribute());
+            setDecoratorChoice(seCombo, value.getSouthEastDecoratorAttribute());
+            setDecoratorChoice(swCombo, value.getSouthWestDecoratorAttribute());
+        }
+
+        @Override
+        protected Decorators getValueFromControls() throws ControlsInvalidException {
+            return new Decorators(getDecoratorChoice(nwCombo), getDecoratorChoice(neCombo), 
+                    getDecoratorChoice(seCombo), getDecoratorChoice(swCombo));
+        }
+
+        @Override
         protected Node createEditorControls() {
             // get all vertex attributes currently in the graph
             final List<String> attributeNames = new ArrayList<>();
@@ -111,19 +131,6 @@ public class DecoratorsEditorFactory extends AttributeValueEditorFactory<Decorat
             return controls;
         }
 
-        @Override
-        public void updateControlsWithValue(final Decorators value) {
-            setDecoratorChoice(nwCombo, value.getNorthWestDecoratorAttribute());
-            setDecoratorChoice(neCombo, value.getNorthEastDecoratorAttribute());
-            setDecoratorChoice(seCombo, value.getSouthEastDecoratorAttribute());
-            setDecoratorChoice(swCombo, value.getSouthWestDecoratorAttribute());
-        }
-
-        @Override
-        protected Decorators getValueFromControls() throws ControlsInvalidException {
-            return new Decorators(getDecoratorChoice(nwCombo), getDecoratorChoice(neCombo), getDecoratorChoice(seCombo), getDecoratorChoice(swCombo));
-        }
-
         private void setDecoratorChoice(final ComboBox<String> comboBox, final String choice) {
             comboBox.getSelectionModel().select(choice == null ? NO_DECORATOR : choice);
         }
@@ -131,6 +138,5 @@ public class DecoratorsEditorFactory extends AttributeValueEditorFactory<Decorat
         private String getDecoratorChoice(final ComboBox<String> comboBox) {
             return comboBox.getSelectionModel().getSelectedItem().equals(NO_DECORATOR) ? null : comboBox.getSelectionModel().getSelectedItem();
         }
-
     }
 }

--- a/CoreAttributeEditor/src/au/gov/asd/tac/constellation/views/attributeeditor/editors/DrawFlagsEditorFactory.java
+++ b/CoreAttributeEditor/src/au/gov/asd/tac/constellation/views/attributeeditor/editors/DrawFlagsEditorFactory.java
@@ -55,8 +55,8 @@ public class DrawFlagsEditorFactory extends AttributeValueEditorFactory<DrawFlag
         }
 
         @Override
-        protected boolean canSet(DrawFlags value) {
-            // This is an editor for primitive booleans, so prevent null values being set.
+        protected boolean canSet(final DrawFlags value) {
+            // Draw flags cannot be null, so prevent null values being set.
             return value != null;
         }
 
@@ -71,12 +71,14 @@ public class DrawFlagsEditorFactory extends AttributeValueEditorFactory<DrawFlag
 
         @Override
         protected DrawFlags getValueFromControls() {
-            return new DrawFlags(drawNodesCheckBox.isSelected(), drawConnectionsCheckBox.isSelected(), drawNodeLabelsCheckBox.isSelected(), drawConnectionLabelsCheckBox.isSelected(), drawBlazesCheckBox.isSelected());
+            return new DrawFlags(drawNodesCheckBox.isSelected(), 
+                    drawConnectionsCheckBox.isSelected(), drawNodeLabelsCheckBox.isSelected(), 
+                    drawConnectionLabelsCheckBox.isSelected(), drawBlazesCheckBox.isSelected());
         }
 
         @Override
         protected Node createEditorControls() {
-            VBox controls = new VBox();
+            final VBox controls = new VBox();
             controls.setFillWidth(true);
 
             drawNodesCheckBox = new CheckBox("Nodes");
@@ -108,6 +110,5 @@ public class DrawFlagsEditorFactory extends AttributeValueEditorFactory<DrawFlag
 
             return controls;
         }
-
     }
 }

--- a/CoreAttributeEditor/src/au/gov/asd/tac/constellation/views/attributeeditor/editors/FloatEditorFactory.java
+++ b/CoreAttributeEditor/src/au/gov/asd/tac/constellation/views/attributeeditor/editors/FloatEditorFactory.java
@@ -51,7 +51,7 @@ public class FloatEditorFactory extends AttributeValueEditorFactory<Float> {
         }
 
         @Override
-        protected boolean canSet(Float value) {
+        protected boolean canSet(final Float value) {
             // This is an editor for primitive floats, so prevent null values being set.
             return value != null;
         }
@@ -65,7 +65,7 @@ public class FloatEditorFactory extends AttributeValueEditorFactory<Float> {
         protected Float getValueFromControls() throws ControlsInvalidException {
             try {
                 return Float.parseFloat(numberField.getText());
-            } catch (NumberFormatException ex) {
+            } catch (final NumberFormatException ex) {
                 throw new ControlsInvalidException("Entered value is not a float.");
             }
         }

--- a/CoreAttributeEditor/src/au/gov/asd/tac/constellation/views/attributeeditor/editors/FloatObjectEditorFactory.java
+++ b/CoreAttributeEditor/src/au/gov/asd/tac/constellation/views/attributeeditor/editors/FloatObjectEditorFactory.java
@@ -67,7 +67,7 @@ public class FloatObjectEditorFactory extends AttributeValueEditorFactory<Float>
             }
             try {
                 return Float.parseFloat(numberField.getText());
-            } catch (NumberFormatException ex) {
+            } catch (final NumberFormatException ex) {
                 throw new ControlsInvalidException("Entered value is not a decimal.");
             }
         }

--- a/CoreAttributeEditor/src/au/gov/asd/tac/constellation/views/attributeeditor/editors/HyperlinkEditorFactory.java
+++ b/CoreAttributeEditor/src/au/gov/asd/tac/constellation/views/attributeeditor/editors/HyperlinkEditorFactory.java
@@ -69,7 +69,7 @@ public class HyperlinkEditorFactory extends AttributeValueEditorFactory<URI> {
             }
             try {
                 return new URI(textField.getText());
-            } catch (URISyntaxException ex) {
+            } catch (final URISyntaxException ex) {
                 throw new ControlsInvalidException("Entered value is not a valid URL.");
             }
         }
@@ -96,6 +96,5 @@ public class HyperlinkEditorFactory extends AttributeValueEditorFactory<URI> {
             controls.addRow(1, noValueCheckBox);
             return controls;
         }
-
     }
 }

--- a/CoreAttributeEditor/src/au/gov/asd/tac/constellation/views/attributeeditor/editors/IntegerEditorFactory.java
+++ b/CoreAttributeEditor/src/au/gov/asd/tac/constellation/views/attributeeditor/editors/IntegerEditorFactory.java
@@ -51,7 +51,7 @@ public class IntegerEditorFactory extends AttributeValueEditorFactory<Integer> {
         }
 
         @Override
-        protected boolean canSet(Integer value) {
+        protected boolean canSet(final Integer value) {
             // This is an editor for primitive ints, so prevent null values being set.
             return value != null;
         }
@@ -65,7 +65,7 @@ public class IntegerEditorFactory extends AttributeValueEditorFactory<Integer> {
         protected Integer getValueFromControls() throws ControlsInvalidException {
             try {
                 return Integer.parseInt(numberField.getText());
-            } catch (NumberFormatException ex) {
+            } catch (final NumberFormatException ex) {
                 throw new ControlsInvalidException("Entered value is not an integer.");
             }
         }

--- a/CoreAttributeEditor/src/au/gov/asd/tac/constellation/views/attributeeditor/editors/LineStyleEditorFactory.java
+++ b/CoreAttributeEditor/src/au/gov/asd/tac/constellation/views/attributeeditor/editors/LineStyleEditorFactory.java
@@ -58,7 +58,7 @@ public class LineStyleEditorFactory extends AttributeValueEditorFactory<LineStyl
         }
 
         @Override
-        protected boolean canSet(LineStyle value) {
+        protected boolean canSet(final LineStyle value) {
             // As LineStyle is an enum, we want one of its constants, not null.
             return value != null;
         }
@@ -101,6 +101,5 @@ public class LineStyleEditorFactory extends AttributeValueEditorFactory<LineStyl
             controls.addRow(0, lineStyleLabel, lineStyleComboBox);
             return controls;
         }
-
     }
 }

--- a/CoreAttributeEditor/src/au/gov/asd/tac/constellation/views/attributeeditor/editors/ListSelectionEditorFactory.java
+++ b/CoreAttributeEditor/src/au/gov/asd/tac/constellation/views/attributeeditor/editors/ListSelectionEditorFactory.java
@@ -58,7 +58,7 @@ public class ListSelectionEditorFactory extends AbstractEditorFactory<List<Strin
         }
 
         @Override
-        protected boolean canSet(List<String> value) {
+        protected boolean canSet(final List<String> value) {
             return value != null;
         }
 
@@ -127,6 +127,5 @@ public class ListSelectionEditorFactory extends AbstractEditorFactory<List<Strin
 
             return controls;
         }
-
     }
 }

--- a/CoreAttributeEditor/src/au/gov/asd/tac/constellation/views/attributeeditor/editors/LocalDateTimeEditorFactory.java
+++ b/CoreAttributeEditor/src/au/gov/asd/tac/constellation/views/attributeeditor/editors/LocalDateTimeEditorFactory.java
@@ -17,6 +17,7 @@ package au.gov.asd.tac.constellation.views.attributeeditor.editors;
 
 import au.gov.asd.tac.constellation.graph.attribute.LocalDateTimeAttributeDescription;
 import au.gov.asd.tac.constellation.graph.attribute.interaction.ValueValidator;
+import au.gov.asd.tac.constellation.utilities.temporal.TemporalFormatting;
 import au.gov.asd.tac.constellation.views.attributeeditor.editors.operations.DefaultGetter;
 import au.gov.asd.tac.constellation.views.attributeeditor.editors.operations.EditOperation;
 import java.time.LocalDate;
@@ -34,6 +35,7 @@ import javafx.scene.control.SpinnerValueFactory;
 import javafx.scene.layout.GridPane;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.VBox;
+import javafx.util.converter.LocalDateStringConverter;
 import org.openide.util.lookup.ServiceProvider;
 
 /**
@@ -90,15 +92,18 @@ public class LocalDateTimeEditorFactory extends AttributeValueEditorFactory<Loca
             if (hourSpinner.getValue() == null || minSpinner.getValue() == null || secSpinner.getValue() == null || milliSpinner.getValue() == null) {
                 throw new ControlsInvalidException("Time spinners must have numeric values");
             }
+            // TODO: figure out how datePicker performs validation.
+//            throw new ControlsInvalidException("Entered value is not a date of format yyyy-mm-dd.");
             final LocalDateTime ldt = LocalDateTime.of(
                     datePicker.getValue(),
-                    LocalTime.of(hourSpinner.getValue().intValue(), minSpinner.getValue().intValue(), secSpinner.getValue().intValue(), milliSpinner.getValue().intValue() * NANOSECONDS_IN_MILLISECOND));
+                    LocalTime.of(hourSpinner.getValue(), minSpinner.getValue(), 
+                            secSpinner.getValue(), milliSpinner.getValue() * NANOSECONDS_IN_MILLISECOND));
             return ldt;
         }
 
         @Override
         protected Node createEditorControls() {
-            GridPane controls = new GridPane();
+            final GridPane controls = new GridPane();
             controls.setAlignment(Pos.CENTER);
             controls.setVgap(CONTROLS_DEFAULT_VERTICAL_SPACING);
 
@@ -113,7 +118,7 @@ public class LocalDateTimeEditorFactory extends AttributeValueEditorFactory<Loca
                 update();
             });
 
-            HBox timeSpinnerContainer = createTimeSpinners();
+            final HBox timeSpinnerContainer = createTimeSpinners();
 
             controls.addRow(0, timeSpinnerContainer);
             controls.addRow(1, noValueCheckBox);
@@ -121,8 +126,9 @@ public class LocalDateTimeEditorFactory extends AttributeValueEditorFactory<Loca
         }
 
         private HBox createTimeSpinners() {
-
             datePicker = new DatePicker();
+            datePicker.setConverter(new LocalDateStringConverter(
+                    TemporalFormatting.DATE_FORMATTER, TemporalFormatting.DATE_FORMATTER));
             datePicker.setValue(LocalDate.now());
             datePicker.valueProperty().addListener((v, o, n) -> {
                 update();
@@ -137,25 +143,25 @@ public class LocalDateTimeEditorFactory extends AttributeValueEditorFactory<Loca
             secSpinner.getValueFactory().setValue(LocalTime.now(ZoneOffset.UTC).getSecond());
             milliSpinner.getValueFactory().setValue(0);
 
-            HBox timeSpinnerContainer = new HBox(CONTROLS_DEFAULT_VERTICAL_SPACING);
+            final HBox timeSpinnerContainer = new HBox(CONTROLS_DEFAULT_VERTICAL_SPACING);
 
-            Label dateLabel = new Label("Date:");
+            final Label dateLabel = new Label("Date:");
             dateLabel.setId("label");
             dateLabel.setLabelFor(datePicker);
 
-            Label hourSpinnerLabel = new Label("Hour:");
+            final Label hourSpinnerLabel = new Label("Hour:");
             hourSpinnerLabel.setId("label");
             hourSpinnerLabel.setLabelFor(hourSpinner);
 
-            Label minSpinnerLabel = new Label("Minute:");
+            final Label minSpinnerLabel = new Label("Minute:");
             minSpinnerLabel.setId("label");
             minSpinnerLabel.setLabelFor(minSpinner);
 
-            Label secSpinnerLabel = new Label("Second:");
+            final Label secSpinnerLabel = new Label("Second:");
             secSpinnerLabel.setId("label");
             secSpinnerLabel.setLabelFor(secSpinner);
 
-            Label milliSpinnerLabel = new Label("Millis:");
+            final Label milliSpinnerLabel = new Label("Millis:");
             milliSpinnerLabel.setId("label");
             milliSpinnerLabel.setLabelFor(milliSpinner);
 
@@ -182,21 +188,20 @@ public class LocalDateTimeEditorFactory extends AttributeValueEditorFactory<Loca
                 update();
             });
 
-            VBox dateLabelNode = new VBox(5);
+            final VBox dateLabelNode = new VBox(5);
             dateLabelNode.getChildren().addAll(dateLabel, datePicker);
-            VBox hourLabelNode = new VBox(5);
+            final VBox hourLabelNode = new VBox(5);
             hourLabelNode.getChildren().addAll(hourSpinnerLabel, hourSpinner);
-            VBox minLabelNode = new VBox(5);
+            final VBox minLabelNode = new VBox(5);
             minLabelNode.getChildren().addAll(minSpinnerLabel, minSpinner);
-            VBox secLabelNode = new VBox(5);
+            final VBox secLabelNode = new VBox(5);
             secLabelNode.getChildren().addAll(secSpinnerLabel, secSpinner);
-            VBox milliLabelNode = new VBox(5);
+            final VBox milliLabelNode = new VBox(5);
             milliLabelNode.getChildren().addAll(milliSpinnerLabel, milliSpinner);
 
             timeSpinnerContainer.getChildren().addAll(dateLabelNode, hourLabelNode, minLabelNode, secLabelNode, milliLabelNode);
 
             return timeSpinnerContainer;
         }
-
     }
 }

--- a/CoreAttributeEditor/src/au/gov/asd/tac/constellation/views/attributeeditor/editors/LocalDateTimeEditorFactory.java
+++ b/CoreAttributeEditor/src/au/gov/asd/tac/constellation/views/attributeeditor/editors/LocalDateTimeEditorFactory.java
@@ -24,6 +24,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.ZoneOffset;
+import java.time.format.DateTimeParseException;
 import java.time.temporal.ChronoField;
 import javafx.geometry.Pos;
 import javafx.scene.Node;
@@ -92,13 +93,16 @@ public class LocalDateTimeEditorFactory extends AttributeValueEditorFactory<Loca
             if (hourSpinner.getValue() == null || minSpinner.getValue() == null || secSpinner.getValue() == null || milliSpinner.getValue() == null) {
                 throw new ControlsInvalidException("Time spinners must have numeric values");
             }
-            // TODO: figure out how datePicker performs validation.
-//            throw new ControlsInvalidException("Entered value is not a date of format yyyy-mm-dd.");
-            final LocalDateTime ldt = LocalDateTime.of(
+            try {
+                final String dateString = datePicker.getEditor().getText();
+                final LocalDate date = datePicker.getConverter().fromString(dateString);
+            } catch (final DateTimeParseException ex) {
+                throw new ControlsInvalidException("Entered value is not a date of format yyyy-mm-dd.");
+            }
+            return LocalDateTime.of(
                     datePicker.getValue(),
                     LocalTime.of(hourSpinner.getValue(), minSpinner.getValue(), 
                             secSpinner.getValue(), milliSpinner.getValue() * NANOSECONDS_IN_MILLISECOND));
-            return ldt;
         }
 
         @Override
@@ -129,6 +133,9 @@ public class LocalDateTimeEditorFactory extends AttributeValueEditorFactory<Loca
             datePicker = new DatePicker();
             datePicker.setConverter(new LocalDateStringConverter(
                     TemporalFormatting.DATE_FORMATTER, TemporalFormatting.DATE_FORMATTER));
+            datePicker.getEditor().textProperty().addListener((v, o, n) -> {
+                update();
+            });
             datePicker.setValue(LocalDate.now());
             datePicker.valueProperty().addListener((v, o, n) -> {
                 update();

--- a/CoreAttributeEditor/src/au/gov/asd/tac/constellation/views/attributeeditor/editors/LongEditorFactory.java
+++ b/CoreAttributeEditor/src/au/gov/asd/tac/constellation/views/attributeeditor/editors/LongEditorFactory.java
@@ -51,7 +51,7 @@ public class LongEditorFactory extends AttributeValueEditorFactory<Long> {
         }
 
         @Override
-        protected boolean canSet(Long value) {
+        protected boolean canSet(final Long value) {
             // This is an editor for primitive longs, so prevent null values being set.
             return value != null;
         }
@@ -65,8 +65,8 @@ public class LongEditorFactory extends AttributeValueEditorFactory<Long> {
         protected Long getValueFromControls() throws AbstractEditorFactory.ControlsInvalidException {
             try {
                 return Long.parseLong(numberField.getText());
-            } catch (NumberFormatException ex) {
-                throw new AbstractEditorFactory.ControlsInvalidException("Entered value is not a long.");
+            } catch (final NumberFormatException ex) {
+                throw new ControlsInvalidException("Entered value is not a long.");
             }
         }
 

--- a/CoreAttributeEditor/src/au/gov/asd/tac/constellation/views/attributeeditor/editors/TimeEditorFactory.java
+++ b/CoreAttributeEditor/src/au/gov/asd/tac/constellation/views/attributeeditor/editors/TimeEditorFactory.java
@@ -82,19 +82,21 @@ public class TimeEditorFactory extends AttributeValueEditorFactory<LocalTime> {
             if (noValueCheckBox.isSelected()) {
                 return null;
             }
-            if (hourSpinner.getValue() == null || minSpinner.getValue() == null || secSpinner.getValue() == null || milliSpinner.getValue() == null) {
+            if (hourSpinner.getValue() == null || minSpinner.getValue() == null || 
+                    secSpinner.getValue() == null || milliSpinner.getValue() == null) {
                 throw new ControlsInvalidException("Time spinners must have numeric values");
             }
-            return LocalTime.of(hourSpinner.getValue().intValue(), minSpinner.getValue().intValue(), secSpinner.getValue().intValue(), milliSpinner.getValue().intValue() * NANOSECONDS_IN_MILLISECOND);
+            return LocalTime.of(hourSpinner.getValue(), minSpinner.getValue(), 
+                    secSpinner.getValue(), milliSpinner.getValue() * NANOSECONDS_IN_MILLISECOND);
         }
 
         @Override
         protected Node createEditorControls() {
-            GridPane controls = new GridPane();
+            final GridPane controls = new GridPane();
             controls.setAlignment(Pos.CENTER);
             controls.setVgap(CONTROLS_DEFAULT_VERTICAL_SPACING);
 
-            HBox timeSpinnerContainer = createTimeSpinners();
+            final HBox timeSpinnerContainer = createTimeSpinners();
 
             noValueCheckBox = new CheckBox(NO_VALUE_LABEL);
             noValueCheckBox.setAlignment(Pos.CENTER);
@@ -112,7 +114,6 @@ public class TimeEditorFactory extends AttributeValueEditorFactory<LocalTime> {
         }
 
         private HBox createTimeSpinners() {
-
             hourSpinner = new Spinner<>(new SpinnerValueFactory.IntegerSpinnerValueFactory(0, 23));
             minSpinner = new Spinner<>(new SpinnerValueFactory.IntegerSpinnerValueFactory(0, 59));
             secSpinner = new Spinner<>(new SpinnerValueFactory.IntegerSpinnerValueFactory(0, 59));
@@ -122,23 +123,23 @@ public class TimeEditorFactory extends AttributeValueEditorFactory<LocalTime> {
             secSpinner.getValueFactory().setValue(LocalTime.now(ZoneOffset.UTC).getSecond());
             milliSpinner.getValueFactory().setValue(0);
 
-            HBox timeSpinnerContainer = new HBox(CONTROLS_DEFAULT_VERTICAL_SPACING);
+            final HBox timeSpinnerContainer = new HBox(CONTROLS_DEFAULT_VERTICAL_SPACING);
 
-            Label hourSpinnerLabel = new Label("hr:");
+            final Label hourSpinnerLabel = new Label("hr:");
             hourSpinnerLabel.setId("label");
             hourSpinnerLabel.setLabelFor(hourSpinner);
 
-            Label minSpinnerLabel = new Label("min:");
+            final Label minSpinnerLabel = new Label("min:");
             minSpinnerLabel.setId("label");
             minSpinnerLabel.setLabelFor(minSpinner);
 
-            Label secSpinnerLabel = new Label("sec:");
+            final Label secSpinnerLabel = new Label("sec:");
             secSpinnerLabel.setId("label");
             secSpinnerLabel.setLabelFor(secSpinner);
 
-            Label milliSpinnerLabel = new Label("ms:");
+            final Label milliSpinnerLabel = new Label("ms:");
             milliSpinnerLabel.setId("label");
-            milliSpinnerLabel.setLabelFor(secSpinner);
+            milliSpinnerLabel.setLabelFor(milliSpinner);
 
             hourSpinner.setPrefWidth(NUMBER_SPINNER_WIDTH);
             minSpinner.setPrefWidth(NUMBER_SPINNER_WIDTH);
@@ -163,19 +164,18 @@ public class TimeEditorFactory extends AttributeValueEditorFactory<LocalTime> {
                 update();
             });
 
-            VBox hourLabelNode = new VBox(5);
+            final VBox hourLabelNode = new VBox(5);
             hourLabelNode.getChildren().addAll(hourSpinnerLabel, hourSpinner);
-            VBox minLabelNode = new VBox(5);
+            final VBox minLabelNode = new VBox(5);
             minLabelNode.getChildren().addAll(minSpinnerLabel, minSpinner);
-            VBox secLabelNode = new VBox(5);
+            final VBox secLabelNode = new VBox(5);
             secLabelNode.getChildren().addAll(secSpinnerLabel, secSpinner);
-            VBox milliLabelNode = new VBox(5);
+            final VBox milliLabelNode = new VBox(5);
             milliLabelNode.getChildren().addAll(milliSpinnerLabel, milliSpinner);
 
             timeSpinnerContainer.getChildren().addAll(hourLabelNode, minLabelNode, secLabelNode, milliLabelNode);
 
             return timeSpinnerContainer;
         }
-
     }
 }

--- a/CoreAttributeEditor/src/au/gov/asd/tac/constellation/views/attributeeditor/editors/TimeZoneEditorFactory.java
+++ b/CoreAttributeEditor/src/au/gov/asd/tac/constellation/views/attributeeditor/editors/TimeZoneEditorFactory.java
@@ -66,14 +66,14 @@ public class TimeZoneEditorFactory extends AttributeValueEditorFactory<ZoneId> {
         }
 
         @Override
-        public void updateControlsWithValue(final ZoneId value) {
-            timeZoneComboBox.getSelectionModel().select(value);
+        protected boolean canSet(final ZoneId value) {
+            // Time zones cannot be null, so prevent null values being set.
+            return value != null;
         }
 
         @Override
-        protected boolean canSet(ZoneId value) {
-            // We do not want to set a null time zone.
-            return value != null;
+        public void updateControlsWithValue(final ZoneId value) {
+            timeZoneComboBox.getSelectionModel().select(value);
         }
 
         @Override
@@ -112,6 +112,5 @@ public class TimeZoneEditorFactory extends AttributeValueEditorFactory<ZoneId> {
             controls.getChildren().addAll(timeZoneComboBox);
             return controls;
         }
-
     }
 }

--- a/CoreAttributeEditor/src/au/gov/asd/tac/constellation/views/attributeeditor/editors/TransactionAttributeNameEditorFactory.java
+++ b/CoreAttributeEditor/src/au/gov/asd/tac/constellation/views/attributeeditor/editors/TransactionAttributeNameEditorFactory.java
@@ -72,8 +72,14 @@ public class TransactionAttributeNameEditorFactory extends AttributeValueEditorF
         }
 
         @Override
-        protected String getValueFromControls() {
-            return attributeList.getSelectionModel().getSelectedItem() != null ? attributeList.getSelectionModel().getSelectedItem() : nameText.getText();
+        protected String getValueFromControls() throws ControlsInvalidException {
+            if (attributeList.getSelectionModel().getSelectedItem() != null) {
+                return attributeList.getSelectionModel().getSelectedItem();
+            } else if (attributeList.getItems().contains(nameText.getText())) {
+                return nameText.getText();
+            } else {
+                throw new ControlsInvalidException("Entered value is not an attribute which exists on this graph.");
+            }
         }
 
         @Override
@@ -125,6 +131,5 @@ public class TransactionAttributeNameEditorFactory extends AttributeValueEditorF
             controls.addRow(2, attributeList);
             return controls;
         }
-
     }
 }

--- a/CoreAttributeEditor/src/au/gov/asd/tac/constellation/views/attributeeditor/editors/TransactionGraphLabelsEditorFactory.java
+++ b/CoreAttributeEditor/src/au/gov/asd/tac/constellation/views/attributeeditor/editors/TransactionGraphLabelsEditorFactory.java
@@ -79,6 +79,30 @@ public class TransactionGraphLabelsEditorFactory extends AttributeValueEditorFac
         }
 
         @Override
+        public void updateControlsWithValue(final GraphLabels value) {
+            labels.clear();
+            labelEntries.getChildren().clear();
+            if (value != null) {
+                value.getLabels().forEach(label -> {
+                    new LabelEntry(labels, labelEntries, label.getAttributeName(), label.getColor(), label.getSize());
+                });
+            }
+        }
+
+        @Override
+        protected GraphLabels getValueFromControls() throws ControlsInvalidException {
+            List<GraphLabel> data = new ArrayList<>();
+            try {
+                labels.forEach(label -> {
+                    data.add(new GraphLabel(label.attrCombo.getSelectionModel().getSelectedItem(), ConstellationColor.fromFXColor(label.color), Float.parseFloat(label.sizeText.getText())));
+                });
+            } catch (final NumberFormatException ex) {
+                throw new ControlsInvalidException("Non numeric value entered for label size");
+            }
+            return new GraphLabels(data);
+        }
+
+        @Override
         protected Node createEditorControls() {
             // get all transaction attributes currently in the graph
             ReadableGraph rg = GraphManager.getDefault().getActiveGraph().getReadableGraph();
@@ -242,31 +266,6 @@ public class TransactionGraphLabelsEditorFactory extends AttributeValueEditorFac
                     dialog.showDialog();
                 };
             }
-
-        }
-
-        @Override
-        public void updateControlsWithValue(final GraphLabels value) {
-            labels.clear();
-            labelEntries.getChildren().clear();
-            if (value != null) {
-                value.getLabels().forEach(label -> {
-                    new LabelEntry(labels, labelEntries, label.getAttributeName(), label.getColor(), label.getSize());
-                });
-            }
-        }
-
-        @Override
-        protected GraphLabels getValueFromControls() throws ControlsInvalidException {
-            List<GraphLabel> data = new ArrayList<>();
-            try {
-                labels.forEach(label -> {
-                    data.add(new GraphLabel(label.attrCombo.getSelectionModel().getSelectedItem(), ConstellationColor.fromFXColor(label.color), Float.parseFloat(label.sizeText.getText())));
-                });
-            } catch (NumberFormatException ex) {
-                throw new ControlsInvalidException("Non numeric value entered for label size");
-            }
-            return new GraphLabels(data);
         }
     }
 }

--- a/CoreAttributeEditor/src/au/gov/asd/tac/constellation/views/attributeeditor/editors/TransactionTypeEditorFactory.java
+++ b/CoreAttributeEditor/src/au/gov/asd/tac/constellation/views/attributeeditor/editors/TransactionTypeEditorFactory.java
@@ -149,6 +149,5 @@ public class TransactionTypeEditorFactory extends AttributeValueEditorFactory<Sc
             controls.addRow(2, typeList);
             return controls;
         }
-
     }
 }

--- a/CoreAttributeEditor/src/au/gov/asd/tac/constellation/views/attributeeditor/editors/VertexAttributeNameEditorFactory.java
+++ b/CoreAttributeEditor/src/au/gov/asd/tac/constellation/views/attributeeditor/editors/VertexAttributeNameEditorFactory.java
@@ -72,8 +72,14 @@ public class VertexAttributeNameEditorFactory extends AttributeValueEditorFactor
         }
 
         @Override
-        protected String getValueFromControls() {
-            return attributeList.getSelectionModel().getSelectedItem() != null ? attributeList.getSelectionModel().getSelectedItem() : nameText.getText();
+        protected String getValueFromControls() throws ControlsInvalidException {
+            if (attributeList.getSelectionModel().getSelectedItem() != null) {
+                return attributeList.getSelectionModel().getSelectedItem();
+            } else if (attributeList.getItems().contains(nameText.getText())) {
+                return nameText.getText();
+            } else {
+                throw new ControlsInvalidException("Entered value is not an attribute which exists on this graph.");
+            }
         }
 
         @Override
@@ -125,6 +131,5 @@ public class VertexAttributeNameEditorFactory extends AttributeValueEditorFactor
             controls.addRow(2, attributeList);
             return controls;
         }
-
     }
 }

--- a/CoreAttributeEditor/src/au/gov/asd/tac/constellation/views/attributeeditor/editors/VertexGraphLabelsEditorFactory.java
+++ b/CoreAttributeEditor/src/au/gov/asd/tac/constellation/views/attributeeditor/editors/VertexGraphLabelsEditorFactory.java
@@ -54,7 +54,7 @@ import org.openide.util.lookup.ServiceProvider;
  * @author twilight_sparkle
  */
 @ServiceProvider(service = AttributeValueEditorFactory.class)
-public class NodeGraphLabelsEditorFactory extends AttributeValueEditorFactory<GraphLabels> {
+public class VertexGraphLabelsEditorFactory extends AttributeValueEditorFactory<GraphLabels> {
 
     @Override
     public AbstractEditor<GraphLabels> createEditor(final EditOperation editOperation, final DefaultGetter<GraphLabels> defaultGetter, final ValueValidator<GraphLabels> validator, final String editedItemName, final GraphLabels initialValue) {
@@ -76,6 +76,30 @@ public class NodeGraphLabelsEditorFactory extends AttributeValueEditorFactory<Gr
 
         protected GraphLabelsEditor(final EditOperation editOperation, final DefaultGetter<GraphLabels> defaultGetter, final ValueValidator<GraphLabels> validator, final String editedItemName, final GraphLabels initialValue) {
             super(editOperation, defaultGetter, validator, editedItemName, initialValue);
+        }
+
+        @Override
+        public void updateControlsWithValue(final GraphLabels value) {
+            labels.clear();
+            labelEntries.getChildren().clear();
+            if (value != null) {
+                value.getLabels().forEach(label -> {
+                    new LabelEntry(labels, labelEntries, label.getAttributeName(), label.getColor(), label.getSize());
+                });
+            }
+        }
+
+        @Override
+        protected GraphLabels getValueFromControls() throws ControlsInvalidException {
+            List<GraphLabel> data = new ArrayList<>();
+            try {
+                labels.forEach(label -> {
+                    data.add(new GraphLabel(label.attrCombo.getSelectionModel().getSelectedItem(), ConstellationColor.fromFXColor(label.color), Float.parseFloat(label.sizeText.getText())));
+                });
+            } catch (final NumberFormatException ex) {
+                throw new ControlsInvalidException("Non numeric value entered for label size");
+            }
+            return new GraphLabels(data);
         }
 
         @Override
@@ -242,31 +266,6 @@ public class NodeGraphLabelsEditorFactory extends AttributeValueEditorFactory<Gr
                     dialog.showDialog();
                 };
             }
-
-        }
-
-        @Override
-        public void updateControlsWithValue(final GraphLabels value) {
-            labels.clear();
-            labelEntries.getChildren().clear();
-            if (value != null) {
-                value.getLabels().forEach(label -> {
-                    new LabelEntry(labels, labelEntries, label.getAttributeName(), label.getColor(), label.getSize());
-                });
-            }
-        }
-
-        @Override
-        protected GraphLabels getValueFromControls() throws ControlsInvalidException {
-            List<GraphLabel> data = new ArrayList<>();
-            try {
-                labels.forEach(label -> {
-                    data.add(new GraphLabel(label.attrCombo.getSelectionModel().getSelectedItem(), ConstellationColor.fromFXColor(label.color), Float.parseFloat(label.sizeText.getText())));
-                });
-            } catch (NumberFormatException ex) {
-                throw new ControlsInvalidException("Non numeric value entered for label size");
-            }
-            return new GraphLabels(data);
         }
     }
 }

--- a/CoreAttributeEditor/src/au/gov/asd/tac/constellation/views/attributeeditor/editors/VertexTypeEditorFactory.java
+++ b/CoreAttributeEditor/src/au/gov/asd/tac/constellation/views/attributeeditor/editors/VertexTypeEditorFactory.java
@@ -149,6 +149,5 @@ public class VertexTypeEditorFactory extends AttributeValueEditorFactory<SchemaV
             controls.addRow(2, typeList);
             return controls;
         }
-
     }
 }

--- a/CoreGraph/src/au/gov/asd/tac/constellation/graph/schema/SchemaTransactionTypeUtilities.java
+++ b/CoreGraph/src/au/gov/asd/tac/constellation/graph/schema/SchemaTransactionTypeUtilities.java
@@ -181,6 +181,7 @@ public class SchemaTransactionTypeUtilities {
             type = new SchemaTransactionType.Builder(SchemaTransactionTypeUtilities.getDefaultType(), name)
                     .setIncomplete(true)
                     .build();
+            SchemaTransactionTypeUtilities.addCustomType(type, false);
         }
         return type;
     }

--- a/CoreGraph/src/au/gov/asd/tac/constellation/graph/schema/SchemaVertexTypeUtilities.java
+++ b/CoreGraph/src/au/gov/asd/tac/constellation/graph/schema/SchemaVertexTypeUtilities.java
@@ -187,6 +187,7 @@ public class SchemaVertexTypeUtilities {
             type = new SchemaVertexType.Builder(SchemaVertexTypeUtilities.getDefaultType(), name)
                     .setIncomplete(true)
                     .build();
+            SchemaVertexTypeUtilities.addCustomType(type, false);
         }
         return type;
     }


### PR DESCRIPTION
🎨 Updated editor date pickers to listen to their text property in order to provide instant feedback (where the value property fails)
🎨 Updated the converters used by editor date pickers to use the TemporalFormatting.DATE_FORMATTER datetime formatter
🎨 SchemaVertexTypeUtilities.getTypeOrBuildNew and SchemaTransactionTypeUtilities.getTypeOrBuildNew now adds new types to schema
🎨 Improved blaze validation by checking for valid angle
🎨 Imporved vertex_attribute_name and transaction_attribute_name validation by ensuring typed names exist on graph
🎨 Renamed NodeGraphLabelsEditorFactory to VertexGraphLabelsEditorFactory

### Description of the Change

Updated all editors using JavaFX Date Pickers to use Constellation's standard date format and to provide better feedback where there are errors

### Alternate Designs

N/A

### Why Should This Be In Core?

Better UX is always a good thing.

### Benefits

N/A

### Possible Drawbacks

N/A

### Verification Process

Tested all editors using manual testing of custom attributes.

### Applicable Issues

N/A
