### PR TITLE
Timeline panning bug fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 2020-05-01 Changes in May 2020
 * Fixed a bug effecting the histogram scrolling
+* Changed parameter types for `OverviewPanel.setExtentPOV()` from longs to doubles.
 
 ## 2020-04-01 Changes in April 2020
 * Added search feature to Table View Column Selection.

--- a/CoreTimelineView/src/au/gov/asd/tac/constellation/views/timeline/OverviewPanel.java
+++ b/CoreTimelineView/src/au/gov/asd/tac/constellation/views/timeline/OverviewPanel.java
@@ -30,7 +30,6 @@ import javafx.scene.chart.AreaChart;
 import javafx.scene.chart.NumberAxis;
 import javafx.scene.chart.XYChart;
 import javafx.scene.input.MouseEvent;
-import javafx.scene.input.ScrollEvent;
 import javafx.scene.layout.AnchorPane;
 import javafx.scene.layout.Pane;
 import javafx.scene.paint.Color;
@@ -103,13 +102,7 @@ public class OverviewPanel extends Pane {
 
         this.getStylesheets().add(OverviewPanel.class.getResource(DARK_THEME).toExternalForm());
         this.getChildren().add(innerPane);
-        this.setOnScroll(new EventHandler<ScrollEvent>() {
-
-            @Override
-            public void handle(final ScrollEvent t) {
-                coordinator.zoomFromOverview(t);
-            }
-        });
+        this.setOnScroll(coordinator::zoomFromOverview);
 
     }
 
@@ -135,12 +128,22 @@ public class OverviewPanel extends Pane {
      * @param upperBound The upper time extent that needs to be represented on
      * the POV component.
      */
-    public void setExtentPOV(long lowerBound, long upperBound) {
-        if (lowerBound <= lowestTimeExtent) {
-            lowerBound = (long) lowestTimeExtent;
+    public void setExtentPOV(double lowerBound, double upperBound) {
+        if (lowerBound < lowestTimeExtent) {
+            lowerBound = lowestTimeExtent;
+            
+            final double currentUpperBound = ((pov.getX() + pov.getWidth()) / this.getWidth() * range) + lowestTimeExtent;
+            if (upperBound < currentUpperBound) {
+                upperBound = currentUpperBound;
+            }
         }
-        if (upperBound >= highestTimeExtent) {
-            upperBound = (long) highestTimeExtent;
+        if (upperBound > highestTimeExtent) {
+            upperBound = highestTimeExtent;
+            
+            final double currentLowerBound = (pov.getX() / this.getWidth() * range) + lowestTimeExtent;
+            if (lowerBound > currentLowerBound) {
+                lowerBound = currentLowerBound;
+            }
         }
 
         final double normalLowerBound = lowerBound - lowestTimeExtent;
@@ -265,8 +268,8 @@ public class OverviewPanel extends Pane {
             xAxis.setLowerBound(0);
             xAxis.setUpperBound(intervals);
 
-            setExtentPOV((long) coordinator.getTimelineLowerTimeExtent(),
-                    (long) coordinator.getTimelineUpperTimeExtent());
+            setExtentPOV(coordinator.getTimelineLowerTimeExtent(),
+                    coordinator.getTimelineUpperTimeExtent());
         }
     }
     // </editor-fold>

--- a/CoreTimelineView/src/au/gov/asd/tac/constellation/views/timeline/TimelineTopComponent.java
+++ b/CoreTimelineView/src/au/gov/asd/tac/constellation/views/timeline/TimelineTopComponent.java
@@ -211,7 +211,7 @@ public final class TimelineTopComponent extends TopComponent implements LookupLi
 
             timelinePanel.updateExclusionState(graphNode.getGraph(),
                     (long) state.getLowerTimeExtent(), (long) state.getUpperTimeExtent(), state.exclusionState());
-            overviewPanel.setExtentPOV((long) state.getLowerTimeExtent(), (long) state.getUpperTimeExtent());
+            overviewPanel.setExtentPOV(state.getLowerTimeExtent(), state.getUpperTimeExtent());
         }
     }
 
@@ -264,7 +264,7 @@ public final class TimelineTopComponent extends TopComponent implements LookupLi
 
             timelinePanel.updateExclusionState(graphNode.getGraph(),
                     (long) state.getLowerTimeExtent(), (long) state.getUpperTimeExtent(), state.exclusionState());
-            overviewPanel.setExtentPOV((long) state.getLowerTimeExtent(), (long) state.getUpperTimeExtent());
+            overviewPanel.setExtentPOV(state.getLowerTimeExtent(), state.getUpperTimeExtent());
         }
     }
 


### PR DESCRIPTION
<!--

### Requirements

* Filling out the template is required. Any pull request that does not include
enough information to be reviewed in a timely manner may be closed at the
maintainers' discretion.
* Follow the check list items defined by https://github.com/constellation-app/constellation/blob/master/CONTRIBUTING.md#pull-requests
* All new code requires unit tests to ensure they work as expected and will
continue to work as new code is added in the future (regression testing).
* Have you read Constellation's Code of Conduct? By filing an issue, you are
expected to comply with it, including treating everyone with respect:
https://github.com/constellation-app/constellation/blob/master/CODE_OF_CONDUCT.md

-->

### Description of the Change

Added a fix for the bug in the timeline view where the box in the summary window would shrink when panning the timeline past the bounds of the of the summary window.

### Alternate Designs

<!--

Explain what other alternates were considered and why the proposed version was
selected.

-->

### Why Should This Be In Core?

Fix for a bug in a feature of Core

### Benefits

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process
1. Open a new graph and create a sphere graph
2. Open timeline view ensuring that summary window is visible
3. Pan timeline across and observe box in summary view doesn't change its size when going past summary window bounds
4.  Verify that the expected ways to change the size of the box (e.g. zooming) still behave as expected

### Applicable Issues

#498 
