### PR TITLE
Analytic View Pane null pointer fix

### DIFF
--- a/CoreAnalyticView/src/au/gov/asd/tac/constellation/views/analyticview/AnalyticConfigurationPane.java
+++ b/CoreAnalyticView/src/au/gov/asd/tac/constellation/views/analyticview/AnalyticConfigurationPane.java
@@ -702,8 +702,13 @@ public class AnalyticConfigurationPane extends VBox {
             // Utilized for Question pane - TODO: when multiple tabs + saving of
             // questions is supported, link this currentquestion variable with 
             // the saved/loaded question
-            analyticConfigurationPane.currentQuestion = currentState.getActiveAnalyticQuestions().isEmpty() ? null :
-                    currentState.getActiveAnalyticQuestions().get(currentState.getCurrentAnalyticQuestionIndex());
+            analyticConfigurationPane.lock.lock();
+            try {
+                analyticConfigurationPane.currentQuestion = currentState.getActiveAnalyticQuestions().isEmpty() ? null : 
+                        currentState.getActiveAnalyticQuestions().get(currentState.getCurrentAnalyticQuestionIndex());
+            } finally {
+                analyticConfigurationPane.lock.unlock();
+            }
             if (!currentState.getActiveSelectablePlugins().isEmpty()) {
                 for (SelectableAnalyticPlugin selectedPlugin : currentState.getActiveSelectablePlugins().get(currentState.getCurrentAnalyticQuestionIndex())) {
                     if (currentCategory.equals(selectedPlugin.plugin.getClass().getAnnotation(AnalyticInfo.class).analyticCategory())) {


### PR DESCRIPTION
<!--

### Requirements

* Filling out the template is required. Any pull request that does not include
enough information to be reviewed in a timely manner may be closed at the
maintainers' discretion.
* Follow the check list items defined by https://github.com/constellation-app/constellation/blob/master/CONTRIBUTING.md#pull-requests
* All new code requires unit tests to ensure they work as expected and will
continue to work as new code is added in the future (regression testing).
* Have you read Constellation's Code of Conduct? By filing an issue, you are
expected to comply with it, including treating everyone with respect:
https://github.com/constellation-app/constellation/blob/master/CODE_OF_CONDUCT.md

-->

### Description of the Change

Fixed a null pointer that would sometimes appear in Analytic view.

The cause of the bug was a race condition between 2 threads that were both editing the value of a field. One had locks applied to prevent a race condition but the other thread was missing these same locks meaning the race condition was still possible (and a null pointer would occur the relevant code from these threads were executed in a particular order). Applying these same locks to the other thread (which was possible) prevents this.

### Alternate Designs

<!--

Explain what other alternates were considered and why the proposed version was
selected.

-->

### Why Should This Be In Core?

Fixes a bug in Core

### Benefits

Fixes a bug in Core

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process

This needs to be run in debug in order to best see the results (as this was the best way to get the NPE to occur more frequently

### Applicable Issues

#456 
