### PR TITLE
Convert into a SelectedInclusionGraph.  Add in a 'do not scale' param…

### DIFF
--- a/CoreArrangementPlugins/src/au/gov/asd/tac/constellation/plugins/arrangements/scatter/Scatter3dArranger.java
+++ b/CoreArrangementPlugins/src/au/gov/asd/tac/constellation/plugins/arrangements/scatter/Scatter3dArranger.java
@@ -69,6 +69,7 @@ public class Scatter3dArranger implements Arranger {
         final boolean xLogarithmic;
         final boolean yLogarithmic;
         final boolean zLogarithmic;
+        final boolean doNotScale;
         if (params != null) {
             xDimension = params.getXDimension();
             yDimension = params.getYDimension();
@@ -76,6 +77,7 @@ public class Scatter3dArranger implements Arranger {
             xLogarithmic = params.getLogarithmicX();
             yLogarithmic = params.getLogarithmicY();
             zLogarithmic = params.getLogarithmicZ();
+            doNotScale = params.getDoNotScale();
         } else {
             return;
         }
@@ -153,7 +155,7 @@ public class Scatter3dArranger implements Arranger {
                 maxZ += 1;
             }
 
-            for (int i = 0; i < vxPos; i++) {
+            for (int i = 0; i < vxPos && !doNotScale; i++) {
                 if (Thread.interrupted()) {
                     throw new InterruptedException();
                 }

--- a/CoreArrangementPlugins/src/au/gov/asd/tac/constellation/plugins/arrangements/scatter/Scatter3dChoiceParameters.java
+++ b/CoreArrangementPlugins/src/au/gov/asd/tac/constellation/plugins/arrangements/scatter/Scatter3dChoiceParameters.java
@@ -28,6 +28,7 @@ public class Scatter3dChoiceParameters {
     private boolean xLogarithmic = false;
     private boolean yLogarithmic = false;
     private boolean zLogarithmic = false;
+    private Boolean doNotScale = false;
 
     public Scatter3dChoiceParameters() {
     }
@@ -65,6 +66,10 @@ public class Scatter3dChoiceParameters {
         this.zLogarithmic = zLogarithmic;
     }
 
+    public void setDoNotScale(final Boolean doNotScale) {
+        this.doNotScale = doNotScale;
+    }
+
     public String getXDimension() {
         return this.xDimension;
     }
@@ -80,10 +85,16 @@ public class Scatter3dChoiceParameters {
     public boolean getLogarithmicX() {
         return xLogarithmic;
     }
+
     public boolean getLogarithmicY() {
         return yLogarithmic;
     }
+
     public boolean getLogarithmicZ() {
         return zLogarithmic;
+    }
+
+    public boolean getDoNotScale() {
+        return doNotScale;
     }
 }


### PR DESCRIPTION
Description of the Change
Modify the scatter3d algorithm to work only on selectInclusionGraphs (it was doing the full graph always previously)

Alternate Designs
Nil.

Why Should This Be In Core?
It's already there.  This allows more flexibility for the end user (in terms of scaling or not scaling the final result)

Benefits
A new way of seeing and looking at the data is able to be viewed.

Possible Drawbacks
Nil that I can seee 

Verification Process
I've tested it further and been unable to break it after the last time it broke...

Applicable Issues
Nil.