### PR TITLE
Update SimpleQueryPlugin.java

### DIFF
--- a/CorePluginFramework/src/au/gov/asd/tac/constellation/plugins/templates/SimpleQueryPlugin.java
+++ b/CorePluginFramework/src/au/gov/asd/tac/constellation/plugins/templates/SimpleQueryPlugin.java
@@ -171,10 +171,10 @@ public abstract class SimpleQueryPlugin extends AbstractPlugin {
                         interaction.notify(PluginNotificationLevel.INFO, "Action cancelled: " + graphs.getGraph() + ": " + getName());
                         throw e;
                     } catch (Exception e) {
-                        final String msg = Bundle.MSG_Query_Failed(graph, getName());
-                        interaction.notify(PluginNotificationLevel.ERROR, msg + "\n" + e.getMessage());
                         cancelled = true;
-                        LOGGER.log(Level.WARNING, msg, e);
+                        final String msg = Bundle.MSG_Query_Failed(graph, getName());
+                        interaction.notify(PluginNotificationLevel.INFO, msg + "\n" + e.getMessage());
+                        LOGGER.log(Level.WARNING, msg);
                         throw e;
                     }
 

--- a/CorePluginFramework/src/au/gov/asd/tac/constellation/plugins/templates/SimpleQueryPlugin.java
+++ b/CorePluginFramework/src/au/gov/asd/tac/constellation/plugins/templates/SimpleQueryPlugin.java
@@ -173,7 +173,6 @@ public abstract class SimpleQueryPlugin extends AbstractPlugin {
                     } catch (Exception e) {
                         cancelled = true;
                         final String msg = Bundle.MSG_Query_Failed(graph, getName());
-                        interaction.notify(PluginNotificationLevel.INFO, msg + "\n" + e.getMessage());
                         LOGGER.log(Level.WARNING, msg);
                         throw e;
                     }


### PR DESCRIPTION
### Description of the Change

Reworked error dialogs to ensure only single dialog.

### Alternate Designs

N/A

### Why Should This Be In Core?

Bug fix of xore code.

### Benefits

Avoid duplicate error dialogs for same issue.

### Possible Drawbacks

None known.

### Verification Process

1. Start Constellation
2. Select 'Help'->'Show Logs'
3. Open the 'Data Access View'
4. In the 'Data Access View', expand 'Utility' and 'Select Top N'
5. Select 'Node' from the 'Mode' dropdown and press the 'Go' button.

Confirm only a single error dialog is shown, but that 2 logs are sent to the 'Output - Logs' panel, showing text similar to:
```
WARNING [au.gov.asd.tac.constellation.plugins.templates.SimpleQueryPlugin]: Action failed: au.gov.asd.tac.constellation.graph.locking.DualGraph@53c56c97; Select Top N
SEVERE [au.gov.asd.tac.constellation.graph.node.plugins.DefaultPluginInteraction]: Select Top N: Select a type category
au.gov.asd.tac.constellation.plugins.PluginException: Select a type category
	at au.gov.asd.tac.constellation.views.dataaccess.plugins.utility.SelectTopNPlugin.edit(SelectTopNPlugin.java:206)
	at au.gov.asd.tac.constellation.plugins.templates.SimpleQueryPlugin.describedEdit(SimpleQueryPlugin.java:265)
	at au.gov.asd.tac.constellation.plugins.templates.SimpleQueryPlugin.run(SimpleQueryPlugin.java:165)
	at au.gov.asd.tac.constellation.graph.node.plugins.DefaultPluginEnvironment.lambda$executePluginLater$0(DefaultPluginEnvironment.java:123)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:834)
```

### Applicable Issues

N/A
