### PR TITLE
Reword the pop up  notification when the REST server is already started

### DIFF
--- a/CoreWebServer/src/au/gov/asd/tac/constellation/webserver/StartRestServerAction.java
+++ b/CoreWebServer/src/au/gov/asd/tac/constellation/webserver/StartRestServerAction.java
@@ -34,9 +34,11 @@ public final class StartRestServerAction implements ActionListener {
 
     @Override
     public void actionPerformed(final ActionEvent e) {
+        // title should be assigned befroe WebServer.start
+        final String title = WebServer.isRunning() ? "Web server already started" : "Web server started";
         final int port = WebServer.start();
         final String msg = String.format("External scripting listening on port %d", port);
-        NotificationDisplayer.getDefault().notify(WebServer.isRunning() ? "Web server already started" : "Web server started",
+        NotificationDisplayer.getDefault().notify(title,
                 UserInterfaceIconProvider.WARNING.buildIcon(16, ConstellationColor.DARK_ORANGE.getJavaColor()),
                 msg,
                 null

--- a/CoreWebServer/src/au/gov/asd/tac/constellation/webserver/StartRestServerAction.java
+++ b/CoreWebServer/src/au/gov/asd/tac/constellation/webserver/StartRestServerAction.java
@@ -36,7 +36,7 @@ public final class StartRestServerAction implements ActionListener {
     public void actionPerformed(final ActionEvent e) {
         final int port = WebServer.start();
         final String msg = String.format("External scripting listening on port %d", port);
-        NotificationDisplayer.getDefault().notify("Web server started",
+        NotificationDisplayer.getDefault().notify(WebServer.isRunning() ? "Web server already started" : "Web server started",
                 UserInterfaceIconProvider.WARNING.buildIcon(16, ConstellationColor.DARK_ORANGE.getJavaColor()),
                 msg,
                 null

--- a/CoreWebServer/src/au/gov/asd/tac/constellation/webserver/WebServer.java
+++ b/CoreWebServer/src/au/gov/asd/tac/constellation/webserver/WebServer.java
@@ -126,6 +126,10 @@ public class WebServer {
     private static final String IPYTHON = ".ipython";
     private static final String RESOURCES = "resources/";
 
+    public static boolean isRunning() {
+        return running;
+    }
+
     public static synchronized int start() {
         if (!running) {
             try {


### PR DESCRIPTION


### Description of the Change

The pop up message when starting the Rest Server saying `Web server started` is displayed for each time the `Tools` > `Start Rest Server` menu item is clicked. This gives a false impression of starting multiple servers.

### Alternate Designs
Disable menu item when the server is already running?

### Why Should This Be In Core?
Less confusion for user

### Benefits
Better UX

### Possible Drawbacks

N/A

### Verification Process

1. Click `Tools` > `Start Rest Server` menu item. The pop up message should say `Web server started`
1. Click `Tools` > `Start Rest Server` menu item again. The pop up message should say `Web server already started`

### Applicable Issues

https://github.com/constellation-app/constellation/issues/711
