### PR TITLE
Updating error messages with expected default formats

### DIFF
--- a/CoreGraphFramework/src/au/gov/asd/tac/constellation/graph/attribute/DateAttributeDescription.java
+++ b/CoreGraphFramework/src/au/gov/asd/tac/constellation/graph/attribute/DateAttributeDescription.java
@@ -259,7 +259,7 @@ public final class DateAttributeDescription extends AbstractAttributeDescription
 
     @Override
     public String acceptsString(String value) {
-        return parseString(value) == NULL_VALUE ? "Not a valid date" : null;
+        return parseString(value) == NULL_VALUE ? "Not a valid date (Expected yyyy-mm-dd)" : null;
     }
 
     @Override

--- a/CoreGraphFramework/src/au/gov/asd/tac/constellation/graph/attribute/LocalDateTimeAttributeDescription.java
+++ b/CoreGraphFramework/src/au/gov/asd/tac/constellation/graph/attribute/LocalDateTimeAttributeDescription.java
@@ -178,7 +178,7 @@ public final class LocalDateTimeAttributeDescription extends AbstractAttributeDe
 
     @Override
     public String acceptsString(String value) {
-        return parseString(value) == NULL_VALUE && value != null ? "Not a valid datetime" : null;
+        return parseString(value) == NULL_VALUE && value != null ? "Not a valid datetime (Expected yyyy-mm-dd hh:MM:ss)" : null;
     }
 
     /**

--- a/CoreGraphFramework/src/au/gov/asd/tac/constellation/graph/attribute/ZonedDateTimeAttributeDescription.java
+++ b/CoreGraphFramework/src/au/gov/asd/tac/constellation/graph/attribute/ZonedDateTimeAttributeDescription.java
@@ -191,7 +191,7 @@ public final class ZonedDateTimeAttributeDescription extends AbstractAttributeDe
 
     @Override
     public String acceptsString(String value) {
-        return value != null && parseString(value) == null ? "Not a valid datetime" : null;
+        return value != null && parseString(value) == null ? "Not a valid datetime (Expected yyyy-MM-ddTHH:mm:ss.SSS[zone])" : null;
     }
 
     /**

--- a/CoreGraphFramework/src/au/gov/asd/tac/constellation/graph/attribute/compatibility/DateAttributeDescriptionV0.java
+++ b/CoreGraphFramework/src/au/gov/asd/tac/constellation/graph/attribute/compatibility/DateAttributeDescriptionV0.java
@@ -338,7 +338,7 @@ public final class DateAttributeDescriptionV0 extends AbstractAttributeDescripti
 
     @Override
     public String acceptsString(String value) {
-        return parseDate(value) == NULL_VALUE ? "Not a valid date" : null;
+        return parseDate(value) == NULL_VALUE ? "Not a valid date (Expected yyyy-mm-dd)" : null;
     }
 
 }

--- a/CoreGraphFramework/src/au/gov/asd/tac/constellation/graph/attribute/compatibility/TimeAttributeDescriptionV0.java
+++ b/CoreGraphFramework/src/au/gov/asd/tac/constellation/graph/attribute/compatibility/TimeAttributeDescriptionV0.java
@@ -118,7 +118,7 @@ public final class TimeAttributeDescriptionV0 extends AbstractAttributeDescripti
 
     @Override
     public String acceptsString(String value) {
-        return setString(value) == NULL_VALUE ? "Not a valid time value" : null;
+        return setString(value) == NULL_VALUE ? "Not a valid time value (Expected HH:mm:ss.SSS)" : null;
     }
 
     private static int setString(final String value) {

--- a/CoreImportExportPlugins/src/au/gov/asd/tac/constellation/plugins/importexport/delimited/DelimitedFileImporterStage.java
+++ b/CoreImportExportPlugins/src/au/gov/asd/tac/constellation/plugins/importexport/delimited/DelimitedFileImporterStage.java
@@ -138,7 +138,6 @@ public class DelimitedFileImporterStage extends Stage {
             }
             userClickedTheCheckboxFirst[0] = false;
         });
-        optionsMenu.getItems().addAll(loadMenuItem, saveMenuItem, showSchemaAttributesItem);
 
         final AnchorPane menuToolbar = new AnchorPane();
         final MenuBar menuBar = new MenuBar();
@@ -189,6 +188,12 @@ public class DelimitedFileImporterStage extends Stage {
         setTitle("Import from Delimited File");
         getIcons().add(new Image(DELIMITED_IMPORTER_ICON_PATH));
         centerOnScreen();
+    }
+
+    public void updateAttributes(String filterAttributes) {
+        importController.setShowFilteredSchemaAttributes(filterAttributes);
+        importController.setClearManuallyAdded(false);
+        importController.setDestination(sourcePane.getDestination());
     }
 
     public void update(final ImportController importController, final List<ImportDefinition> definitions) {

--- a/CoreImportExportPlugins/src/au/gov/asd/tac/constellation/plugins/importexport/delimited/ImportController.java
+++ b/CoreImportExportPlugins/src/au/gov/asd/tac/constellation/plugins/importexport/delimited/ImportController.java
@@ -75,6 +75,7 @@ public class ImportController {
     private ImportFileParser importFileParser;
     private boolean schemaInitialised;
     private boolean showAllSchemaAttributes;
+    private String filterAttributes = "";
     private PluginParameters currentParameters = null;
 
     // Attributes that exist in the graph or schema.
@@ -170,7 +171,12 @@ public class ImportController {
     }
 
     public void setDestination(final ImportDestination<?> destination) {
-        this.currentDestination = destination;
+        if (destination != null) {
+            this.currentDestination = destination;
+        }
+        if (this.currentDestination == null) {
+            return;
+        }
 
         // Clearing the manually added attributes removes them when loading a template.
         // The destination is set with clearmanuallyAdded true before loading the
@@ -183,7 +189,7 @@ public class ImportController {
         keys.clear();
 
         final boolean showSchemaAttributes = importExportPrefs.getBoolean(ImportExportPreferenceKeys.SHOW_SCHEMA_ATTRIBUTES, ImportExportPreferenceKeys.DEFAULT_SHOW_SCHEMA_ATTRIBUTES);
-        loadAllSchemaAttributes(destination, showSchemaAttributes);
+        loadAllSchemaAttributes(this.currentDestination, showSchemaAttributes);
 
         updateDisplayedAttributes();
     }
@@ -328,8 +334,22 @@ public class ImportController {
 
     private Map<String, Attribute> createDisplayedAttributes(final Map<String, Attribute> autoAddedAttributes, final Map<String, Attribute> manuallyAddedAttributes) {
         Map<String, Attribute> displayedAttributes = new HashMap<>();
-        displayedAttributes.putAll(manuallyAddedAttributes);
-        displayedAttributes.putAll(autoAddedAttributes);
+
+        if (filterAttributes != null &&  filterAttributes.length() > 0) {
+            for (String name : autoAddedAttributes.keySet()) {
+                if (name.toUpperCase().matches(".*" + filterAttributes.toUpperCase() + ".*")) {
+                    displayedAttributes.put(name, autoAddedAttributes.get(name));
+                }
+            }
+            for (String name : manuallyAddedAttributes.keySet()) {
+                if (name.toUpperCase().matches(filterAttributes.toUpperCase())) {
+                    displayedAttributes.put(name, manuallyAddedAttributes.get(name));
+                }
+            }
+        } else {
+            displayedAttributes.putAll(manuallyAddedAttributes);
+            displayedAttributes.putAll(autoAddedAttributes);
+        }
         return displayedAttributes;
     }
 
@@ -486,6 +506,10 @@ public class ImportController {
         this.showAllSchemaAttributes = showAllSchemaAttributes;
         importExportPrefs.putBoolean(ImportExportPreferenceKeys.SHOW_SCHEMA_ATTRIBUTES, showAllSchemaAttributes);
         // TODO: the tick box could have changed but the menu item isn't updated, fix it
+    }
+
+    public void setShowFilteredSchemaAttributes(final String filterAttributes) {
+        this.filterAttributes = filterAttributes;
     }
 
     public String[] getCurrentColumns() {

--- a/CoreImportExportPlugins/src/au/gov/asd/tac/constellation/plugins/importexport/delimited/RunPane.java
+++ b/CoreImportExportPlugins/src/au/gov/asd/tac/constellation/plugins/importexport/delimited/RunPane.java
@@ -21,6 +21,8 @@ import au.gov.asd.tac.constellation.plugins.importexport.delimited.model.CellVal
 import au.gov.asd.tac.constellation.plugins.importexport.delimited.model.TableRow;
 import au.gov.asd.tac.constellation.utilities.icon.UserInterfaceIconProvider;
 import java.awt.Color;
+import java.awt.event.KeyEvent;
+import java.awt.event.KeyListener;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -51,6 +53,7 @@ import javafx.scene.control.TextField;
 import javafx.scene.control.Tooltip;
 import javafx.scene.image.Image;
 import javafx.scene.image.ImageView;
+import javafx.scene.input.KeyCode;
 import javafx.scene.input.MouseEvent;
 import javafx.scene.layout.BorderPane;
 import javafx.scene.layout.Priority;
@@ -66,7 +69,7 @@ import javafx.util.Callback;
  *
  * @author sirius
  */
