### PR TITLE
Disable shallow clone for SonarCloud

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,10 @@ cache:
 env:
   - runner_image="constellationapplication/netbeans-runner:8.2"
 
+# Disable shallow clone for SCM SonarCloud analysis
+git:
+  depth: false
+
 jobs:
   include:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## 2020-02-01 Changes in February 2020
 * Fixed a bug which now ensures that overriding a transaction direction using `GraphRecordStoreUtilities.DIRECTED_KEY` persists with the Type.
-* Renamed SupporPackageAction to SupportPackageAction to fix a spelling typo.
+* Renamed `NodeGraphLabelsEditorFactory` to `VertexGraphLabelsEditorFactory`.
+* Renamed `SupporPackageAction` to `SupportPackageAction` to fix a spelling typo.
 
 ## 2020-01-01 Changes in January 2020
 * Added LabelFontsOptionsPanel to allow setting of fonts rendered on the graph through the UI.

--- a/CoreFunctionality/src/au/gov/asd/tac/constellation/functionality/whatsnew/whatsnew.txt
+++ b/CoreFunctionality/src/au/gov/asd/tac/constellation/functionality/whatsnew/whatsnew.txt
@@ -1,6 +1,9 @@
 == 3030-12-31 Getting Started
 <p>If you're new to CONSTELLATION, read the <a href="" helpId="au.gov.asd.tac.constellation.functionality.introduction">introduction</a>.</p>
 
+== 2020-02-23 Improved Validation
+<p>Validation of custom attributes using dates, blaze angles, node and transaction attribute labels have been improved to provide instant feedback when an invalid value is set.</p>
+
 == 2020-02-07 Font Improvements
 <p>Support for rendering fonts in a Constellation graph has been overhauled enabling support for multiple fonts.
 Font preferences for the graph can be made by going to Setup &gt; Options &gt; Constellation &gt; Label Fonts. 


### PR DESCRIPTION
Disables shallow clone for SonarCloud, as recommended by [the docs](https://docs.travis-ci.com/user/sonarcloud/#accessing-full-scm-history)
