### PR TITLE
Bug #387 Fix graph/mouse offset issue on MacOS

### DIFF
--- a/CoreInteractiveGraph/src/au/gov/asd/tac/constellation/graph/interaction/framework/VisualInteraction.java
+++ b/CoreInteractiveGraph/src/au/gov/asd/tac/constellation/graph/interaction/framework/VisualInteraction.java
@@ -140,4 +140,12 @@ public interface VisualInteraction {
      * bottom edges of the rectangle in camera coordinates.
      */
     public float[] windowBoxToCameraBox(final int left, final int right, final int top, final int bottom);
+    
+    /**
+     * Returns the global DPI Scale factor used to convert mouse coordinates to 
+     * the correct values.
+     * 
+     * @return A float value describing the scale factor
+     */
+    public float getDPIScalingFactor();
 }

--- a/CoreInteractiveGraph/src/au/gov/asd/tac/constellation/graph/interaction/visual/DefaultInteractionEventHandler.java
+++ b/CoreInteractiveGraph/src/au/gov/asd/tac/constellation/graph/interaction/visual/DefaultInteractionEventHandler.java
@@ -70,6 +70,8 @@ import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import javax.swing.AbstractAction;
 import javax.swing.JComponent;
 import javax.swing.JMenu;
@@ -142,6 +144,8 @@ public class DefaultInteractionEventHandler implements InteractionEventHandler {
 
     private boolean announceNextFlush = false;
     private boolean handleEvents;
+    
+    private static final Logger LOGGER = Logger.getLogger(DefaultInteractionEventHandler.class.getName());
 
     /**
      * A Functional interface that describes how a single mouse or keyboard
@@ -217,7 +221,21 @@ public class DefaultInteractionEventHandler implements InteractionEventHandler {
                     // Continue to loop whilst we see events before the alloted time is up
                     while (handler != null) {
                         long beforeProcessing = System.currentTimeMillis();
-                        final long nextWaitTime = Math.max(0, beforeProcessing + handler.processEvent(interactionGraph) - System.currentTimeMillis());
+                        //HACK_DPI
+                        // TODO: there's a race condition here which is causing access to interactionGraph to raise
+                        // a NullPointerException on the handling of some events.  It appears to happen far more often
+                        // on an old MacBook than in Windows on a moderately powerful PC.  There is no attempt at a fix
+                        // here and this issue needs to be resolved in a future change.
+                        //final long nextWaitTime = Math.max(0, beforeProcessing + handler.processEvent(interactionGraph) - System.currentTimeMillis());
+                        long nextWaitTime = 0;
+                        try
+                        {
+                            nextWaitTime = Math.max(0, beforeProcessing + handler.processEvent(interactionGraph) - System.currentTimeMillis());
+                        }
+                        catch(Exception ex)
+                        {
+                            LOGGER.log(Level.WARNING, "Null exception accessing interactionGraph", ex);
+                        }
                         // Add any visual operations that need to occur after a graph flush.
                         final List<VisualOperation> operations = new LinkedList<>();
                         operationQueue.drainTo(operations);
@@ -382,6 +400,10 @@ public class DefaultInteractionEventHandler implements InteractionEventHandler {
     public void mouseDragged(final MouseEvent event) {
         queue.add(wg -> {
             // If a mouse pressed event was never registered (can happen when left clicking off a context menu) we ignore this event.
+            // HACK_DPI - Multiply point by DPI scale factor
+            Point point = event.getPoint();
+            scaleMousePointByDPIFactor(point);
+            
             if (eventState.isMousePressed()) {
                 if (wg != null) {
                     final Camera camera = new Camera(VisualGraphUtilities.getCamera(wg));
@@ -391,7 +413,7 @@ public class DefaultInteractionEventHandler implements InteractionEventHandler {
                     switch (eventState.getCurrentAction()) {
                         case ROTATING:
                             from = eventState.getFirstValidPoint(EventState.DRAG_POINT, EventState.REFERENCE_POINT);
-                            to = event.getPoint();
+                            to = point;
                             final boolean zAxisRotation = !VisualGraphUtilities.getDisplayModeIs3D(wg) || (event.isControlDown() && event.isShiftDown());
                             if (zAxisRotation) {
                                 CameraUtilities.spin(camera, visualInteraction.convertTranslationToSpin(from, to));
@@ -402,7 +424,7 @@ public class DefaultInteractionEventHandler implements InteractionEventHandler {
                             break;
                         case PANNING:
                             from = eventState.getFirstValidPoint(EventState.DRAG_POINT, EventState.REFERENCE_POINT);
-                            to = event.getPoint();
+                            to = point;
                             final Vector3f panReferencePoint = eventState.hasClosestNode() ? eventState.getClosestNode() : CameraUtilities.getFocusVector(camera);
                             final Vector3f translation = visualInteraction.convertTranslationToPan(from, to, panReferencePoint);
                             CameraUtilities.pan(camera, translation.getX(), translation.getY());
@@ -410,22 +432,23 @@ public class DefaultInteractionEventHandler implements InteractionEventHandler {
                             break;
                         case DRAG_NODES:
                             from = eventState.getFirstValidPoint(EventState.DRAG_POINT, EventState.REFERENCE_POINT);
-                            to = event.getPoint();
+                            to = point; 
                             performDrag(wg, camera, from, to);
                             break;
                         case SELECTING:
-                            updateSelectionBoxModel(new SelectionBoxModel(eventState.getPoint(EventState.PRESSED_POINT), event.getPoint()));
+                            updateSelectionBoxModel(new SelectionBoxModel(eventState.getPoint(EventState.PRESSED_POINT), point));
                             break;
                         default:
                             break;
                     }
-                    updateCameraAndNewLine(wg, event.getPoint(), cameraChange ? camera : VisualGraphUtilities.getCamera(wg), cameraChange);
+                    updateCameraAndNewLine(wg, point, cameraChange ? camera : VisualGraphUtilities.getCamera(wg), cameraChange);
+                        
                 }
-
-                eventState.storePoint(event.getPoint(), EventState.DRAG_POINT);
+                
+                eventState.storePoint(point, EventState.DRAG_POINT);
             } else if (wg != null) {
                 // In this case, a button is held down but its pressed event was not registered for whatever reason.
-                updateHitTestAndNewLine(wg, event.getPoint());
+                updateHitTestAndNewLine(wg, point);
             }
             return 0;
         });
@@ -436,9 +459,13 @@ public class DefaultInteractionEventHandler implements InteractionEventHandler {
         queue.add(wg -> {
             // If the mouse is currently pressed (meaning this event represents pressing multiple buttons) we ignore this event.
             if (!eventState.isMousePressed()) {
+                // HACK_DPI - Multiply point by DPI scale factor
+                Point point = event.getPoint();
+                scaleMousePointByDPIFactor(point);
+                
                 // In case we are panning, we must take the distance of the scene from the camera into account,
                 // otherwise scenes that are further away will appear to move very slowly.
-                eventState.storePoint(event.getPoint(), EventState.PRESSED_POINT, EventState.REFERENCE_POINT);
+                eventState.storePoint(point, EventState.PRESSED_POINT, EventState.REFERENCE_POINT);
                 eventState.setCurrentButton(event.getButton());
 
                 final Camera camera;
@@ -446,12 +473,12 @@ public class DefaultInteractionEventHandler implements InteractionEventHandler {
                     camera = VisualGraphUtilities.getCamera(wg);
 
                     // Order a hit test and wait for it to complete.
-                    orderHitTest(event.getPoint(), HitTestMode.HANDLE_SYNCHRONOUSLY);
+                    orderHitTest(point, HitTestMode.HANDLE_SYNCHRONOUSLY);
 
                     // Now that we have got the results of hit testing we can turn it off until the mouse is released.
                     setHitTestingEnabled(false);
 
-                    eventState.setClosestNode(visualInteraction.closestNodeCameraCoordinates(wg, camera, event.getPoint()));
+                    eventState.setClosestNode(visualInteraction.closestNodeCameraCoordinates(wg, camera, point));
                 } else {
                     camera = null;
                 }
@@ -494,12 +521,15 @@ public class DefaultInteractionEventHandler implements InteractionEventHandler {
                     setHitTestingEnabled(true);
 
                     final Camera camera = VisualGraphUtilities.getCamera(wg);
+                    // HACK_DPI - Multiply point by DPI scale factor
+                    Point point = event.getPoint();
+                    scaleMousePointByDPIFactor(point);
                     final Point from;
                     final Point to;
                     switch (eventState.getCurrentAction()) {
                         case SELECTING:
                             if (eventState.isMouseDragged()) {
-                                performBoxSelection(wg, event.getPoint(), eventState.getPoint(EventState.PRESSED_POINT), event.isShiftDown(), event.isControlDown());
+                                performBoxSelection(wg, point, eventState.getPoint(EventState.PRESSED_POINT), event.isShiftDown(), event.isControlDown());
                                 clearSelectionBoxModel();
                             } else {
                                 // If the mouse has clicked on an element (and neither pan nor control are pressed),
@@ -511,7 +541,7 @@ public class DefaultInteractionEventHandler implements InteractionEventHandler {
                         case CREATING:
                             switch (eventState.getCurrentCreationMode()) {
                                 case CREATING_VERTEX:
-                                    createVertex(camera, event.getPoint());
+                                    createVertex(camera, point);
                                     eventState.setCurrentCreationMode(CreationMode.NONE);
                                     break;
                                 case FINISHING_TRANSACTION:
@@ -546,7 +576,7 @@ public class DefaultInteractionEventHandler implements InteractionEventHandler {
                         case DRAG_NODES:
                             if (eventState.isMouseDragged()) {
                                 from = eventState.getPoint(EventState.DRAG_POINT);
-                                to = event.getPoint();
+                                to = point;
                                 performDrag(wg, camera, from, to);
                                 eventState.addEventName(DRAG_ACTION_NAME);
                             }
@@ -578,7 +608,10 @@ public class DefaultInteractionEventHandler implements InteractionEventHandler {
     public void mouseMoved(final MouseEvent event) {
         queue.add(wg -> {
             if (wg != null) {
-                updateHitTestAndNewLine(wg, event.getPoint());
+                // HACK_DPI - Multiply point by DPI scale factor
+                Point point = event.getPoint();
+                scaleMousePointByDPIFactor(point);
+                updateHitTestAndNewLine(wg, point);
             }
             return 0;
         });
@@ -590,6 +623,7 @@ public class DefaultInteractionEventHandler implements InteractionEventHandler {
             if (wg != null) {
                 final Camera camera = new Camera(VisualGraphUtilities.getCamera(wg));
                 final Point wheelPoint = event.getPoint();
+                // HACK_DPI: Don't need to scale the wheelPoint.
                 eventState.setClosestNode(visualInteraction.closestNodeCameraCoordinates(wg, camera, wheelPoint));
                 if (!eventState.isPoint(EventState.WHEEL_POINT) || !wheelPoint.equals(eventState.getPoint(EventState.WHEEL_POINT))) {
                     eventState.storePoint(wheelPoint, EventState.WHEEL_POINT);
@@ -1114,5 +1148,12 @@ public class DefaultInteractionEventHandler implements InteractionEventHandler {
         }
 
         popup.show(manager.getVisualComponent(), screenLocation.x, screenLocation.y);
+    }
+    
+    private void scaleMousePointByDPIFactor(Point pointToScale){
+        // HACK_DPI - Get the DPI scale factor and multiply the point by it
+        final float dpiScalingFactor = this.visualInteraction.getDPIScalingFactor();
+        pointToScale.x *= dpiScalingFactor;
+        pointToScale.y *= dpiScalingFactor;
     }
 }

--- a/CoreInteractiveGraph/src/au/gov/asd/tac/constellation/graph/interaction/visual/InteractiveGLVisualProcessor.java
+++ b/CoreInteractiveGraph/src/au/gov/asd/tac/constellation/graph/interaction/visual/InteractiveGLVisualProcessor.java
@@ -42,11 +42,14 @@ import au.gov.asd.tac.constellation.visual.opengl.renderer.GLVisualProcessor;
 import java.awt.Point;
 import java.awt.dnd.DropTarget;
 import java.awt.dnd.DropTargetListener;
+import java.awt.Graphics2D;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Queue;
+import java.util.logging.Logger;
+import java.util.logging.Level;
 
 /**
  * An extension of the {@link GLVisualProcessor} that adds support for user
@@ -75,6 +78,8 @@ public class InteractiveGLVisualProcessor extends GLVisualProcessor implements V
     private InteractionEventHandler handler;
     private DropTargetListener targetListener;
     private DropTarget target;
+    
+    private static final Logger LOGGER = Logger.getLogger(InteractiveGLVisualProcessor.class.getName());
 
     /**
      * Create a new InteractiveGLVisualProcessor.
@@ -316,5 +321,21 @@ public class InteractiveGLVisualProcessor extends GLVisualProcessor implements V
         final float topScale = (((float) (viewport[3] - top) / (float) viewport[3]) - 0.5f) * verticalScale * 2;
         final float bottomScale = (((float) (viewport[3] - bottom) / (float) viewport[3]) - 0.5f) * verticalScale * 2;
         return new float[]{leftScale, rightScale, topScale, bottomScale};
+    }
+    
+    @Override
+    public float getDPIScalingFactor(){
+        // HACK_DPI - Get the X Scale value from the GLCanva's transform matrix
+        // This method was derived from the JOGL post found here:
+        // http://forum.jogamp.org/canvas-not-filling-frame-td4040092.html#a4040210
+        try
+        {
+        	return (float)((Graphics2D)getCanvas().getGraphics()).getTransform().getScaleX();
+        }
+        catch (Exception ex)
+        {
+        	LOGGER.log(Level.WARNING, "Null exception accessing interactionGraph", ex);
+        	return 1.0f;	
+        }
     }
 }


### PR DESCRIPTION
On MacOS the render target for GLCanvas is being scaled correctly (possibly because of custom code in JOGL but I haven't confirmed this, however the mouse positions from Java AWT are coming through as not scaled (ie. MouseEvent.java ->event.getPosition()). This change adds code to get the correct scale from the GLCanvas' transform matrix and apply it to the mouse points.


