### PR TITLE
javahelp-update

### DIFF
--- a/CoreInteractiveGraph/src/au/gov/asd/tac/constellation/graph/interaction/framework/VisualInteraction.java
+++ b/CoreInteractiveGraph/src/au/gov/asd/tac/constellation/graph/interaction/framework/VisualInteraction.java
@@ -52,11 +52,11 @@ public interface VisualInteraction {
      * Calculate the direction vector in which to zoom, in camera coordinates,
      * based on a point at which a zoom was requested, in window coordinates.
      *
-     * @param zoomPoint The point in window coordinates at which a zoom was
+     * @param point The point in window coordinates at which a zoom was
      * requested.
      * @return A Vector holding the direction to zoom in camera coordinates.
      */
-    public Vector3f convertZoomPointToDirection(final Point zoomPoint);
+    public Vector3f convertZoomPointToDirection(final Point point);
 
     /**
      * Calculates the camera coordinates of the node in the graph which is
@@ -68,11 +68,11 @@ public interface VisualInteraction {
      *
      * @param graph The graph to search
      * @param camera The current Camera
-     * @param p The point in window coordinates
+     * @param point The point in window coordinates
      * @return A vector giving the camera coordiantes of the 'closest' node, or
      * null if the graph is empty.
      */
-    public Vector3f closestNodeCameraCoordinates(final GraphReadMethods graph, final Camera camera, final Point p);
+    public Vector3f closestNodeCameraCoordinates(final GraphReadMethods graph, final Camera camera, final Point point);
 
     /**
      * Unprojects the supplied point from window coordinates to graph

--- a/CoreInteractiveGraph/src/au/gov/asd/tac/constellation/graph/interaction/visual/InteractiveGLVisualProcessor.java
+++ b/CoreInteractiveGraph/src/au/gov/asd/tac/constellation/graph/interaction/visual/InteractiveGLVisualProcessor.java
@@ -36,10 +36,12 @@ import au.gov.asd.tac.constellation.utilities.visual.VisualChangeBuilder;
 import au.gov.asd.tac.constellation.utilities.visual.VisualOperation;
 import au.gov.asd.tac.constellation.utilities.visual.VisualProperty;
 import au.gov.asd.tac.constellation.utilities.camera.Graphics3DUtilities;
+import au.gov.asd.tac.constellation.utilities.datastructure.Tuple;
 import au.gov.asd.tac.constellation.utilities.graphics.Matrix44f;
 import au.gov.asd.tac.constellation.utilities.graphics.Vector3f;
 import au.gov.asd.tac.constellation.visual.opengl.renderer.GLVisualProcessor;
 import java.awt.Component;
+import java.awt.Graphics2D;
 import java.awt.Point;
 import java.awt.dnd.DropTarget;
 import java.awt.dnd.DropTargetListener;
@@ -206,11 +208,10 @@ public class InteractiveGLVisualProcessor extends GLVisualProcessor implements V
 
     @Override
     public Vector3f convertZoomPointToDirection(final Point zoomPoint) {
-        final Component canvas = getCanvas();
         return new Vector3f(
-                (float) (canvas.getWidth() / 2.0 - zoomPoint.x),
-                (float) (zoomPoint.y - canvas.getHeight() / 2.0),
-                (float) (canvas.getHeight() / (2 * Math.tan(Camera.FIELD_OF_VIEW * Math.PI / 180 / 2))));
+                (float) (getCanvas().getWidth() / 2.0 - zoomPoint.x),
+                (float) (zoomPoint.y - getCanvas().getHeight() / 2.0),
+                (float) (getCanvas().getHeight() / (2 * Math.tan(Camera.FIELD_OF_VIEW * Math.PI / 180 / 2))));
     }
 
     @Override
@@ -229,10 +230,8 @@ public class InteractiveGLVisualProcessor extends GLVisualProcessor implements V
 
     @Override
     public float convertTranslationToSpin(final Point from, final Point to) {
-        final int canvasWidth = getCanvas().getWidth();
-        final int canvasHeight = getCanvas().getHeight();
-        final float xDist = (canvasWidth / 2.0f - to.x) / (canvasWidth / 2.0f);
-        final float yDist = (canvasHeight / 2.0f - to.y) / (canvasHeight / 2.0f);
+        final float xDist = (getCanvas().getWidth() / 2.0f - to.x) / (getCanvas().getWidth() / 2.0f);
+        final float yDist = (getCanvas().getHeight() / 2.0f - to.y) / (getCanvas().getHeight() / 2.0f);
         final float xDelta = (from.x - to.x) / 2.0f;
         final float yDelta = (from.y - to.y) / 2.0f;
         return yDist * xDelta - xDist * yDelta;
@@ -315,7 +314,6 @@ public class InteractiveGLVisualProcessor extends GLVisualProcessor implements V
         final float verticalScale = (float) (Math.tan(Math.toRadians(Camera.FIELD_OF_VIEW / 2.0)));
         final float horizontalScale = verticalScale * getCanvas().getWidth() / getCanvas().getHeight();
         final int[] viewport = getViewport();
-
         final float leftScale = (((float) left / (float) viewport[2]) - 0.5f) * horizontalScale * 2;
         final float rightScale = (((float) right / (float) viewport[2]) - 0.5f) * horizontalScale * 2;
         final float topScale = (((float) (viewport[3] - top) / (float) viewport[3]) - 0.5f) * verticalScale * 2;

--- a/CoreOpenGLDisplay/src/au/gov/asd/tac/constellation/visual/opengl/renderer/GLRenderer.java
+++ b/CoreOpenGLDisplay/src/au/gov/asd/tac/constellation/visual/opengl/renderer/GLRenderer.java
@@ -174,19 +174,11 @@ public final class GLRenderer implements GLEventListener {
     @Override
     public void reshape(final GLAutoDrawable drawable, final int x, final int y, final int width, final int height) {
         final GL3 gl = drawable.getGL().getGL3();
-        
-        // --- START TEMPORARY FIX ---
-        // JOGL 2.3.2 does not scale with os display scaling on Windows and Linux.
-        // This will be fixed in JOGL 2.4.0, but until then we can use this temporary hack.
-        final double dpiScalingFactor = ((Graphics2D) ((Component) drawable).getGraphics()).getTransform().getScaleX();
-        final int scaledWidth = (int) (width * dpiScalingFactor);
-        final int scaledHeight = (int) (height * dpiScalingFactor);
-        // --- END TEMPORARY FIX ---
-        
-        gl.glViewport(0, 0, scaledWidth, scaledHeight);
+
+        gl.glViewport(0, 0, width, height);
 
         // Create the projection matrix, and load it on the projection matrix stack.
-        viewFrustum.setPerspective(FIELD_OF_VIEW, (float) scaledWidth / (float) scaledHeight, PERSPECTIVE_NEAR, PERSPECTIVE_FAR);
+        viewFrustum.setPerspective(FIELD_OF_VIEW, (float) width / (float) height, PERSPECTIVE_NEAR, PERSPECTIVE_FAR);
 
         projectionMatrix.set(viewFrustum.getProjectionMatrix());
 
@@ -195,13 +187,13 @@ public final class GLRenderer implements GLEventListener {
         ((Component) drawable).setMinimumSize(new Dimension(0, 0));
 
         renderables.forEach(renderable -> {
-            renderable.reshape(x, y, scaledWidth, scaledHeight);
+            renderable.reshape(x, y, width, height);
         });
 
         viewport[0] = x;
         viewport[1] = y;
-        viewport[2] = scaledWidth;
-        viewport[3] = scaledHeight;
+        viewport[2] = width;
+        viewport[3] = height;
     }
 
     /**


### PR DESCRIPTION
:bug: reverting canvas scaling - unfortunately, while we can scale the canvas during a reshape in `GLRenderer`, and we can scale the canvas for interactions in `InteractiveGLVisualProcessor`, we cannot scale the canvas for event listeners as that would only be possible by changing private methods within `GLCanvas` itself.
