### PR TITLE
Upgrade Schema Vertex Types - Fixes #730

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Constellation Changes
 
 ## 2020-07-01 Changes in July 2020
+* Added `AnalyticSchemaV4UpdateProvider` to upgrade `SchemaVertexType`s that have changed.
 * Added utility class `NotifyDisplayer` and static method `NotifyDisplayer#display` for use when displaying a `NotifyDescriptor` message box.
 * Fixed a bug exporting Glyph Textures to the wrong location if the folder path had a period.
 * Updated `QualityControlAutoVetter` to improve performance by using a `SimpleReadPlugin` internally.

--- a/CoreAnalyticSchema/src/au/gov/asd/tac/constellation/graph/schema/analytic/compatibility/AnalyticSchemaV4UpdateProvider.java
+++ b/CoreAnalyticSchema/src/au/gov/asd/tac/constellation/graph/schema/analytic/compatibility/AnalyticSchemaV4UpdateProvider.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2010-2020 Australian Signals Directorate
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package au.gov.asd.tac.constellation.graph.schema.analytic.compatibility;
+
+import au.gov.asd.tac.constellation.graph.StoreGraph;
+import au.gov.asd.tac.constellation.graph.schema.SchemaFactory;
+import au.gov.asd.tac.constellation.graph.schema.SchemaFactoryUtilities;
+import au.gov.asd.tac.constellation.graph.schema.analytic.AnalyticSchemaFactory;
+import au.gov.asd.tac.constellation.graph.schema.analytic.concept.AnalyticConcept;
+import au.gov.asd.tac.constellation.graph.schema.type.SchemaVertexType;
+import au.gov.asd.tac.constellation.graph.versioning.SchemaUpdateProvider;
+import au.gov.asd.tac.constellation.graph.versioning.UpdateProvider;
+import java.util.HashMap;
+import java.util.Map;
+import org.openide.util.lookup.ServiceProvider;
+
+/**
+ * Upgrade Vertex Types that have changed.
+ * <p>
+ * The detection regex and validation regex was reviewed and improved.
+ *
+ * @author arcturus
+ */
+@ServiceProvider(service = UpdateProvider.class)
+public class AnalyticSchemaV4UpdateProvider extends SchemaUpdateProvider {
+
+    public static final int SCHEMA_VERSION_THIS_UPDATE = 4;
+
+    @Override
+    protected SchemaFactory getSchema() {
+        return SchemaFactoryUtilities.getSchemaFactory(AnalyticSchemaFactory.ANALYTIC_SCHEMA_ID);
+    }
+
+    @Override
+    public int getFromVersionNumber() {
+        return AnalyticSchemaV3UpdateProvider.SCHEMA_VERSION_THIS_UPDATE;
+    }
+
+    @Override
+    public int getToVersionNumber() {
+        return SCHEMA_VERSION_THIS_UPDATE;
+    }
+
+    @Override
+    protected void schemaUpdate(final StoreGraph graph) {
+        final int typeAttribute = AnalyticConcept.VertexAttribute.TYPE.get(graph);
+
+        final Map<String, SchemaVertexType> typesToUpgrade = new HashMap<>() {
+            {
+                put(AnalyticConcept.VertexType.MD5.getName(), AnalyticConcept.VertexType.MD5);
+                put(AnalyticConcept.VertexType.SHA1.getName(), AnalyticConcept.VertexType.SHA1);
+                put(AnalyticConcept.VertexType.SHA256.getName(), AnalyticConcept.VertexType.SHA256);
+                put(AnalyticConcept.VertexType.COUNTRY.getName(), AnalyticConcept.VertexType.COUNTRY);
+                put(AnalyticConcept.VertexType.GEOHASH.getName(), AnalyticConcept.VertexType.GEOHASH);
+                put(AnalyticConcept.VertexType.MGRS.getName(), AnalyticConcept.VertexType.MGRS);
+                put(AnalyticConcept.VertexType.MD5.getName(), AnalyticConcept.VertexType.MD5);
+                put(AnalyticConcept.VertexType.IPV4.getName(), AnalyticConcept.VertexType.IPV4);
+                put(AnalyticConcept.VertexType.IPV6.getName(), AnalyticConcept.VertexType.IPV6);
+                put(AnalyticConcept.VertexType.EMAIL_ADDRESS.getName(), AnalyticConcept.VertexType.EMAIL_ADDRESS);
+                put(AnalyticConcept.VertexType.HOST_NAME.getName(), AnalyticConcept.VertexType.HOST_NAME);
+                put(AnalyticConcept.VertexType.URL.getName(), AnalyticConcept.VertexType.URL);
+                put(AnalyticConcept.VertexType.TELEPHONE_IDENTIFIER.getName(), AnalyticConcept.VertexType.TELEPHONE_IDENTIFIER);
+            }
+        };
+
+        for (int vertex = 0; vertex < graph.getVertexCount(); vertex++) {
+            final int vertexId = graph.getVertex(vertex);
+            final SchemaVertexType oldType = graph.getObjectValue(typeAttribute, vertexId);
+
+            if (typesToUpgrade.containsKey(oldType.getName())) {
+                graph.setObjectValue(typeAttribute, vertexId, typesToUpgrade.get(oldType.getName()));
+            }
+        }
+    }
+}

