### PR TITLE
Windows-DPI-Scaling-Fix

### DIFF
--- a/CoreInteractiveGraph/src/au/gov/asd/tac/constellation/graph/interaction/visual/renderables/HitTester.java
+++ b/CoreInteractiveGraph/src/au/gov/asd/tac/constellation/graph/interaction/visual/renderables/HitTester.java
@@ -24,6 +24,7 @@ import au.gov.asd.tac.constellation.visual.opengl.utilities.GLTools;
 import com.jogamp.common.nio.Buffers;
 import com.jogamp.opengl.GL3;
 import com.jogamp.opengl.GLAutoDrawable;
+import java.awt.Graphics2D; //Pulled in by Windows-DPI-Scaling fix
 import java.nio.FloatBuffer;
 import java.util.LinkedList;
 import java.util.Queue;
@@ -160,7 +161,18 @@ public final class HitTester implements GLRenderable {
         if (!notificationQueues.isEmpty()) {
             final int x = hitTestRequest.getX();
             final int y = hitTestRequest.getY();
-            final int surfaceHeight = drawable.getSurfaceHeight();
+            
+             
+            //  Windows-DPI-Scaling
+            //
+            // If JOGL is ever fixed or another solution is found, either change
+            // needsManualDPIScaling to return false (so there is effectively no
+            // DPI scaling here) or to remove dpiScaleY below.            
+            float dpiScaleY = 1.0f;
+            if (GLTools.needsManualDPIScaling()){
+                dpiScaleY = parent.getDPIScaleY();
+            }
+            final int surfaceHeight = (int)(drawable.getSurfaceHeight() * dpiScaleY);
 
             // Allocate 3 floats for RGB values.
             FloatBuffer fbuf = Buffers.newDirectFloatBuffer(3);

--- a/CoreOpenGLDisplay/src/au/gov/asd/tac/constellation/visual/opengl/renderer/GLRenderer.java
+++ b/CoreOpenGLDisplay/src/au/gov/asd/tac/constellation/visual/opengl/renderer/GLRenderer.java
@@ -18,6 +18,7 @@ package au.gov.asd.tac.constellation.visual.opengl.renderer;
 import au.gov.asd.tac.constellation.utilities.VersionUtilities;
 import au.gov.asd.tac.constellation.utilities.graphics.Frustum;
 import au.gov.asd.tac.constellation.utilities.graphics.Matrix44f;
+import au.gov.asd.tac.constellation.visual.opengl.utilities.GLTools;
 import au.gov.asd.tac.constellation.visual.opengl.utilities.RenderException;
 import com.jogamp.opengl.DebugGL3;
 import com.jogamp.opengl.GL;
@@ -175,10 +176,26 @@ public final class GLRenderer implements GLEventListener {
     public void reshape(final GLAutoDrawable drawable, final int x, final int y, final int width, final int height) {
         final GL3 gl = drawable.getGL().getGL3();
 
-        gl.glViewport(0, 0, width, height);
+        //  Windows-DPI-Scaling
+        //
+        // If JOGL is ever fixed or another solution is found, either change
+        // needsManualDPIScaling to return false (so there is effectively no
+        // DPI scaling here) or remove the scaled height and width below.         
+        float dpiScaleX = 1.0f;
+        float dpiScaleY = 1.0f;
+        if (GLTools.needsManualDPIScaling()){
+            dpiScaleX = (float)((Graphics2D)(parent.canvas).getGraphics()).getTransform().getScaleX();
+            dpiScaleY = (float)((Graphics2D)(parent.canvas).getGraphics()).getTransform().getScaleY();
+        }
+        
+        // These need to be final as they are used in the lambda function below
+        final int dpiScaledWidth = (int)(width * dpiScaleX);
+        final int dpiScaledHeight = (int)(height * dpiScaleY);
+        
+        gl.glViewport(0, 0, dpiScaledWidth, dpiScaledHeight);
 
         // Create the projection matrix, and load it on the projection matrix stack.
-        viewFrustum.setPerspective(FIELD_OF_VIEW, (float) width / (float) height, PERSPECTIVE_NEAR, PERSPECTIVE_FAR);
+        viewFrustum.setPerspective(FIELD_OF_VIEW, (float) dpiScaledWidth / (float) dpiScaledHeight, PERSPECTIVE_NEAR, PERSPECTIVE_FAR);
 
         projectionMatrix.set(viewFrustum.getProjectionMatrix());
 
@@ -187,13 +204,13 @@ public final class GLRenderer implements GLEventListener {
         ((Component) drawable).setMinimumSize(new Dimension(0, 0));
 
         renderables.forEach(renderable -> {
-            renderable.reshape(x, y, width, height);
+            renderable.reshape(x, y, dpiScaledWidth, dpiScaledHeight);
         });
 
         viewport[0] = x;
         viewport[1] = y;
-        viewport[2] = width;
-        viewport[3] = height;
+        viewport[2] = dpiScaledWidth;
+        viewport[3] = dpiScaledHeight;
     }
 
     /**

--- a/CoreOpenGLDisplay/src/au/gov/asd/tac/constellation/visual/opengl/renderer/GLVisualProcessor.java
+++ b/CoreOpenGLDisplay/src/au/gov/asd/tac/constellation/visual/opengl/renderer/GLVisualProcessor.java
@@ -32,6 +32,7 @@ import com.jogamp.opengl.awt.GLCanvas;
 import com.jogamp.opengl.util.awt.AWTGLReadBufferUtil;
 import java.awt.Component;
 import java.awt.Cursor;
+import java.awt.Graphics2D;
 import java.awt.image.BufferedImage;
 import java.io.File;
 import java.io.IOException;
@@ -524,4 +525,16 @@ public class GLVisualProcessor extends VisualProcessor {
         // If certain changes requried other renderables to be updated, eg. an attribute that set the size of the axes to draw, we could delgeate that here rather than this being a trivial operation.
         return graphRenderable.getChangeProcessor(property);
     }
+    
+    /**
+     * Windows-DPI-Scaling
+     * 
+     * This function is only needed by the fix for Windows DPI scaling to get 
+     * access to the GLCanvas which is a protected member.  If JOGL is ever 
+     * updated to fix Windows DPI scaling this function should be removed.
+     */
+    public float getDPIScaleY() {
+        return (float)((Graphics2D)(canvas).getGraphics()).getTransform().getScaleY();
+    }
+            
 }

--- a/CoreOpenGLDisplay/src/au/gov/asd/tac/constellation/visual/opengl/utilities/GLTools.java
+++ b/CoreOpenGLDisplay/src/au/gov/asd/tac/constellation/visual/opengl/utilities/GLTools.java
@@ -40,6 +40,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import org.openide.util.Utilities; //pulled in by Windows-DPI-Scaling
 
 /**
  * Tools for OpenGL and JOGL.
@@ -868,5 +869,22 @@ public final class GLTools {
             errtext = "framebuffer unsupported";
         }
         LOGGER.log(Level.SEVERE, "**** Framebuffer error %{0}: %{1} ({2})", new Object[]{msg, errtext, fboStatus});
+    }
+    
+    /**
+     * Windows-DPI-Scaling
+     * 
+     * JOGL version 2.3.2 on Windows doesn't correctly support DPI scaling.
+     * setSurfaceScale() is not overridden in WindowsJAWTWindow so it is not
+     * possible to scale the the canvas and mouse events at this level.  It 
+     * should be noted that it is overridden in MacOSXJAWTWindow.
+     * Where manual scaling is required the caller will need to scale each GL
+     * viewport and ensure hit tests take that size into account.
+     * 
+     * If JOGL is ever fixed or another solution is found, either change this
+     * function to return false or look for any code that calls it and remove it.
+     */    
+    public static boolean needsManualDPIScaling() {
+        return Utilities.isWindows();
     }
 }


### PR DESCRIPTION
* JOGL version 2.3.2 on Windows doesn't correctly support DPI scaling.
  setSurfaceScale() is not overridden in WindowsJAWTWindow so it is not
  possible to scale the canvas and mouse events at this level.  It
  should be noted that it is overridden in MacOSXJAWTWindow.  Where manual
  scaling is required the caller scales each GL viewport and
  ensures hit tests take that size into account.
* Changes annoted with Windows-DPI-Scaling comment.

<!--

### Requirements

* Filling out the template is required. Any pull request that does not include
enough information to be reviewed in a timely manner may be closed at the
maintainers' discretion.
* Follow the check list items defined by https://github.com/constellation-app/constellation/blob/master/CONTRIBUTING.md#pull-requests
* All new code requires unit tests to ensure they work as expected and will
continue to work as new code is added in the future (regression testing).
* Have you read Constellation's Code of Conduct? By filing an issue, you are
expected to comply with it, including treating everyone with respect:
https://github.com/constellation-app/constellation/blob/master/CODE_OF_CONDUCT.md

-->

### Description of the Change

<!--

Scale viewport and colour mask hit test for Windows DPI scaling.

-->

### Alternate Designs

<!--

It is possible to fix this by changing surface scaling in JOGL.  However that is a different project I don't wish to maintain so this fix is a work around until a correct fix is made in JOGL.

-->

### Why Should This Be In Core?

<!--

This is a minor change to correct the surface of interactive graphs being incorrect on Windows machines with DPI scaling != 100%

-->

### Benefits

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

This code is restricted only to Windows OSes, but has only been tested on Windows 10.  It is possible this may cause incorrect rendering and selection offsets on other versions of Windows.

<!--

What process did you follow to verify that your change has the desired effects?

Manual testing, creating new interactive graphs, adding nodes and testing drag, rotation and selection.

-->

### Applicable Issues

<!-- Link any applicable issues here -->
