### PR TITLE
Fix the Body type parameters in the Rest API

### DIFF
--- a/CoreOpenGLDisplay/src/au/gov/asd/tac/constellation/visual/opengl/utilities/glyphs/FontInfo.java
+++ b/CoreOpenGLDisplay/src/au/gov/asd/tac/constellation/visual/opengl/utilities/glyphs/FontInfo.java
@@ -80,7 +80,7 @@ public class FontInfo {
             font = new Font(fontName, fontStyle, fontSize);
         }
 
-        if (font.getFamily(Locale.US).equals(Font.DIALOG)) {
+        if (font.getFamily(Locale.ENGLISH).equals(Font.DIALOG)) {
             // From the Javadoc:
             // If the name parameter represents something other than a logical
             // font, i.e. is interpreted as a physical font face or family, and

--- a/CoreOpenGLDisplay/src/au/gov/asd/tac/constellation/visual/opengl/utilities/glyphs/GlyphsFrame.java
+++ b/CoreOpenGLDisplay/src/au/gov/asd/tac/constellation/visual/opengl/utilities/glyphs/GlyphsFrame.java
@@ -85,7 +85,7 @@ public class GlyphsFrame extends JFrame {
         glyphManager = new GlyphManagerBI(fontsInfo, textureBufferSize, BufferedImage.TYPE_INT_ARGB);
 
         final GraphicsEnvironment ge = GraphicsEnvironment.getLocalGraphicsEnvironment();
-        final String[] availablefonts = Arrays.stream(ge.getAvailableFontFamilyNames(Locale.US))
+        final String[] availablefonts = Arrays.stream(ge.getAvailableFontFamilyNames(Locale.ENGLISH))
                 .filter(f -> !f.startsWith(Font.DIALOG))
                 .sorted()
                 .toArray(String[]::new);

--- a/CoreWebServer/src/au/gov/asd/tac/constellation/webserver/api/SwaggerServlet.java
+++ b/CoreWebServer/src/au/gov/asd/tac/constellation/webserver/api/SwaggerServlet.java
@@ -100,7 +100,7 @@ public class SwaggerServlet extends ConstellationHttpServlet {
                 final ObjectNode paths = (ObjectNode) root.get("paths");
                 RestServiceRegistry.getServices().forEach(serviceKey -> {
                     final ObjectNode path = paths.putObject(String.format(SERVICE_PATH, serviceKey.name));
-                    final ObjectNode httpMethod = path.putObject(serviceKey.httpMethod.name().toLowerCase(Locale.US));
+                    final ObjectNode httpMethod = path.putObject(serviceKey.httpMethod.name().toLowerCase(Locale.ENGLISH));
 
                     final RestService rs = RestServiceRegistry.get(serviceKey);
 
@@ -123,9 +123,9 @@ public class SwaggerServlet extends ConstellationHttpServlet {
                     rs.createParameters().getParameters().entrySet().forEach(entry -> {
                         final PluginParameter<?> pp = entry.getValue();
 
-                        if (pp.getName().toLowerCase(Locale.US).contains("(body)")) {
+                        if (pp.getName().toLowerCase(Locale.ENGLISH).contains("(body)")) {
                             final ObjectNode requestBody = httpMethod.putObject("requestBody");
-                            requestBody.put(DESCRIPTION, pp.getDescription());
+                            requestBody.put(DESCRIPTION, pp.getName().replace("(body)", " - ") + pp.getDescription());
                             requestBody.put("required", false); //fix in the other ticket
                             final ObjectNode content = requestBody.putObject("content");
                             final ObjectNode mime = content.putObject(RestServiceUtilities.APPLICATION_JSON);
@@ -162,7 +162,7 @@ public class SwaggerServlet extends ConstellationHttpServlet {
                         schema.put("format", "binary");
                     } else if (rs.getMimeType().equals(RestServiceUtilities.APPLICATION_JSON)) {
                         // Make a wild guess about the response.
-                        if (serviceKey.name.toLowerCase(Locale.US).startsWith("list")) {
+                        if (serviceKey.name.toLowerCase(Locale.ENGLISH).startsWith("list")) {
                             schema.put("type", "array");
                             final ObjectNode items = schema.putObject("items");
                             items.put("type", "object");

--- a/CoreWebServer/src/au/gov/asd/tac/constellation/webserver/api/SwaggerServlet.java
+++ b/CoreWebServer/src/au/gov/asd/tac/constellation/webserver/api/SwaggerServlet.java
@@ -74,6 +74,8 @@ public class SwaggerServlet extends ConstellationHttpServlet {
 
     private static final String DESCRIPTION = "description";
     private static final String SCHEMA = "schema";
+    private static final String REQUIRED = "required";
+    private static final String OBJECT = "object";
 
     @Override
     protected void doGet(final HttpServletRequest request, final HttpServletResponse response) throws ServletException {
@@ -126,19 +128,19 @@ public class SwaggerServlet extends ConstellationHttpServlet {
                         if (pp.getName().toLowerCase(Locale.ENGLISH).contains("(body)")) {
                             final ObjectNode requestBody = httpMethod.putObject("requestBody");
                             requestBody.put(DESCRIPTION, pp.getName().replace("(body)", " - ") + pp.getDescription());
-                            requestBody.put("required", false); //fix in the other ticket
+                            requestBody.put(REQUIRED, false); //fix in the other ticket
                             final ObjectNode content = requestBody.putObject("content");
                             final ObjectNode mime = content.putObject(RestServiceUtilities.APPLICATION_JSON);
                             final ObjectNode schema = mime.putObject(SCHEMA);
-                            schema.put("type", "object");
+                            schema.put("type", OBJECT);
                         } else {
-                        final ObjectNode param = params.addObject();
-                        param.put("name", pp.getId());
+                            final ObjectNode param = params.addObject();
+                            param.put("name", pp.getId());
                             param.put("in", "query");
-                        param.put("required", false); // TODO Hard-code this until PluginParameters grows a required field.
-                        param.put(DESCRIPTION, pp.getDescription());
-                        final ObjectNode schema = param.putObject(SCHEMA);
-                        schema.put("type", pp.getType().getId());
+                            param.put(REQUIRED, false); // TODO Hard-code this until PluginParameters grows a required field.
+                            param.put(DESCRIPTION, pp.getDescription());
+                            final ObjectNode schema = param.putObject(SCHEMA);
+                            schema.put("type", pp.getType().getId());
                         }
                     });
 
@@ -146,7 +148,7 @@ public class SwaggerServlet extends ConstellationHttpServlet {
                     final ObjectNode secretParam = params.addObject();
                     secretParam.put("name", "X-CONSTELLATION-SECRET");
                     secretParam.put("in", "header");
-                    secretParam.put("required", true);
+                    secretParam.put(REQUIRED, true);
                     secretParam.put(DESCRIPTION, "CONSTELLATION secret");
                     final ObjectNode secretSchema = secretParam.putObject(SCHEMA);
                     secretSchema.put("type", "string");
@@ -165,9 +167,9 @@ public class SwaggerServlet extends ConstellationHttpServlet {
                         if (serviceKey.name.toLowerCase(Locale.ENGLISH).startsWith("list")) {
                             schema.put("type", "array");
                             final ObjectNode items = schema.putObject("items");
-                            items.put("type", "object");
+                            items.put("type", OBJECT);
                         } else {
-                            schema.put("type", "object");
+                            schema.put("type", OBJECT);
                         }
                     }
                 });

--- a/CoreWebServer/src/au/gov/asd/tac/constellation/webserver/api/SwaggerServlet.java
+++ b/CoreWebServer/src/au/gov/asd/tac/constellation/webserver/api/SwaggerServlet.java
@@ -122,13 +122,24 @@ public class SwaggerServlet extends ConstellationHttpServlet {
                     final ArrayNode params = httpMethod.putArray("parameters");
                     rs.createParameters().getParameters().entrySet().forEach(entry -> {
                         final PluginParameter<?> pp = entry.getValue();
+
+                        if (pp.getName().toLowerCase(Locale.US).contains("(body)")) {
+                            final ObjectNode requestBody = httpMethod.putObject("requestBody");
+                            requestBody.put(DESCRIPTION, pp.getDescription());
+                            requestBody.put("required", false); //fix in the other ticket
+                            final ObjectNode content = requestBody.putObject("content");
+                            final ObjectNode mime = content.putObject(RestServiceUtilities.APPLICATION_JSON);
+                            final ObjectNode schema = mime.putObject(SCHEMA);
+                            schema.put("type", "object");
+                        } else {
                         final ObjectNode param = params.addObject();
                         param.put("name", pp.getId());
-                        param.put("in", pp.getName().toLowerCase(Locale.US).contains("(body)") ? "body" : "query");
+                            param.put("in", "query");
                         param.put("required", false); // TODO Hard-code this until PluginParameters grows a required field.
                         param.put(DESCRIPTION, pp.getDescription());
                         final ObjectNode schema = param.putObject(SCHEMA);
                         schema.put("type", pp.getType().getId());
+                        }
                     });
 
                     // Add the required CONSTELLATION secret header parameter.

--- a/CoreWebServer/src/au/gov/asd/tac/constellation/webserver/api/SwaggerServlet.java
+++ b/CoreWebServer/src/au/gov/asd/tac/constellation/webserver/api/SwaggerServlet.java
@@ -128,7 +128,7 @@ public class SwaggerServlet extends ConstellationHttpServlet {
                         if (pp.getName().toLowerCase(Locale.ENGLISH).contains("(body)")) {
                             final ObjectNode requestBody = httpMethod.putObject("requestBody");
                             requestBody.put(DESCRIPTION, pp.getName().replace("(body)", " - ") + pp.getDescription());
-                            requestBody.put(REQUIRED, false); //fix in the other ticket
+                            requestBody.put(REQUIRED, false); //TODO Remove hard-code in #633
                             final ObjectNode content = requestBody.putObject("content");
                             final ObjectNode mime = content.putObject(RestServiceUtilities.APPLICATION_JSON);
                             final ObjectNode schema = mime.putObject(SCHEMA);

--- a/CoreWebServer/src/au/gov/asd/tac/constellation/webserver/restapi/RestServiceUtilities.java
+++ b/CoreWebServer/src/au/gov/asd/tac/constellation/webserver/restapi/RestServiceUtilities.java
@@ -56,7 +56,7 @@ public class RestServiceUtilities {
          */
         public static HttpMethod getValue(final String s) {
             try {
-                return HttpMethod.valueOf(s.toUpperCase(Locale.US));
+                return HttpMethod.valueOf(s.toUpperCase(Locale.ENGLISH));
             } catch (final IllegalArgumentException ex) {
                 return null;
             }


### PR DESCRIPTION
<!--

### Requirements

* Filling out the template is required. Any pull request that does not include
enough information to be reviewed in a timely manner may be closed at the
maintainers' discretion.
* Follow the check list items defined by https://github.com/constellation-app/constellation/blob/master/CONTRIBUTING.md#pull-requests
* All new code requires unit tests to ensure they work as expected and will
continue to work as new code is added in the future (regression testing).
* Have you read Constellation's Code of Conduct? By filing an issue, you are
expected to comply with it, including treating everyone with respect:
https://github.com/constellation-app/constellation/blob/master/CODE_OF_CONDUCT.md

-->

### Description of the Change
The parameters of `body` type in the REST API are broken. The request doesn't add any content for any user input.
E.g.:
plugins parameter in run_plugins endpoint
args parameter in run_plugin endpoint
data parameter in add_recordstore endpoint
<!--

We must be able to understand the design of your change from this description.
If we can't get a good idea of what the code will be doing from the description
here, the pull request may be closed at the maintainers' discretion. Keep in
mind that the maintainer reviewing this PR may not be familiar with or have
worked with the code here recently, so please walk us through the concepts.

-->

### Alternate Designs
N/A
<!--

Explain what other alternates were considered and why the proposed version was
selected.

-->

### Why Should This Be In Core?
Fixes the bug
<!--

Explain why this functionality should be in Constellation Core as opposed to a
different module suite. Note that this question is more applicable when adding
new functionality. If this change is a minor update to an exising file then it
is understood that this change has to be to this module suite and a response
and therefore a response to this question is not required.

-->

### Benefits
The endpoints are now usable with json type parameters. This can be improved to contain `Example Value` which will be fixed in another case.
<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks
N/A
<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process
1. Open Swagger (Run constellation and `Tools`->`Start Rest Server` then `Display Rest Server Documentation)`
2. Try any of the above endpoints in the REST API with a valid json input
3. Verify it worked with a successful response message and the request should contain the JSON you entered.


<!--

What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (e.g., buttons you clicked, text you typed,
commands you ran, etc.), and describe the results you observed.

-->

### Applicable Issues
https://github.com/constellation-app/constellation/issues/654