--- a/CoreAnalyticSchema/src/au/gov/asd/tac/constellation/graph/schema/analytic/compatibility/AnalyticSchemaV4UpdateProvider.java
+++ b/CoreAnalyticSchema/src/au/gov/asd/tac/constellation/graph/schema/analytic/compatibility/AnalyticSchemaV4UpdateProvider.java
@@ -58,23 +58,20 @@ public class AnalyticSchemaV4UpdateProvider extends SchemaUpdateProvider {
     protected void schemaUpdate(final StoreGraph graph) {
         final int typeAttribute = AnalyticConcept.VertexAttribute.TYPE.get(graph);
 
-        final Map<String, SchemaVertexType> typesToUpgrade = new HashMap<>() {
-            {
-                put(AnalyticConcept.VertexType.MD5.getName(), AnalyticConcept.VertexType.MD5);
-                put(AnalyticConcept.VertexType.SHA1.getName(), AnalyticConcept.VertexType.SHA1);
-                put(AnalyticConcept.VertexType.SHA256.getName(), AnalyticConcept.VertexType.SHA256);
-                put(AnalyticConcept.VertexType.COUNTRY.getName(), AnalyticConcept.VertexType.COUNTRY);
-                put(AnalyticConcept.VertexType.GEOHASH.getName(), AnalyticConcept.VertexType.GEOHASH);
-                put(AnalyticConcept.VertexType.MGRS.getName(), AnalyticConcept.VertexType.MGRS);
-                put(AnalyticConcept.VertexType.MD5.getName(), AnalyticConcept.VertexType.MD5);
-                put(AnalyticConcept.VertexType.IPV4.getName(), AnalyticConcept.VertexType.IPV4);
-                put(AnalyticConcept.VertexType.IPV6.getName(), AnalyticConcept.VertexType.IPV6);
-                put(AnalyticConcept.VertexType.EMAIL_ADDRESS.getName(), AnalyticConcept.VertexType.EMAIL_ADDRESS);
-                put(AnalyticConcept.VertexType.HOST_NAME.getName(), AnalyticConcept.VertexType.HOST_NAME);
-                put(AnalyticConcept.VertexType.URL.getName(), AnalyticConcept.VertexType.URL);
-                put(AnalyticConcept.VertexType.TELEPHONE_IDENTIFIER.getName(), AnalyticConcept.VertexType.TELEPHONE_IDENTIFIER);
-            }
-        };
+        final Map<String, SchemaVertexType> typesToUpgrade = new HashMap<>();
+        typesToUpgrade.put(AnalyticConcept.VertexType.MD5.getName(), AnalyticConcept.VertexType.MD5);
+        typesToUpgrade.put(AnalyticConcept.VertexType.SHA1.getName(), AnalyticConcept.VertexType.SHA1);
+        typesToUpgrade.put(AnalyticConcept.VertexType.SHA256.getName(), AnalyticConcept.VertexType.SHA256);
+        typesToUpgrade.put(AnalyticConcept.VertexType.COUNTRY.getName(), AnalyticConcept.VertexType.COUNTRY);
+        typesToUpgrade.put(AnalyticConcept.VertexType.GEOHASH.getName(), AnalyticConcept.VertexType.GEOHASH);
+        typesToUpgrade.put(AnalyticConcept.VertexType.MGRS.getName(), AnalyticConcept.VertexType.MGRS);
+        typesToUpgrade.put(AnalyticConcept.VertexType.MD5.getName(), AnalyticConcept.VertexType.MD5);
+        typesToUpgrade.put(AnalyticConcept.VertexType.IPV4.getName(), AnalyticConcept.VertexType.IPV4);
+        typesToUpgrade.put(AnalyticConcept.VertexType.IPV6.getName(), AnalyticConcept.VertexType.IPV6);
+        typesToUpgrade.put(AnalyticConcept.VertexType.EMAIL_ADDRESS.getName(), AnalyticConcept.VertexType.EMAIL_ADDRESS);
+        typesToUpgrade.put(AnalyticConcept.VertexType.HOST_NAME.getName(), AnalyticConcept.VertexType.HOST_NAME);
+        typesToUpgrade.put(AnalyticConcept.VertexType.URL.getName(), AnalyticConcept.VertexType.URL);
+        typesToUpgrade.put(AnalyticConcept.VertexType.TELEPHONE_IDENTIFIER.getName(), AnalyticConcept.VertexType.TELEPHONE_IDENTIFIER);
 
         for (int vertex = 0; vertex < graph.getVertexCount(); vertex++) {
             final int vertexId = graph.getVertex(vertex);

--- a/CoreAnalyticSchema/src/au/gov/asd/tac/constellation/graph/schema/analytic/compatibility/AnalyticSchemaV4UpdateProvider.java
+++ b/CoreAnalyticSchema/src/au/gov/asd/tac/constellation/graph/schema/analytic/compatibility/AnalyticSchemaV4UpdateProvider.java
@@ -65,7 +65,6 @@ public class AnalyticSchemaV4UpdateProvider extends SchemaUpdateProvider {
         typesToUpgrade.put(AnalyticConcept.VertexType.COUNTRY.getName(), AnalyticConcept.VertexType.COUNTRY);
         typesToUpgrade.put(AnalyticConcept.VertexType.GEOHASH.getName(), AnalyticConcept.VertexType.GEOHASH);
         typesToUpgrade.put(AnalyticConcept.VertexType.MGRS.getName(), AnalyticConcept.VertexType.MGRS);
-        typesToUpgrade.put(AnalyticConcept.VertexType.MD5.getName(), AnalyticConcept.VertexType.MD5);
         typesToUpgrade.put(AnalyticConcept.VertexType.IPV4.getName(), AnalyticConcept.VertexType.IPV4);
         typesToUpgrade.put(AnalyticConcept.VertexType.IPV6.getName(), AnalyticConcept.VertexType.IPV6);
         typesToUpgrade.put(AnalyticConcept.VertexType.EMAIL_ADDRESS.getName(), AnalyticConcept.VertexType.EMAIL_ADDRESS);


### PR DESCRIPTION
<!--

### Requirements

* Filling out the template is required. Any pull request that does not include
enough information to be reviewed in a timely manner may be closed at the
maintainers' discretion.
* Follow the check list items defined by https://github.com/constellation-app/constellation/blob/master/CONTRIBUTING.md#pull-requests
* All new code requires unit tests to ensure they work as expected and will
continue to work as new code is added in the future (regression testing).
* Make sure your branch name is prefixed by `feature`, `bugfix`, `hotfix` or `release`
* Have you read Constellation's Code of Conduct? By filing an issue, you are
expected to comply with it, including treating everyone with respect:
https://github.com/constellation-app/constellation/blob/master/CODE_OF_CONDUCT.md

-->

### Description of the Change

Adding certain nodes to a v1 graph opened in v2 will introduce duplicate types. This is because the Type have changed (which is the validation and detection regex).

We can use the Schema upgrade framework to detect old graphs and then upgrade them. Once this change goes through, the Analytic Schema version will be 4.

### Alternate Designs

<!--

Explain what other alternates were considered and why the proposed version was
selected.

-->

### Why Should This Be In Core?

<!--

Explain why this functionality should be in Constellation Core as opposed to a
different module suite. Note that this question is more applicable when adding
new functionality. If this change is a minor update to an exising file then it
is understood that this change has to be to this module suite and a response
and therefore a response to this question is not required.

-->

### Benefits

Supporting backwords compatibilty is something we always want to do in Constellation to make it seamless for users to continue working with their graphs and not worry about version upgrades breaking their graphs.

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process

1. I created a graph in v1.3.1 using [this script](https://gist.github.com/arcturus2/5d211d9f993f240564011ee42353fcdb) run in the Scripting View. There are 27 nodes.
2. Opened the graph in v2 and ran the script again. This showed 13 new nodes. These needed to be upgraded.

After adding `AnalyticSchemaV4UpdateProvider` I re-ran step 2 and observed that there was 27 nodes.

I decided to use the Scripting View so that I didn't need to write a plugin and have to checkout Constellation v1 to implement it there also. I guess there was only 27 nodes so you could create them by hand...but where is the fun in that?

### Applicable Issues

#730
