### PR TITLE
fix help page links

### DIFF
--- a/CoreArrangementPlugins/src/au/gov/asd/tac/constellation/plugins/arrangements/docs/arrangements-idx.xml
+++ b/CoreArrangementPlugins/src/au/gov/asd/tac/constellation/plugins/arrangements/docs/arrangements-idx.xml
@@ -3,7 +3,7 @@
 <index version="2.0">
     <indexitem text="Grid" target="au.gov.asd.tac.constellation.plugins.arrangements.grid"/>
     <indexitem text="Grid (General)" target="au.gov.asd.tac.constellation.plugins.arrangements.gridGeneral"/>
-    <indexitem text="Hierarchical" target="au.gov.asd.tac.constellation.plugins.arrangements.hierarchical"/>
+    <indexitem text="Hierarchical" target="au.gov.asd.tac.constellation.plugins.arrangements.hierarchical.HierarchicalAction"/>
     <indexitem text="Tree" target="au.gov.asd.tac.constellation.plugins.arrangements.tree"/>
     <indexitem text="Circle" target="au.gov.asd.tac.constellation.plugins.arrangements.circle"/>
     <indexitem text="Scatter 3D" target="au.gov.asd.tac.constellation.plugins.arrangements.scatter3d"/>
@@ -13,5 +13,5 @@
     <indexitem text="Expand Graph" target="au.gov.asd.tac.constellation.plugins.arrangements.expandGraph"/>
     <indexitem text="Layer by Time" target="au.gov.asd.tac.constellation.plugins.arrangements.layerByTime"/>
     <indexitem text="Clusters on Hilbert Curve" target="au.gov.asd.tac.constellation.plugins.arrangements.clustersOnHilbertCurve"/>
-    <indexitem text="Bubble Tree" target="au.gov.asd.tac.constellation.plugins.arrangements.bubbleTree"/>
+    <indexitem text="Bubble Tree" target="au.gov.asd.tac.constellation.plugins.arrangements.trees.BubbleTreeAction"/>
 </index>

--- a/CoreArrangementPlugins/src/au/gov/asd/tac/constellation/plugins/arrangements/docs/arrangements-map.xml
+++ b/CoreArrangementPlugins/src/au/gov/asd/tac/constellation/plugins/arrangements/docs/arrangements-map.xml
@@ -3,7 +3,7 @@
 <map version="2.0">
     <mapID target="au.gov.asd.tac.constellation.plugins.arrangements.grid" url="grid.html"/>
     <mapID target="au.gov.asd.tac.constellation.plugins.arrangements.gridGeneral" url="grid-general.html"/>
-    <mapID target="au.gov.asd.tac.constellation.plugins.arrangements.hierarchical" url="hierarchical.html"/>
+    <mapID target="au.gov.asd.tac.constellation.plugins.arrangements.hierarchical.HierarchicalAction" url="hierarchical.html"/>
     <mapID target="au.gov.asd.tac.constellation.plugins.arrangements.tree" url="tree.html"/>
     <mapID target="au.gov.asd.tac.constellation.plugins.arrangements.circle" url="circle.html"/>
     <mapID target="au.gov.asd.tac.constellation.plugins.arrangements.scatter3d" url="scatter3d.html"/>
@@ -13,5 +13,5 @@
     <mapID target="au.gov.asd.tac.constellation.plugins.arrangements.expandGraph" url="expand-graph.html"/>
     <mapID target="au.gov.asd.tac.constellation.plugins.arrangements.layerByTime" url="layer-by-time.html"/>
     <mapID target="au.gov.asd.tac.constellation.plugins.arrangements.clustersOnHilbertCurve" url="hilbert.html"/>
-    <mapID target="au.gov.asd.tac.constellation.plugins.arrangements.bubbleTree" url="bubble-tree.html"/>
+    <mapID target="au.gov.asd.tac.constellation.plugins.arrangements.trees.BubbleTreeAction" url="bubble-tree.html"/>
 </map>

--- a/CoreArrangementPlugins/src/au/gov/asd/tac/constellation/plugins/arrangements/docs/arrangements-toc.xml
+++ b/CoreArrangementPlugins/src/au/gov/asd/tac/constellation/plugins/arrangements/docs/arrangements-toc.xml
@@ -4,14 +4,14 @@
     <tocitem text="Arrangements">
         <tocitem text="Grid" target="au.gov.asd.tac.constellation.plugins.arrangements.grid"/>
         <tocitem text="Grid (General)" target="au.gov.asd.tac.constellation.plugins.arrangements.gridGeneral"/>
