### PR TITLE
Added code to ensure temp POI directory exists prior to excel export …

### DIFF
--- a/CoreTableView/src/au/gov/asd/tac/constellation/views/tableview2/TableViewUtilities.java
+++ b/CoreTableView/src/au/gov/asd/tac/constellation/views/tableview2/TableViewUtilities.java
@@ -228,9 +228,9 @@ public class TableViewUtilities {
         @Override
         public void execute(final PluginGraphs graphs, final PluginInteraction interaction, final PluginParameters parameters) throws InterruptedException, PluginException {
             try (final SXSSFWorkbook workbook = new SXSSFWorkbook(SXSSFWorkbook.DEFAULT_WINDOW_SIZE)) {
-                File poi_dir = new File(System.getProperty("java.io.tmpdir"), "poifiles");
-                if (!poi_dir.exists()) {
-                    poi_dir.mkdir();
+                File poiDir = new File(System.getProperty("java.io.tmpdir"), "poifiles");
+                if (!poiDir.exists()) {
+                    poiDir.mkdir();
                 }
                 final Sheet sheet = workbook.createSheet(sheetName);
 

--- a/CoreTableView/src/au/gov/asd/tac/constellation/views/tableview2/TableViewUtilities.java
+++ b/CoreTableView/src/au/gov/asd/tac/constellation/views/tableview2/TableViewUtilities.java
@@ -228,6 +228,10 @@ public class TableViewUtilities {
         @Override
         public void execute(final PluginGraphs graphs, final PluginInteraction interaction, final PluginParameters parameters) throws InterruptedException, PluginException {
             try (final SXSSFWorkbook workbook = new SXSSFWorkbook(SXSSFWorkbook.DEFAULT_WINDOW_SIZE)) {
+                File poi_dir = new File(System.getProperty("java.io.tmpdir"), "poifiles");
+                if (!poi_dir.exists()) {
+                    poi_dir.mkdir();
+                }
                 final Sheet sheet = workbook.createSheet(sheetName);
 
                 final List<Integer> visibleIndices = table.getColumns().stream()


### PR DESCRIPTION
…... this shouldn't be needed  (as POI code is meant to create the folder as needed), however I found cases where without it the export failed...


### Description of the Change

Added a couple lines of code to force temporary poifiles directory to be created prior to call to Excel export  (SXSSFWorkbook package) which seemed to have some occasional/rare uissues if poifiles directory didn't exist (even though this code does create the directory).

### Alternate Designs

Nil

### Why Should This Be In Core?

Address occasional issue exporting to Excel.

### Benefits

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks

None known.

### Verification Process

1. Open Constelattion
2. Create a graph
3. Open table view
4. Select Export to Excel and export the data - confirm file is created
5. using Windows Expolrer or alternate means, delete the directory %TEMP%/poifiles
6. Select Export to Excel and export the data - confirm file is created
7. Close constellation.

Repate the above steps multiuple times and confirm files are created in expected location.


### Applicable Issues

Nil
