### PR TITLE
Dramatically improve preview performance of CSV files

### DIFF
--- a/CoreFunctionality/src/au/gov/asd/tac/constellation/functionality/whatsnew/whatsnew.txt
+++ b/CoreFunctionality/src/au/gov/asd/tac/constellation/functionality/whatsnew/whatsnew.txt
@@ -1,6 +1,9 @@
 == 3030-12-31 Getting Started
 <p>If you're new to CONSTELLATION, read the <a href="" helpId="au.gov.asd.tac.constellation.functionality.introduction">introduction</a>.</p>
 
+== 2020-07-23 Delimited File Importer
+<p>Dramatically improve the preview performance of a CSV file import.</p>
+
 == 2020-07-20 Version 2
 <p>Constellation v2.0.0 is officially released!</p>
 

--- a/CoreImportExportPlugins/src/au/gov/asd/tac/constellation/plugins/importexport/delimited/parser/CSVImportFileParser.java
+++ b/CoreImportExportPlugins/src/au/gov/asd/tac/constellation/plugins/importexport/delimited/parser/CSVImportFileParser.java
@@ -44,8 +44,7 @@ public class CSVImportFileParser extends ImportFileParser {
     public List<String[]> parse(final InputSource input, final PluginParameters parameters) throws IOException {
         final ArrayList<String[]> results = new ArrayList<>();
         try (final CSVParser csvFileParser = CSVFormat.RFC4180.parse(new InputStreamReader(input.getInputStream(), StandardCharsets.UTF_8.name()))) {
-            final List<CSVRecord> records = csvFileParser.getRecords();
-            for (final CSVRecord record : records) {
+            for (final CSVRecord record : csvFileParser) {
                 final String[] line = new String[record.size()];
                 for (int i = 0; i < record.size(); i++) {
                     line[i] = record.get(i);
@@ -62,15 +61,13 @@ public class CSVImportFileParser extends ImportFileParser {
         final ArrayList<String[]> results = new ArrayList<>();
         try (final CSVParser csvFileParser = CSVFormat.RFC4180.parse(new InputStreamReader(input.getInputStream(), StandardCharsets.UTF_8.name()))) {
             int count = 0;
-            final List<CSVRecord> records = csvFileParser.getRecords();
-            for (final CSVRecord record : records) {
+            for (final CSVRecord record : csvFileParser) {
                 final String[] line = new String[record.size()];
                 for (int i = 0; i < record.size(); i++) {
                     line[i] = record.get(i);
                 }
                 results.add(line);
-                count += 1;
-                if (count >= limit) {
+                if (++count >= limit) {
                     return results;
                 }
             }

--- a/CoreImportExportPlugins/src/au/gov/asd/tac/constellation/plugins/importexport/delimited/parser/InputSource.java
+++ b/CoreImportExportPlugins/src/au/gov/asd/tac/constellation/plugins/importexport/delimited/parser/InputSource.java
@@ -31,12 +31,12 @@ public class InputSource {
     private final File file;
     private final InputStream inputStream;
 
-    public InputSource(File file) {
+    public InputSource(final File file) {
         this.file = file;
         this.inputStream = null;
     }
 
-    public InputSource(InputStream inputStream) {
+    public InputSource(final InputStream inputStream) {
         this.file = null;
         this.inputStream = inputStream;
     }


### PR DESCRIPTION
<!--

### Requirements

* Filling out the template is required. Any pull request that does not include
enough information to be reviewed in a timely manner may be closed at the
maintainers' discretion.
* Follow the check list items defined by https://github.com/constellation-app/constellation/blob/master/CONTRIBUTING.md#pull-requests
* All new code requires unit tests to ensure they work as expected and will
continue to work as new code is added in the future (regression testing).
* Make sure your branch name is prefixed by `feature`, `bugfix`, `hotfix` or `release`
* Have you read Constellation's Code of Conduct? By filing an issue, you are
expected to comply with it, including treating everyone with respect:
https://github.com/constellation-app/constellation/blob/master/CODE_OF_CONDUCT.md

-->

### Description of the Change

* :racehorse: Dramatically improve preview performance of CSV files

The issue was that the preview was still loading all of the data. It now properly streams.

Try downloading https://www.kaggle.com/gidutz/autotel-shared-car-locations/data and run a preview. The import still fails with out of memory and is still something that needs fixing.

### Alternate Designs

<!--

Explain what other alternates were considered and why the proposed version was
selected.

-->

### Why Should This Be In Core?

<!--

Explain why this functionality should be in Constellation Core as opposed to a
different module suite. Note that this question is more applicable when adding
new functionality. If this change is a minor update to an exising file then it
is understood that this change has to be to this module suite and a response
and therefore a response to this question is not required.

-->

### Benefits

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process

Try loading a large csv file. I've referenced a Kaggle dataset as an example.

### Applicable Issues

#611
