### PR TITLE
:art: Clustering interactions ux + bug fix

### DIFF
--- a/CoreAlgorithmPlugins/src/au/gov/asd/tac/constellation/plugins/algorithms/clustering/hierarchical/Bundle.properties
+++ b/CoreAlgorithmPlugins/src/au/gov/asd/tac/constellation/plugins/algorithms/clustering/hierarchical/Bundle.properties
@@ -1,6 +1,6 @@
 HierarchicalControllerTopComponent.displayName=Hierarchical Clusters
 HierarchicalControllerTopComponent.excludedElementsLabel.text=Excluded Elements
-HierarchicalControllerTopComponent.interactiveButton.text=Interactive
+HierarchicalControllerTopComponent.interactiveButton.text=Interactive - Disabled
 HierarchicalControllerTopComponent.reclusterButton.text=Cluster
 HierarchicalControllerTopComponent.returnToOptimumButton.text=Optimal Clustering
 HierarchicalControllerTopComponent.infoLabel.text=\ 

--- a/CoreAlgorithmPlugins/src/au/gov/asd/tac/constellation/plugins/algorithms/clustering/hierarchical/HierarchicalControllerTopComponent.java
+++ b/CoreAlgorithmPlugins/src/au/gov/asd/tac/constellation/plugins/algorithms/clustering/hierarchical/HierarchicalControllerTopComponent.java
@@ -560,7 +560,11 @@ public final class HierarchicalControllerTopComponent extends TopComponent imple
             if (state != null && doUpdate) {
                 updateGraph();
             }
-            interactiveButton.setText(state != null ? state.interactive ? INTERACTIVE_ENABLED : INTERACTIVE_DISABLED : INTERACTIVE_DISABLED);
+            if(state != null && state.interactive) {
+                interactiveButton.setText(INTERACTIVE_ENABLED);
+            } else {
+                interactiveButton.setText(INTERACTIVE_DISABLED);
+            }
         }
         interactiveButton.setEnabled(state != null);
         interactiveButton.setSelected(false);

--- a/CoreAlgorithmPlugins/src/au/gov/asd/tac/constellation/plugins/algorithms/clustering/hierarchical/HierarchicalControllerTopComponent.java
+++ b/CoreAlgorithmPlugins/src/au/gov/asd/tac/constellation/plugins/algorithms/clustering/hierarchical/HierarchicalControllerTopComponent.java
@@ -560,11 +560,7 @@ public final class HierarchicalControllerTopComponent extends TopComponent imple
             if (state != null && doUpdate) {
                 updateGraph();
             }
-            if(state != null && state.interactive) {
-                interactiveButton.setText(INTERACTIVE_ENABLED);
-            } else {
-                interactiveButton.setText(INTERACTIVE_DISABLED);
-            }
+            interactiveButton.setText((state != null && state.interactive) ? INTERACTIVE_ENABLED : INTERACTIVE_DISABLED);
         }
         interactiveButton.setEnabled(state != null);
         interactiveButton.setSelected(false);