-public class RunPane extends BorderPane {
+public class RunPane extends BorderPane implements KeyListener {
 
     private final ImportController importController;
     private final TableView<TableRow> sampleDataView = new TableView<>();
@@ -81,6 +84,7 @@ public class RunPane extends BorderPane {
     final TextField filterField;
     private final RowFilter rowFilter = new RowFilter();
     private String filter = "";
+    private String attributeFilter = "";
 
     private ObservableList<TableRow> currentRows = FXCollections.observableArrayList();
     private String[] currentColumnLabels = new String[0];
@@ -164,7 +168,8 @@ public class RunPane extends BorderPane {
                 + "5. Click on the Import button to import the data to your destination graph.\n"
                 + "6. Save your configuration using Options -> Save.\n\n"
                 + "HINT: See all supported attributes using Options -> Show all schema attributes\n"
-                + "HINT: Hover over the attribute name for a tooltip.");
+                + "HINT: Hover over the attribute name for a tooltip.\n"
+                + "HINT: Start typing to filter attributes (press delete to remove).");
         startupHelpText.setStyle("-fx-font-size: 14pt;-fx-fill: grey;");
         sampleDataView.setPlaceholder(startupHelpText);
 
@@ -186,6 +191,19 @@ public class RunPane extends BorderPane {
 
         attributePane.addRow(0, sourceVertexScrollPane, destinationVertexScrollPane, transactionScrollPane);
 
+        attributePane.setOnKeyPressed(event -> {
+            final KeyCode c = event.getCode();
+            if (c == KeyCode.DELETE) {
+                attributeFilter = "";
+            } else if (c == KeyCode.BACK_SPACE) {
+                attributeFilter = "";
+            } else if (c.isLetterKey()) {
+                attributeFilter += c.getChar();
+            }
+            importController.setShowFilteredSchemaAttributes(attributeFilter);
+            importController.setDestination(null);
+        });
+
         attributePane.setPadding(new Insets(5));
         attributePane.setVgap(5);
         attributePane.setHgap(5);
@@ -199,6 +217,7 @@ public class RunPane extends BorderPane {
         attributeScrollPane.setHbarPolicy(ScrollPane.ScrollBarPolicy.NEVER);
         attributeScrollPane.setVbarPolicy(ScrollPane.ScrollBarPolicy.AS_NEEDED);
         splitPane.getItems().add(attributeScrollPane);
+        splitPane.onKeyPressedProperty().bind(attributePane.onKeyPressedProperty());
 
         columnRectangle.setStyle("-fx-fill: rgba(200, 200, 200, 0.3);");
         columnRectangle.setVisible(false);
@@ -252,7 +271,7 @@ public class RunPane extends BorderPane {
     public void setDraggingAttributeNode(AttributeNode draggingAttributeNode) {
         this.draggingAttributeNode = draggingAttributeNode;
     }
-    
+
     public void handleAttributeMoved(double sceneX, double sceneY) {
         if (draggingAttributeNode != null) {
             Point2D location = sceneToLocal(sceneX, sceneY);
@@ -526,4 +545,23 @@ public class RunPane extends BorderPane {
             }
         });
     }
+
+    @Override
+    public void keyTyped(KeyEvent arg0) {
+        throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+    }
+
+    @Override
+    public void keyReleased(KeyEvent arg0) {
+        throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+    }
+
+    @Override
+    public void keyPressed(final KeyEvent event) {
+        final int keyCode = event.getKeyCode();
+        // Avoid the control key so we don't interfere with ^S for save, for example.
+        final boolean isCtrl = event.isControlDown();
+        final boolean isShift = event.isShiftDown();
+    }
+
 }

--- a/CoreImportExportPlugins/src/au/gov/asd/tac/constellation/plugins/importexport/geospatial/ExportToShapefilePlugin.java
+++ b/CoreImportExportPlugins/src/au/gov/asd/tac/constellation/plugins/importexport/geospatial/ExportToShapefilePlugin.java
@@ -99,7 +99,7 @@ public class ExportToShapefilePlugin extends AbstractGeoExportPlugin {
             try {
                 GeometryType.valueOf(s);
             } catch (IllegalArgumentException ex) {
-                return String.format("%s is not a valid shape type.", s);
+                return String.format("%s is not a valid shape type (Expected Box, Line, Multi_Polygon, Point, Polygon).", s);
             }
             return null;
         }

--- a/CoreMapView/src/au/gov/asd/tac/constellation/views/mapview/utilities/MarkerUtilities.java
+++ b/CoreMapView/src/au/gov/asd/tac/constellation/views/mapview/utilities/MarkerUtilities.java
@@ -96,7 +96,7 @@ public class MarkerUtilities {
             final int b = Integer.parseInt(rgbHtml.substring(4, 6), 16);
             return color(a, r, g, b);
         } else { 
-            throw new IllegalArgumentException("The string provided is not a valid HTML color");
+            throw new IllegalArgumentException("The string provided is not a valid HTML color (Expected #RRGGBB or #aaRRGGBB)");
         }
         
     }


### PR DESCRIPTION

# Description of the Change

Expand the error message to include the required data format for data input that don't match various elements in the code 

### Alternate Designs

Modifying for everything including floats/integers was considered but I think most people know this already?

### Why Should This Be In Core?

As a user, would be helpful to know what internal format will be used

### Benefits

As a user, would be helpful to know what internal format will be used

### Possible Drawbacks

Will need to be maintained if the internal format does end up changing

### Verification Process

- How did you verify that all new functionality works as expected?
Ran and tested this manually (for example, ingesting a new .csv with an incorrect datetime format)
- How did you verify that all changed functionality works as expected?
This is only modifying the existing error message
- How did you verify that the change has not introduced any regressions?
Ran existing tests
