### PR TITLE
Fixed a bug preventing v1 graphs from being open.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Constellation Changes
 
 ## 2020-05-01 Changes in May 2020
-* Fixed a bug effecting the histogram scrolling
+* Fixed a bug effecting the histogram scrolling.
+* Fixed a bug preventing v1 graphs from being open.
 
 ## 2020-04-01 Changes in April 2020
 * Added search feature to Table View Column Selection.

--- a/CoreVisualGraph/src/au/gov/asd/tac/constellation/graph/visual/framework/GraphVisualAccess.java
+++ b/CoreVisualGraph/src/au/gov/asd/tac/constellation/graph/visual/framework/GraphVisualAccess.java
@@ -1120,20 +1120,30 @@ public final class GraphVisualAccess implements VisualAccess {
             switch (connectionElementTypes[connection]) {
                 case LINK:
                     float linkVisibility = -1;
-                    final int linkId = connectionElementIds[connection];
-                    for (int i = 0; i < accessGraph.getLinkTransactionCount(linkId); i++) {
-                        final int transactionId = accessGraph.getLinkTransaction(linkId, i);
-                        linkVisibility = Math.max(linkVisibility, accessGraph.getFloatValue(transactionLayerVisibility, transactionId)); // handle case of no layer vis - ie no layer
+                    if (transactionLayerVisibility != Graph.NOT_FOUND) {
+                        final int linkId = connectionElementIds[connection];
+                        for (int i = 0; i < accessGraph.getLinkTransactionCount(linkId); i++) {
+                            final int transactionId = accessGraph.getLinkTransaction(linkId, i);
+                            linkVisibility = Math.max(linkVisibility, accessGraph.getFloatValue(transactionLayerVisibility, transactionId)); // handle case of no layer vis - ie no layer
+                        }
+                        return linkVisibility;
+                    } else {
+                        return VisualGraphDefaults.DEFAULT_TRANSACTION_VISIBILITY;
                     }
-                    return linkVisibility;
+                    
                 case EDGE:
                     float edgeVisibility = -1;
-                    final int edgeId = connectionElementIds[connection];
-                    for (int i = 0; i < accessGraph.getEdgeTransactionCount(edgeId); i++) {
-                        final int transactionId = accessGraph.getEdgeTransaction(edgeId, i);
-                        edgeVisibility = Math.max(edgeVisibility, accessGraph.getFloatValue(transactionLayerVisibility, transactionId));
+                    if (transactionLayerVisibility != Graph.NOT_FOUND) {
+                        final int edgeId = connectionElementIds[connection];
+                        for (int i = 0; i < accessGraph.getEdgeTransactionCount(edgeId); i++) {
+                            final int transactionId = accessGraph.getEdgeTransaction(edgeId, i);
+                            edgeVisibility = Math.max(edgeVisibility, accessGraph.getFloatValue(transactionLayerVisibility, transactionId));
+                        }
+                        return edgeVisibility;
+                    } else {
+                        return VisualGraphDefaults.DEFAULT_TRANSACTION_VISIBILITY;
                     }
-                    return edgeVisibility;
+                    
                 case TRANSACTION:
                 default:
                     float transLayerVisibility = transactionLayerVisibility != Graph.NOT_FOUND ? accessGraph.getFloatValue(transactionLayerVisibility, connectionElementIds[connection]) : VisualGraphDefaults.DEFAULT_TRANSACTION_FILTER_VISIBILITY;


### PR DESCRIPTION
<!--

### Requirements

* Filling out the template is required. Any pull request that does not include
enough information to be reviewed in a timely manner may be closed at the
maintainers' discretion.
* Follow the check list items defined by https://github.com/constellation-app/constellation/blob/master/CONTRIBUTING.md#pull-requests
* All new code requires unit tests to ensure they work as expected and will
continue to work as new code is added in the future (regression testing).
* Have you read Constellation's Code of Conduct? By filing an issue, you are
expected to comply with it, including treating everyone with respect:
https://github.com/constellation-app/constellation/blob/master/CODE_OF_CONDUCT.md

-->

### Description of the Change

Fixed a bug preventing v1 graphs from being open. The exception was:

```
SEVERE [global]
java.lang.ArrayIndexOutOfBoundsException: Index -1107 out of bounds for length 64
	at au.gov.asd.tac.constellation.graph.StoreGraph.getFloatValue(StoreGraph.java:1882)
	at au.gov.asd.tac.constellation.graph.visual.framework.GraphVisualAccess.getConnectionVisibility(GraphVisualAccess.java:1134)
	at au.gov.asd.tac.constellation.visual.opengl.renderer.batcher.LineBatcher.bufferColorInfo(LineBatcher.java:258)
	at au.gov.asd.tac.constellation.visual.opengl.renderer.batcher.LineBatcher.lambda$createBatch$1(LineBatcher.java:165)
	at java.base/java.util.ArrayList.forEach(Unknown Source)
	at au.gov.asd.tac.constellation.visual.opengl.renderer.batcher.LineBatcher.createBatch(LineBatcher.java:161)
	at au.gov.asd.tac.constellation.visual.opengl.renderer.GraphRenderable.lambda$getChangeProcessor$4(GraphRenderable.java:178)
	at au.gov.asd.tac.constellation.utilities.visual.VisualProcessor.lambda$processChangeSet$1(VisualProcessor.java:296)
	at java.base/java.util.ArrayList.forEach(Unknown Source)
	at au.gov.asd.tac.constellation.utilities.visual.VisualProcessor.lambda$processChangeSet$2(VisualProcessor.java:295)
	at java.base/java.util.HashMap.forEach(Unknown Source)
	at au.gov.asd.tac.constellation.utilities.visual.VisualProcessor.processChangeSet(VisualProcessor.java:293)
	at au.gov.asd.tac.constellation.utilities.visual.VisualProcessor.lambda$update$0(VisualProcessor.java:206)
[catch] at java.base/java.lang.Thread.run(Unknown Source)
```

### Alternate Designs

<!--

Explain what other alternates were considered and why the proposed version was
selected.

-->

### Why Should This Be In Core?

<!--

Explain why this functionality should be in Constellation Core as opposed to a
different module suite. Note that this question is more applicable when adding
new functionality. If this change is a minor update to an exising file then it
is understood that this change has to be to this module suite and a response
and therefore a response to this question is not required.

-->

### Benefits

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process

1. Created a graph in v1.3.1
2. Tried to open the graph in v2

### Applicable Issues

<!-- Link any applicable issues here -->