--- a/CoreAlgorithmPlugins/src/au/gov/asd/tac/constellation/plugins/algorithms/clustering/hierarchical/HierarchicalControllerTopComponent.java
+++ b/CoreAlgorithmPlugins/src/au/gov/asd/tac/constellation/plugins/algorithms/clustering/hierarchical/HierarchicalControllerTopComponent.java
@@ -88,6 +88,8 @@ import org.openide.windows.TopComponent;
 public final class HierarchicalControllerTopComponent extends TopComponent implements LookupListener, GraphChangeListener {
 
     private static final String INFO_STRING = "%s clusters";
+    private static final String INTERACTIVE_DISABLED = "Interactive - Disabled";
+    private static final String INTERACTIVE_ENABLED = "Interactive - Enabled";
 
     private final Lookup.Result<GraphNode> result;
     private GraphNode graphNode;
@@ -442,6 +444,7 @@ public final class HierarchicalControllerTopComponent extends TopComponent imple
     private void updateInteractivity() {
         state.interactive = !state.interactive;
         if (!state.interactive) {
+            interactiveButton.setText(INTERACTIVE_DISABLED);
             nestedDiagramScrollPane.setViewportView(null);
             nestedDiagramScrollPane.repaint();
             if (state.colored) {
@@ -449,6 +452,7 @@ public final class HierarchicalControllerTopComponent extends TopComponent imple
                 PluginExecution.withPlugin(uncolor).interactively(true).executeLater(graph);
             }
         } else {
+            interactiveButton.setText(INTERACTIVE_ENABLED);
             nestedDiagramScrollPane.setViewportView(dp);
             nestedDiagramScrollPane.repaint();
             if (state.colored) {
@@ -549,6 +553,7 @@ public final class HierarchicalControllerTopComponent extends TopComponent imple
                 revalidateParents(dp);
             }
             if (state != null && doUpdate) {
+                interactiveButton.setText(INTERACTIVE_DISABLED);
                 updateGraph();
             }
         }
@@ -629,12 +634,15 @@ public final class HierarchicalControllerTopComponent extends TopComponent imple
                 state = stateAttr != Graph.NOT_FOUND ? (HierarchicalState) rg.getObjectValue(stateAttr, 0) : null;
                 if (rg.getSchema() != null && !(rg.getSchema().getFactory() instanceof VisualSchemaFactory)) {
                     interactiveButton.setSelected(false);
+                    interactiveButton.setText(INTERACTIVE_ENABLED);
                     interactivityPermitted = false;
                 } else if (state != null) {
+                    interactiveButton.setText(state.interactive ? INTERACTIVE_ENABLED : INTERACTIVE_DISABLED);
                     interactiveButton.setSelected(state.interactive);
                     colorClustersCheckBox.setSelected(state.colored);
                     interactivityPermitted = true;
                 } else {
+                    interactiveButton.setText(INTERACTIVE_DISABLED);
                     interactiveButton.setSelected(true);
                     colorClustersCheckBox.setSelected(true);
                     interactivityPermitted = true;

--- a/CoreAlgorithmPlugins/src/au/gov/asd/tac/constellation/plugins/algorithms/clustering/hierarchical/HierarchicalControllerTopComponent.java
+++ b/CoreAlgorithmPlugins/src/au/gov/asd/tac/constellation/plugins/algorithms/clustering/hierarchical/HierarchicalControllerTopComponent.java
@@ -416,6 +416,9 @@ public final class HierarchicalControllerTopComponent extends TopComponent imple
                 Set<Integer> verticesToPath = new HashSet<>();
                 for (int pos = 0; pos < graph.getVertexCount(); pos++) {
                     Group group = state.groups[pos];
+                    if (group == null) {
+                        continue;
+                    }
                     while (group.getMergeStep() <= state.currentStep) {
                         group = group.getParent();
                     }
@@ -546,6 +549,8 @@ public final class HierarchicalControllerTopComponent extends TopComponent imple
             }
             if (state == null) {
                 reclusterButton.setEnabled(true);
+                interactiveButton.setEnabled(false);
+                interactiveButton.setText(INTERACTIVE_DISABLED);
             }
 
             if (dp != null) {
@@ -553,10 +558,12 @@ public final class HierarchicalControllerTopComponent extends TopComponent imple
                 revalidateParents(dp);
             }
             if (state != null && doUpdate) {
-                interactiveButton.setText(INTERACTIVE_DISABLED);
                 updateGraph();
             }
+            interactiveButton.setText(state != null ? state.interactive ? INTERACTIVE_ENABLED : INTERACTIVE_DISABLED : INTERACTIVE_DISABLED);
         }
+        interactiveButton.setEnabled(state != null);
+        interactiveButton.setSelected(false);
     }
 
     private void updateGraph() {
@@ -610,7 +617,8 @@ public final class HierarchicalControllerTopComponent extends TopComponent imple
             state.modificationCounter = mc;
             reclusterButton.setEnabled(smc != state.strucModificationCount);
         }
-
+        // Interactive button should only be available if state is available
+        interactiveButton.setEnabled(state != null);
     }
 
     /**
@@ -716,6 +724,9 @@ public final class HierarchicalControllerTopComponent extends TopComponent imple
             for (int pos = 0; pos < vertexCount; pos++) {
                 int vertex = graph.getVertex(pos);
                 Group group = state.groups[pos];
+                if (group == null) {
+                    continue;
+                }
                 // When excluding single vertices
                 if (state.excludeSingleVertices && group.getSingleStep() > state.currentStep) {
                     graph.setIntValue(vertexClusterAttribute, vertex, -1);

--- a/CoreAlgorithmPlugins/src/au/gov/asd/tac/constellation/plugins/algorithms/clustering/hierarchical/HierarchicalStateIoProvider.java
+++ b/CoreAlgorithmPlugins/src/au/gov/asd/tac/constellation/plugins/algorithms/clustering/hierarchical/HierarchicalStateIoProvider.java
@@ -176,7 +176,6 @@ public class HierarchicalStateIoProvider extends AbstractGraphIOProvider {
                 for (final FastNewman.Group group : state.groups) {
                     if (group != null) {
                         jsonGenerator.writeStartObject();
-                        graph.getVertexPosition(state.steps);
                         jsonGenerator.writeNumberField("vertex", group.getVertex());
                         jsonGenerator.writeNumberField("merge_step", group.getMergeStep());
                         jsonGenerator.writeNumberField("single_step", group.getSingleStep());

--- a/CoreAlgorithmPlugins/src/au/gov/asd/tac/constellation/plugins/algorithms/clustering/hierarchical/NestedHierarchicalDisplayPanel.java
+++ b/CoreAlgorithmPlugins/src/au/gov/asd/tac/constellation/plugins/algorithms/clustering/hierarchical/NestedHierarchicalDisplayPanel.java
@@ -85,8 +85,11 @@ public class NestedHierarchicalDisplayPanel extends JPanel implements ComponentL
 
         for (LinePositioning line : lines) {
             GroupTreeNode node = line.n;
-            while (node.mergeStep <= state.currentStep) {
+            while (node != null && node.mergeStep <= state.currentStep) {
                 node = node.parent;
+            }
+            if (node == null) {
+                return;
             }
             line.color = node.color;
         }

--- a/CoreAlgorithmPlugins/src/au/gov/asd/tac/constellation/plugins/algorithms/clustering/ktruss/Bundle.properties
+++ b/CoreAlgorithmPlugins/src/au/gov/asd/tac/constellation/plugins/algorithms/clustering/ktruss/Bundle.properties
@@ -17,5 +17,5 @@ KTrussControllerTopComponent.upButton.text=>
 KTrussControllerTopComponent.upButton.toolTipText=
 KTrussControllerTopComponent.excludedElementsLabel.text=\ Excluded Elements:
 KTrussControllerTopComponent.colorNestedTrussesCheckBox.text=Colour Nested K-Trusses
-KTrussControllerTopComponent.interactiveButton.text=Interactive
+KTrussControllerTopComponent.interactiveButton.text=Interactive - Disabled
 KTrussControllerTopComponent.reclusterButton.text=Cluster

--- a/CoreAlgorithmPlugins/src/au/gov/asd/tac/constellation/plugins/algorithms/clustering/ktruss/KTrussControllerTopComponent.java
+++ b/CoreAlgorithmPlugins/src/au/gov/asd/tac/constellation/plugins/algorithms/clustering/ktruss/KTrussControllerTopComponent.java
@@ -85,6 +85,9 @@ import org.openide.windows.TopComponent;
 })
 public final class KTrussControllerTopComponent extends TopComponent implements LookupListener, GraphChangeListener, ComponentListener {
 
+    private static final String INTERACTIVE_DISABLED = "Interactive - Disabled";
+    private static final String INTERACTIVE_ENABLED = "Interactive - Enabled";
+    
     private final Lookup.Result<GraphNode> result;
     private GraphNode graphNode;
     private Graph graph;
@@ -367,6 +370,7 @@ public final class KTrussControllerTopComponent extends TopComponent implements 
     private void updateInteractivity() {
         state.setInteractive(!state.getInteractive());
         if (!state.getInteractive()) {
+            interactiveButton.setText(INTERACTIVE_DISABLED);
             if (state.getNestedTrussesVisible()) {
                 hideNestedTrussesPanel();
             }
@@ -375,6 +379,7 @@ public final class KTrussControllerTopComponent extends TopComponent implements 
                 PluginExecution.withPlugin(uncolor).interactively(true).executeLater(graph);
             }
         } else {
+            interactiveButton.setText(INTERACTIVE_ENABLED);
             if (state.getNestedTrussesVisible()) {
                 showNestedTrussesPanel();
             }
@@ -556,8 +561,10 @@ public final class KTrussControllerTopComponent extends TopComponent implements 
                 if (state != null) {
                     colorNestedTrussesCheckBox.setSelected(state.getNestedTrussesColored());
                     interactiveButton.setSelected(state.getInteractive());
+                    interactiveButton.setText(state.getInteractive() ? INTERACTIVE_ENABLED : INTERACTIVE_DISABLED);
                 } else {
                     interactiveButton.setSelected(false);
+                    interactiveButton.setText(INTERACTIVE_DISABLED);
                     colorNestedTrussesCheckBox.setSelected(false);
                 }
             } finally {
@@ -701,11 +708,15 @@ public final class KTrussControllerTopComponent extends TopComponent implements 
                     c.setEnabled(false);
                 }
             }
-            if (state == null) {
+            if (state != null) {
+                // Interactive button should only be available if state is available
+                interactiveButton.setEnabled(true);
+                interactiveButton.setText(INTERACTIVE_ENABLED);
+            } else {
                 reclusterButton.setEnabled(true);
+                interactiveButton.setEnabled(false);
+                interactiveButton.setText(INTERACTIVE_DISABLED);
             }
-            // Interactive button should only be available if state is available
-            interactiveButton.setEnabled(state != null);
         }
 
         if ((state != null) && doUpdate) {
@@ -722,6 +733,7 @@ public final class KTrussControllerTopComponent extends TopComponent implements 
         // This is used to revert the graph display when the component is closed and was previously
         // set to interactive.
         boolean interactive = state.getInteractive();
+        interactiveButton.setText(interactive ? INTERACTIVE_ENABLED : INTERACTIVE_DISABLED);
         if (!interactive) {
             final RemoveOverlayColors removeColors = new RemoveOverlayColors();
             PluginExecution.withPlugin(removeColors).interactively(true).executeLater(graph);


### PR DESCRIPTION
<!--

### Requirements

* Filling out the template is required. Any pull request that does not include
enough information to be reviewed in a timely manner may be closed at the
maintainers' discretion.
* Follow the check list items defined by https://github.com/constellation-app/constellation/blob/master/CONTRIBUTING.md#pull-requests
* All new code requires unit tests to ensure they work as expected and will
continue to work as new code is added in the future (regression testing).
* Have you read Constellation's Code of Conduct? By filing an issue, you are
expected to comply with it, including treating everyone with respect:
https://github.com/constellation-app/constellation/blob/master/CODE_OF_CONDUCT.md

-->

### Description of the Change
Fix a bug with hierarchical clustering #543
Fix a bug with auto-save/save of attribute not working with state.step = -1
Fix a null pointer issue when adding vertices to graph, and toggling interactive. 
Add text to button to allow visible confirmation that the view interactive mode is enabled or disabled. #190 

The clustering menus are now consistent, and when loaded on a graph without state will have the interactive button disabled, and cluster enabled. When cluster is ran, the interactive button will be enabled for use. For graphs with states, this consistency is kept at close and open of the view and or graph.
![image](https://user-images.githubusercontent.com/58677759/82526483-4b97b800-9b73-11ea-9e97-3d44d9094cfe.png)

<!--

We must be able to understand the design of your change from this description.
If we can't get a good idea of what the code will be doing from the description
here, the pull request may be closed at the maintainers' discretion. Keep in
mind that the maintainer reviewing this PR may not be familiar with or have
worked with the code here recently, so please walk us through the concepts.

-->

### Alternate Designs
N/A
<!--

Explain what other alternates were considered and why the proposed version was
selected.

-->

### Why Should This Be In Core?
Fixes bugs, improves ux
<!--

Explain why this functionality should be in Constellation Core as opposed to a
different module suite. Note that this question is more applicable when adding
new functionality. If this change is a minor update to an exising file then it
is understood that this change has to be to this module suite and a response
and therefore a response to this question is not required.

-->

### Benefits
Now less error prone and easier for a user to utilize.
<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks
Fix a bug with auto-save/save of attribute not working with state.step = -1
This fix is outlined in the IOProvider. I would appreciate it if someone else checked it out as it appeared to be getting a value but doing nothing with the returned value. I removed it to solve the bug. 
<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process
Testing with and without state on graphs, opening states and components for the view at different times. Ensuring that the button was disabled at the correct time and enabled when necessary.
<!--

What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (e.g., buttons you clicked, text you typed,
commands you ran, etc.), and describe the results you observed.

-->

### Applicable Issues
#543 
#190 
<!-- Link any applicable issues here -->
