### PR TITLE
Drag from Attribute Editor the graph exception resolution

### DIFF
--- a/CoreAttributeEditorView/src/au/gov/asd/tac/constellation/views/attributeeditor/LabelDropper.java
+++ b/CoreAttributeEditorView/src/au/gov/asd/tac/constellation/views/attributeeditor/LabelDropper.java
@@ -18,9 +18,11 @@ package au.gov.asd.tac.constellation.views.attributeeditor;
 import au.gov.asd.tac.constellation.graph.Graph;
 import au.gov.asd.tac.constellation.graph.GraphElementType;
 import au.gov.asd.tac.constellation.graph.GraphWriteMethods;
+import au.gov.asd.tac.constellation.graph.schema.visual.GraphLabel;
+import au.gov.asd.tac.constellation.graph.schema.visual.GraphLabels;
+import au.gov.asd.tac.constellation.graph.schema.visual.concept.VisualConcept;
 import au.gov.asd.tac.constellation.graph.visual.dragdrop.GraphDropper;
 import au.gov.asd.tac.constellation.graph.visual.dragdrop.GraphDropper.DropInfo;
-import au.gov.asd.tac.constellation.graph.schema.visual.concept.VisualConcept;
 import au.gov.asd.tac.constellation.plugins.PluginException;
 import au.gov.asd.tac.constellation.plugins.PluginExecution;
 import au.gov.asd.tac.constellation.plugins.PluginInfo;
@@ -30,8 +32,6 @@ import au.gov.asd.tac.constellation.plugins.logging.ConstellationLoggerHelper;
 import au.gov.asd.tac.constellation.plugins.parameters.PluginParameters;
 import au.gov.asd.tac.constellation.plugins.templates.SimpleEditPlugin;
 import au.gov.asd.tac.constellation.utilities.color.ConstellationColor;
-import au.gov.asd.tac.constellation.graph.schema.visual.GraphLabel;
-import au.gov.asd.tac.constellation.graph.schema.visual.GraphLabels;
 import java.awt.datatransfer.DataFlavor;
 import java.awt.datatransfer.Transferable;
 import java.awt.datatransfer.UnsupportedFlavorException;
@@ -133,6 +133,8 @@ public class LabelDropper implements GraphDropper {
 
             } catch (final UnsupportedFlavorException | IOException | ClassNotFoundException ex) {
                 Exceptions.printStackTrace(ex);
+            } catch (final ClassCastException ex) {
+                //Do nothing
             }
         }
 

--- a/CoreAttributeEditorView/src/au/gov/asd/tac/constellation/views/attributeeditor/LabelDropper.java
+++ b/CoreAttributeEditorView/src/au/gov/asd/tac/constellation/views/attributeeditor/LabelDropper.java
@@ -135,6 +135,7 @@ public class LabelDropper implements GraphDropper {
                 Exceptions.printStackTrace(ex);
             } catch (final ClassCastException ex) {
                 //Do nothing
+                //This exception occurs when dragging a label from Attribute Editor to graph area
             }
         }
 


### PR DESCRIPTION
<!--

### Requirements

* Filling out the template is required. Any pull request that does not include
enough information to be reviewed in a timely manner may be closed at the
maintainers' discretion.
* Follow the check list items defined by https://github.com/constellation-app/constellation/blob/master/CONTRIBUTING.md#pull-requests
* All new code requires unit tests to ensure they work as expected and will
continue to work as new code is added in the future (regression testing).
* Have you read Constellation's Code of Conduct? By filing an issue, you are
expected to comply with it, including treating everyone with respect:
https://github.com/constellation-app/constellation/blob/master/CODE_OF_CONDUCT.md

-->

### Description of the Change
Added a catch for ClassCastException to account for the issue where you would get the exception when you drag a label into the graph.

### Alternate Designs

Looked at options around handling the case when casting ByteBufferInputStream to ByteBuffer (the case that was causing the exception) but ByteBufferInputStream is contained in a private which we can't edit.

Also looked at other options around what to do in the catch block for ClassCastException but ultimately doing nothing felt right.

### Why Should This Be In Core?

<!--

Explain why this functionality should be in Constellation Core as opposed to a
different module suite. Note that this question is more applicable when adding
new functionality. If this change is a minor update to an exising file then it
is understood that this change has to be to this module suite and a response
and therefore a response to this question is not required.

-->

### Benefits

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process

- opened a new graph and the attribute editor
- left-clicked and dragged an attribute label from the attribute editor to the graph space
- right-clicked and dragged an attribute label from the attribute editor to the graph space

### Applicable Issues
#448 
