### PR TITLE
Scatter3d - allow negative numbers to have logarithmic expansion as well

### DIFF
--- a/CoreArrangementPlugins/src/au/gov/asd/tac/constellation/plugins/arrangements/scatter/Scatter3dArranger.java
+++ b/CoreArrangementPlugins/src/au/gov/asd/tac/constellation/plugins/arrangements/scatter/Scatter3dArranger.java
@@ -176,12 +176,12 @@ public class Scatter3dArranger implements Arranger {
         }
     }
 
-    private float scaleValue(float value, boolean logarithmic) {
+    private float scaleValue(final float value, final boolean logarithmic) {
         if (logarithmic) {
-            if (value <= 0.0) {
-                return (float) Math.log10(-value) * -1;
+            if (value != 0.0) {
+                return (float) Math.log10(Math.abs(value)) * Math.signum(value);
             }
-            return (float) Math.log10(value);
+            return 0.0f;
         }
         return value;
     }

--- a/CoreArrangementPlugins/src/au/gov/asd/tac/constellation/plugins/arrangements/scatter/Scatter3dArranger.java
+++ b/CoreArrangementPlugins/src/au/gov/asd/tac/constellation/plugins/arrangements/scatter/Scatter3dArranger.java
@@ -179,7 +179,7 @@ public class Scatter3dArranger implements Arranger {
     private float scaleValue(float value, boolean logarithmic) {
         if (logarithmic) {
             if (value <= 0.0) {
-                return 0.0f;
+                return (float) Math.log10(-value) * -1;
             }
             return (float) Math.log10(value);
         }


### PR DESCRIPTION
### Description of the Change

Allow logs for negative numbers.  Log(-veNumber) 
### Alternate Designs

As it was, I had set everything to be 0

### Why Should This Be In Core?

Already is.

### Benefits

Able to see more visual based information for negative numbers.

### Possible Drawbacks

Nil

### Verification Process

Was checked via different datasets being thrown at it.

### Applicable Issues

Nil.