-        <tocitem text="Hierarchical" target="au.gov.asd.tac.constellation.plugins.arrangements.hierarchical"/>
+        <tocitem text="Hierarchical" target="au.gov.asd.tac.constellation.plugins.arrangements.hierarchical.HierarchicalAction"/>
         <tocitem text="Tree" target="au.gov.asd.tac.constellation.plugins.arrangements.tree"/>
         <tocitem text="Circle" target="au.gov.asd.tac.constellation.plugins.arrangements.circle"/>
         <tocitem text="Scatter 3D" target="au.gov.asd.tac.constellation.plugins.arrangements.scatter3d"/>
         <tocitem text="Sphere" target="au.gov.asd.tac.constellation.plugins.arrangements.sphere"/>
         <tocitem text="Layer by Time" target="au.gov.asd.tac.constellation.plugins.arrangements.layerByTime"/>
         <tocitem text="Clusters on Hilbert Curve" target="au.gov.asd.tac.constellation.plugins.arrangements.clustersOnHilbertCurve"/>
-        <tocitem text="Bubble Tree" target="au.gov.asd.tac.constellation.plugins.arrangements.bubbleTree"/>
+        <tocitem text="Bubble Tree" target="au.gov.asd.tac.constellation.plugins.arrangements.trees.BubbleTreeAction"/>
         <tocitem text="Flatten Z Field" target="au.gov.asd.tac.constellation.plugins.arrangements.flattenZField"/>
         <tocitem text="Expand Graph" target="au.gov.asd.tac.constellation.plugins.arrangements.expandGraph"/>
         <tocitem text="Contract Graph" target="au.gov.asd.tac.constellation.plugins.arrangements.contractGraph"/>

--- a/CoreArrangementPlugins/src/au/gov/asd/tac/constellation/plugins/arrangements/hierarchical/ArrangeInHierarchyAction.java
+++ b/CoreArrangementPlugins/src/au/gov/asd/tac/constellation/plugins/arrangements/hierarchical/ArrangeInHierarchyAction.java
@@ -55,6 +55,7 @@ import org.openide.util.NbBundle;
 public class ArrangeInHierarchyAction extends AbstractAction {
 
     private final GraphNode context;
+    private static final String HELP_LOCATION = "au.gov.asd.tac.constellation.plugins.arrangements.hierarchical.HierarchicalAction";
 
     public ArrangeInHierarchyAction(final GraphNode context) {
         this.context = context;
@@ -74,7 +75,7 @@ public class ArrangeInHierarchyAction extends AbstractAction {
 
                     final SelectNamedSelectionPanel ssp = new SelectNamedSelectionPanel(nsState.getNamedSelections(), "Select a named selection to represent the top of the hierarchy.");
                     final DialogDescriptor dd = new DialogDescriptor(ssp, Bundle.CTL_ArrangeInHierarchyAction());
-                    dd.setHelpCtx(new HelpCtx("au.gov.asd.tac.constellation.plugins.arrangements.hierarchical.HierarchicalAction"));
+                    dd.setHelpCtx(new HelpCtx(HELP_LOCATION));
                     final Object result = DialogDisplayer.getDefault().notify(dd);
                     if (result == DialogDescriptor.OK_OPTION) {
                         final long selectionId = ssp.getNamedSelectionId();

--- a/CoreArrangementPlugins/src/au/gov/asd/tac/constellation/plugins/arrangements/tree/ArrangeInBubbleTreeAction.java
+++ b/CoreArrangementPlugins/src/au/gov/asd/tac/constellation/plugins/arrangements/tree/ArrangeInBubbleTreeAction.java
@@ -54,6 +54,7 @@ import org.openide.util.NbBundle;
 @NbBundle.Messages("CTL_ArrangeInBubbleTreeAction=Bubble Tree 3D")
 public class ArrangeInBubbleTreeAction extends AbstractAction {
 
+    private static final String HELP_LOCATION = "au.gov.asd.tac.constellation.plugins.arrangements.trees.BubbleTreeAction";
     private final GraphNode context;
 
     public ArrangeInBubbleTreeAction(final GraphNode context) {
@@ -74,7 +75,7 @@ public class ArrangeInBubbleTreeAction extends AbstractAction {
 
                     final SelectNamedSelectionPanel ssp = new SelectNamedSelectionPanel(nsState.getNamedSelections(), "Select a named selection to represent the tree roots.");
                     final DialogDescriptor dd = new DialogDescriptor(ssp, Bundle.CTL_ArrangeInBubbleTreeAction());
-                    dd.setHelpCtx(new HelpCtx("au.gov.asd.tac.constellation.plugins.arrangements.trees.BubbleTreeAction"));
+                    dd.setHelpCtx(new HelpCtx(HELP_LOCATION));
                     final Object result = DialogDisplayer.getDefault().notify(dd);
                     if (result == DialogDescriptor.OK_OPTION) {
                         final long selectionId = ssp.getNamedSelectionId();


### PR DESCRIPTION

### Description of the Change

Help pages over time have linked to the wrong module paths
This Pr fixes those so the help files link back up.
*bubble tree action - Does not have a proper documentation page, just a page with the title `bubble tree action`
*hierarchy action

Added a constant to hold the help location so it is easily seen within the classes in the need for future changes
