### PR TITLE
Closing the close graph prompt exits graph without save

### DIFF
--- a/CoreInteractiveGraph/src/au/gov/asd/tac/constellation/graph/interaction/gui/VisualGraphTopComponent.java
+++ b/CoreInteractiveGraph/src/au/gov/asd/tac/constellation/graph/interaction/gui/VisualGraphTopComponent.java
@@ -637,16 +637,19 @@ public final class VisualGraphTopComponent extends CloneableTopComponent impleme
             final NotifyDescriptor d = new NotifyDescriptor(message, "Close", NotifyDescriptor.YES_NO_CANCEL_OPTION, NotifyDescriptor.QUESTION_MESSAGE, options, "Save");
             final Object o = DialogDisplayer.getDefault().notify(d);
 
-            if (o.equals(CANCEL)) {
-                return false;
-            } else if (o.equals(DISCARD)) {
+            if (o.equals(DISCARD)) {
                 savable.setModified(false);
-            } else {
+            } else if (o.equals(SAVE)){
                 try {
                     savable.handleSave();
+                    if (!savable.isSaved()){
+                        return false;
+                    }
                 } catch (IOException ex) {
                     Exceptions.printStackTrace(ex);
                 }
+            } else {
+                return false;
             }
         }
 
@@ -855,6 +858,7 @@ public final class VisualGraphTopComponent extends CloneableTopComponent impleme
     private class MySavable extends AbstractSavable implements Icon {
 
         private boolean isModified;
+        private boolean isSaved = false;
 
         /**
          * Construct a new MySavable instance.
@@ -901,6 +905,9 @@ public final class VisualGraphTopComponent extends CloneableTopComponent impleme
             return isModified;
         }
 
+        public boolean isSaved() {
+            return isSaved;
+        }
         /**
          * register the instance if in modified state
          */
@@ -940,6 +947,7 @@ public final class VisualGraphTopComponent extends CloneableTopComponent impleme
 
                 SaveAsAction action = new SaveAsAction();
                 action.actionPerformed(null);
+                isSaved = action.isSaved();
                 return;
             }
 

--- a/CoreInteractiveGraph/src/au/gov/asd/tac/constellation/graph/interaction/plugins/io/SaveAsAction.java
+++ b/CoreInteractiveGraph/src/au/gov/asd/tac/constellation/graph/interaction/plugins/io/SaveAsAction.java
@@ -189,7 +189,7 @@ public class SaveAsAction extends AbstractAction implements ContextAwareAction {
     @Override
     public void actionPerformed(final ActionEvent e) {
         refreshListeners();
-        Collection<? extends SaveAsCapable> inst = lkpInfo.allInstances();        
+        Collection<? extends SaveAsCapable> inst = lkpInfo.allInstances();
         if (!inst.isEmpty()) {
             SaveAsCapable saveAs = inst.iterator().next();
             File newFile = getNewFileName();

--- a/CoreInteractiveGraph/src/au/gov/asd/tac/constellation/graph/interaction/plugins/io/SaveAsAction.java
+++ b/CoreInteractiveGraph/src/au/gov/asd/tac/constellation/graph/interaction/plugins/io/SaveAsAction.java
@@ -148,6 +148,7 @@ public class SaveAsAction extends AbstractAction implements ContextAwareAction {
     private PropertyChangeListener registryListener;
     private LookupListener lookupListener;
     private static String lastDir = "";
+    private boolean isSaved = false;
 
     private final PropertyChangeSupport pcs = new PropertyChangeSupport(this);
 
@@ -181,10 +182,14 @@ public class SaveAsAction extends AbstractAction implements ContextAwareAction {
         return super.isEnabled();
     }
 
+    public boolean isSaved() {
+        return isSaved;
+    } 
+
     @Override
     public void actionPerformed(final ActionEvent e) {
         refreshListeners();
-        Collection<? extends SaveAsCapable> inst = lkpInfo.allInstances();
+        Collection<? extends SaveAsCapable> inst = lkpInfo.allInstances();        
         if (!inst.isEmpty()) {
             SaveAsCapable saveAs = inst.iterator().next();
             File newFile = getNewFileName();
@@ -220,6 +225,7 @@ public class SaveAsAction extends AbstractAction implements ContextAwareAction {
                                     ioE.getLocalizedMessage()));
                     Logger.getLogger(getClass().getName()).log(Level.SEVERE, null, ioE);
                 }
+                isSaved = true;
             }
         }
     }


### PR DESCRIPTION


<!--

### Requirements

* Filling out the template is required. Any pull request that does not include
enough information to be reviewed in a timely manner may be closed at the
maintainers' discretion.
* Follow the check list items defined by https://github.com/constellation-app/constellation/blob/master/CONTRIBUTING.md#pull-requests
* All new code requires unit tests to ensure they work as expected and will
continue to work as new code is added in the future (regression testing).
* Have you read Constellation's Code of Conduct? By filing an issue, you are
expected to comply with it, including treating everyone with respect:
https://github.com/constellation-app/constellation/blob/master/CODE_OF_CONDUCT.md

-->

### Description of the Change
When closing an unsaved graph, closing the 'Close' dialog no longer opens the 'Save Graph' dialog. 
When cancelling or closing the 'Save Graph' dialog, the unsaved graph is no longer discarded.
<!--

We must be able to understand the design of your change from this description.
If we can't get a good idea of what the code will be doing from the description
here, the pull request may be closed at the maintainers' discretion. Keep in
mind that the maintainer reviewing this PR may not be familiar with or have
worked with the code here recently, so please walk us through the concepts.

-->

### Alternate Designs
N/A
<!--

Explain what other alternates were considered and why the proposed version was
selected.

-->

### Why Should This Be In Core?
Better UX as this is preventing users from loosing unsaved graphs.
<!--

Explain why this functionality should be in Constellation Core as opposed to a
different module suite. Note that this question is more applicable when adding
new functionality. If this change is a minor update to an exising file then it
is understood that this change has to be to this module suite and a response
and therefore a response to this question is not required.

-->

### Benefits
Better UX as this is preventing users from loosing unsaved graphs.
<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks
N/A
<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process
Case A

Open new graph
Make a change
X on graph tab to close
X on close prompt
-> No Save Graph Dialog opening and close operation is cancelled (unsaved graph still exists).

Case B
Open new graph
Make a change
X on graph tab to close
Save
Close Save File Dialog || Press Cancel
->Close operation is cancelled (unsaved graph still exists)
<!--

What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (e.g., buttons you clicked, text you typed,
commands you ran, etc.), and describe the results you observed.

-->

### Applicable Issues
#508
<!-- Link any applicable issues here -->
