### PR TITLE
Add feature to search / filter in Table View Column Selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Constellation Changes
 
+## 2020-04-03 Changes in April
+* Added search feature to Table View Column Selection 
+
 ## 2020-03-01 Changes in March 2020
 * Added new module Core View Framework containing `AbstractTopComponent` and other related classes.
 * Added new module Core Plugin Reporter to separate it from the plugin framework.

--- a/CoreTableView/src/au/gov/asd/tac/constellation/views/tableview2/TableViewPane.java
+++ b/CoreTableView/src/au/gov/asd/tac/constellation/views/tableview2/TableViewPane.java
@@ -66,13 +66,16 @@ import javafx.scene.control.Separator;
 import javafx.scene.control.SeparatorMenuItem;
 import javafx.scene.control.TableCell;
 import javafx.scene.control.TableColumn;
+import javafx.scene.control.TextField;
 import javafx.scene.control.TableView;
 import javafx.scene.control.ToggleButton;
 import javafx.scene.control.ToolBar;
 import javafx.scene.control.Tooltip;
 import javafx.scene.image.ImageView;
+import javafx.scene.input.KeyEvent;
 import javafx.scene.input.MouseButton;
 import javafx.scene.layout.BorderPane;
+import javafx.scene.layout.HBox;
 import javax.swing.SwingUtilities;
 import org.controlsfx.control.table.TableFilter;
 
@@ -284,7 +287,30 @@ public final class TableViewPane extends BorderPane {
 
     private ContextMenu initColumnVisibilityContextMenu() {
         final ContextMenu cm = new ContextMenu();
-
+        ArrayList<CustomMenuItem> colCheckboxes = new ArrayList<>();
+        
+        Label label1 = new Label("Filter:");
+        TextField searchField = new TextField ();
+        HBox hb = new HBox();
+        hb.getChildren().addAll(label1, searchField);
+        final CustomMenuItem search = new CustomMenuItem(hb);
+        
+        search.setHideOnClick(false);
+        searchField.setOnKeyReleased((KeyEvent e) -> {
+            String searchTerm = searchField.getText();
+            if (searchTerm.trim().equals("")) {
+                colCheckboxes.forEach((item) -> {
+                    item.setVisible(true);
+                });
+            } else {
+                colCheckboxes.forEach((CustomMenuItem item) -> {
+                    String name = item.getId();
+                    item.setVisible(name.contains(searchTerm));
+                });
+            }
+            
+        });
+        
         final CustomMenuItem allColumns = new CustomMenuItem(new Label(ALL_COLUMNS));
         allColumns.setHideOnClick(false);
         allColumns.setOnAction(e -> {
@@ -339,7 +365,7 @@ public final class TableViewPane extends BorderPane {
             e.consume();
         });
 
-        cm.getItems().addAll(allColumns, defaultColumns, keyColumns, noColumns, new SeparatorMenuItem());
+        cm.getItems().addAll(allColumns, defaultColumns, keyColumns, noColumns, new SeparatorMenuItem(), search);
 
         columnIndex.forEach(columnTuple -> {
             final CheckBox columnCheckbox = new CheckBox(columnTuple.getThird().getText());
@@ -352,7 +378,8 @@ public final class TableViewPane extends BorderPane {
 
             final CustomMenuItem columnVisibility = new CustomMenuItem(columnCheckbox);
             columnVisibility.setHideOnClick(false);
-
+            columnVisibility.setId(columnTuple.getThird().getText());
+            colCheckboxes.add(columnVisibility);
             cm.getItems().add(columnVisibility);
         });
 


### PR DESCRIPTION
This addresses issue 'Table View Column Selection - Search Columns #375'


### Description of the Change
As outlined in issue 375 the column selection can become unwieldy when many attributes are used.  A blank analytic graph has more then a page of attributes. 
![image](https://user-images.githubusercontent.com/4240272/78336641-6fab3400-75db-11ea-9bbd-22beae5ad467.png)
I've added in a simple search that allows the user to filter the attributes by name within the column selection allowing easier selection of attributes.


![image](https://user-images.githubusercontent.com/4240272/78336903-d92b4280-75db-11ea-833b-c37f00f0b4f5.png)
_Simple search form at the top of the attributes._

![image](https://user-images.githubusercontent.com/4240272/78336980-f829d480-75db-11ea-9218-096f8e5f6724.png)
_An example of the filtering of attributes._

### Alternate Designs

### Why Should This Be In Core?
 This feature makes the column selection easier for the user.

### Benefits

### Possible Drawbacks

### Verification Process

1. Open a graph
2. Open the Table View 
3. Click the column selection button
4. Enter search term in the search box
