### PR TITLE
Bugfix/scene batcher issue591

### DIFF
--- a/CoreOpenGLDisplay/src/au/gov/asd/tac/constellation/visual/opengl/utilities/LabelUtilities.java
+++ b/CoreOpenGLDisplay/src/au/gov/asd/tac/constellation/visual/opengl/utilities/LabelUtilities.java
@@ -63,8 +63,7 @@ public final class LabelUtilities {
         if (text != null) {
 
             String remaining = text.trim();
-            int prevSpace = Integer.MAX_VALUE;
-
+            int prevSpace = Integer.MIN_VALUE;
             while (!remaining.isEmpty() && lines.size() < MAX_LINES_PER_ATTRIBUTE) {
 
                 final int space = remaining.indexOf(' ', prevSpace);
@@ -73,14 +72,21 @@ public final class LabelUtilities {
                 final boolean isNewLine = pos == newLine;
 
                 if (pos > MAX_LINE_LENGTH_PER_ATTRIBUTE || pos == -1) {
-                    final int trimPoint = remaining.length() < MAX_LINE_LENGTH_PER_ATTRIBUTE ? remaining.length() : Math.min(prevSpace, MAX_LINE_LENGTH_PER_ATTRIBUTE);
+                    int trimPoint;
+                    if (remaining.length() <= MAX_LINE_LENGTH_PER_ATTRIBUTE) {
+                        trimPoint = remaining.length();
+                    } else if (prevSpace == Integer.MIN_VALUE) {
+                        trimPoint = MAX_LINE_LENGTH_PER_ATTRIBUTE;
+                    } else {
+                        trimPoint = Math.min(prevSpace, MAX_LINE_LENGTH_PER_ATTRIBUTE);
+                    }
                     lines.add(remaining.substring(0, trimPoint).trim());
                     remaining = remaining.substring(trimPoint).trim();
-                    prevSpace = Integer.MAX_VALUE;
+                    prevSpace = Integer.MIN_VALUE;
                 } else if (isNewLine) {
                     lines.add(remaining.substring(0, pos).trim());
                     remaining = remaining.substring(pos).trim();
-                    prevSpace = Integer.MAX_VALUE;
+                    prevSpace = Integer.MIN_VALUE;
                 } else {
                     prevSpace = pos + 1;
                 }

--- a/CoreOpenGLDisplay/test/unit/src/au/gov/asd/tac/constellation/visual/opengl/utilities/LabelUtilitiesNGTest.java
+++ b/CoreOpenGLDisplay/test/unit/src/au/gov/asd/tac/constellation/visual/opengl/utilities/LabelUtilitiesNGTest.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package au.gov.asd.tac.constellation.visual.opengl;
+package au.gov.asd.tac.constellation.visual.opengl.utilities;
 
 import au.gov.asd.tac.constellation.visual.opengl.utilities.LabelUtilities;
 import java.util.ArrayList;
@@ -26,7 +26,7 @@ import org.testng.annotations.Test;
  *
  * @author algol
  */
-public class SceneBatchNGTest {
+public class LabelUtilitiesNGTest {
 
     @Test
     public void ellipsisIsSingleChar() {

--- a/CoreOpenGLDisplay/test/unit/src/au/gov/asd/tac/constellation/visual/opengl/utilities/LabelUtilitiesNGTest.java
+++ b/CoreOpenGLDisplay/test/unit/src/au/gov/asd/tac/constellation/visual/opengl/utilities/LabelUtilitiesNGTest.java
@@ -183,10 +183,10 @@ public class LabelUtilitiesNGTest {
 
         final List<String> out = LabelUtilities.splitTextIntoLines(text);
         assertEquals(out.size(), LabelUtilities.MAX_LINES_PER_ATTRIBUTE);
-        assertEquals("00000000001111111111222222222233333333334444444444", out.get(0));
-        assertEquals("55555555556666666666777777777788888888889999999999", out.get(1));
-        assertEquals("aaaaaaaaaabbbbbbbbbbccccccccccddddddddddeeeeeeeeee", out.get(2));
-        assertEquals("ffffffffffgggggggggghhhhhhhhhhiiiiiiiiiijjjjjjjjj" + LabelUtilities.ELLIPSIS, out.get(3));
+        assertEquals(out.get(0), "00000000001111111111222222222233333333334444444444");
+        assertEquals(out.get(1), "55555555556666666666777777777788888888889999999999");
+        assertEquals(out.get(2), "aaaaaaaaaabbbbbbbbbbccccccccccddddddddddeeeeeeeeee");
+        assertEquals(out.get(3), "ffffffffffgggggggggghhhhhhhhhhiiiiiiiiiijjjjjjjjj" + LabelUtilities.ELLIPSIS);
     }
 
     /**
@@ -199,10 +199,10 @@ public class LabelUtilitiesNGTest {
 
         final List<String> out = LabelUtilities.splitTextIntoLines(text);
         assertEquals(out.size(), LabelUtilities.MAX_LINES_PER_ATTRIBUTE);
-        assertEquals("00000000001111111111222222222233333333334444444444", out.get(0));
-        assertEquals("55555555556666666666777777777788888888889999999999", out.get(1));
-        assertEquals("aaaaaaaaaabbbbbbbbbbccccccccccddddddddddeeeeeeeeee", out.get(2));
-        assertEquals("ffffffffffgggggggggghhhhhhhhhhiiiiiiiiiijjjjjjjjj" + LabelUtilities.ELLIPSIS, out.get(3));
+        assertEquals(out.get(0), "00000000001111111111222222222233333333334444444444");
+        assertEquals(out.get(1), "55555555556666666666777777777788888888889999999999");
+        assertEquals(out.get(2), "aaaaaaaaaabbbbbbbbbbccccccccccddddddddddeeeeeeeeee");
+        assertEquals(out.get(3), "ffffffffffgggggggggghhhhhhhhhhiiiiiiiiiijjjjjjjjj" + LabelUtilities.ELLIPSIS);
         assertTrue(out.get(LabelUtilities.MAX_LINES_PER_ATTRIBUTE - 1).endsWith(LabelUtilities.ELLIPSIS));
     }
 


### PR DESCRIPTION
### Description of the Change

<!--
Fixed bug causing lines with spaces to be split in the middle of words.

-->

### Why Should This Be In Core?

<!--

Already part of core. Just a bug fix.

-->

### Benefits

Attribute values to big to fit on a single line will now be split on spaces if possible. Previously these would have been split in a word.

### Possible Drawbacks

Unknown

### Verification Process

<!--
Static analysis of texts to double check they test as described in the name and comments.

Ensured changes pass tests.

-->

### Applicable Issues

https://github.com/constellation-app/constellation/issues/591
