### PR TITLE
Feature/issue#296

### DIFF
--- a/CoreAttributeEditorView/src/au/gov/asd/tac/constellation/views/attributeeditor/AttributeEditorTopComponent.java
+++ b/CoreAttributeEditorView/src/au/gov/asd/tac/constellation/views/attributeeditor/AttributeEditorTopComponent.java
@@ -225,12 +225,6 @@ public final class AttributeEditorTopComponent extends TopComponent implements G
     @Override
     public void graphChanged(GraphChangeEvent event) {
         event = event.getLatest();
-        /*event.getEditor() is null whenever this event is invoked due to an action 
-        which is not relevent to this class e.g. zoom in/out, therefore return 
-        from this method without any further execution */
-        if (event.getEditor() == null) {
-            return;
-        }
         if (event.getId() > latestGraphChangeID) {
             latestGraphChangeID = event.getId();
             if (activeGraph != null && reader != null) {


### PR DESCRIPTION
### Description of the Change

Modify check which is preventing some graph changes (ie pan, rotate, node move) from reflecting updates to associated attirbutes in attribute editor.

### Alternate Designs

nil

### Why Should This Be In Core?

bug fix, requested by advocates

### Benefits

Changes will immediately reflect in Attribute Editor

### Possible Drawbacks

None known

### Verification Process

1. Open a graph
2. Open the Attribute Editor an expand the Node block
3. Select a Node on the graph and note its X/Y position in the Attribute Editor
4. Move this node and confirm after moving it, that its position updates in the Attribute Editor
5. Rotate the graph and confirm the Graph cmarea attribute changes
6. Pan the graph and confirm the Graph cmarea attribute changes


### Applicable Issues

https://github.com/constellation-app/constellation/issues/296