### PR TITLE
Split Nodes and Extract words from text plugins to default values in drop downs only if they are null

### DIFF
--- a/CoreDataAccessView/src/au/gov/asd/tac/constellation/views/dataaccess/plugins/clean/SplitNodesPlugin.java
+++ b/CoreDataAccessView/src/au/gov/asd/tac/constellation/views/dataaccess/plugins/clean/SplitNodesPlugin.java
@@ -112,8 +112,6 @@ public class SplitNodesPlugin extends RecordStoreQueryPlugin implements DataAcce
     @Override
     public void updateParameters(Graph graph, PluginParameters parameters) {
         if (parameters != null && parameters.getParameters() != null) {
-            @SuppressWarnings("unchecked") //TRANSACTION_TYPE_PARAMETER is always of type SingleChoiceParameter
-            final PluginParameter<SingleChoiceParameterValue> transactionType = (PluginParameter<SingleChoiceParameterValue>) parameters.getParameters().get(TRANSACTION_TYPE_PARAMETER_ID);
             final List<String> types = new ArrayList<>();
             if (graph != null && graph.getSchema() != null) {
                 for (final SchemaTransactionType type : SchemaTransactionTypeUtilities.getTypes(graph.getSchema().getFactory().getRegisteredConcepts())) {
@@ -123,6 +121,8 @@ public class SplitNodesPlugin extends RecordStoreQueryPlugin implements DataAcce
                     types.sort(String::compareTo);
                 }
             }
+            @SuppressWarnings("unchecked") //TRANSACTION_TYPE_PARAMETER is always of type SingleChoiceParameter
+            final PluginParameter<SingleChoiceParameterValue> transactionType = (PluginParameter<SingleChoiceParameterValue>) parameters.getParameters().get(TRANSACTION_TYPE_PARAMETER_ID);
             transactionType.suppressEvent(true, new ArrayList<>());
             SingleChoiceParameterType.setOptions(transactionType, types);
 

--- a/CoreDataAccessView/src/au/gov/asd/tac/constellation/views/dataaccess/plugins/clean/SplitNodesPlugin.java
+++ b/CoreDataAccessView/src/au/gov/asd/tac/constellation/views/dataaccess/plugins/clean/SplitNodesPlugin.java
@@ -126,7 +126,7 @@ public class SplitNodesPlugin extends RecordStoreQueryPlugin implements DataAcce
             transactionType.suppressEvent(true, new ArrayList<>());
             SingleChoiceParameterType.setOptions(transactionType, types);
 
-            if (types.contains(AnalyticConcept.TransactionType.CORRELATION.getName())) {
+            if (transactionType.getSingleChoice() == null && types.contains(AnalyticConcept.TransactionType.CORRELATION.getName())) {
                 SingleChoiceParameterType.setChoice(transactionType, AnalyticConcept.TransactionType.CORRELATION.getName());
             }
             transactionType.suppressEvent(false, new ArrayList<>());

--- a/CoreDataAccessView/src/au/gov/asd/tac/constellation/views/dataaccess/plugins/importing/ExtractWordsFromTextPlugin.java
+++ b/CoreDataAccessView/src/au/gov/asd/tac/constellation/views/dataaccess/plugins/importing/ExtractWordsFromTextPlugin.java
@@ -257,7 +257,7 @@ public class ExtractWordsFromTextPlugin extends SimpleQueryPlugin implements Dat
             final PluginParameter<SingleChoiceParameterValue> contentAttribute = (PluginParameter<SingleChoiceParameterValue>) parameters.getParameters().get(ATTRIBUTE_PARAMETER_ID);
             contentAttribute.suppressEvent(true, new ArrayList<>());
             SingleChoiceParameterType.setOptions(contentAttribute, attributes);
-            if (attributes.contains(ContentConcept.TransactionAttribute.CONTENT.getName())) {
+            if (contentAttribute.getSingleChoice() == null && attributes.contains(ContentConcept.TransactionAttribute.CONTENT.getName())) {
                 SingleChoiceParameterType.setChoice(contentAttribute, ContentConcept.TransactionAttribute.CONTENT.getName());
             }
             contentAttribute.suppressEvent(false, new ArrayList<>());


### PR DESCRIPTION


### Description of the Change

In `Split Nodes Plugin` in Data Access View,  if `Correlation` exists in the `Transaction Type` drop down list, it was applying "Correlation" instead of the user selected value. 
In `Extract words from text plugin`  if the `Content` is there in the `Words to Extract` drop down, it was applying "Content" instead of the user selected value. 

### Alternate Designs
N/A
<!--

Explain what other alternates were considered and why the proposed version was
selected.

-->

### Why Should This Be In Core?
Bug Fix
<!--

Explain why this functionality should be in Constellation Core as opposed to a
different module suite. Note that this question is more applicable when adding
new functionality. If this change is a minor update to an exising file then it
is understood that this change has to be to this module suite and a response
and therefore a response to this question is not required.

-->

### Benefits
Bug Fix
<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks
N/A
<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process

1. Open a graph. Open DAV and Attribute Editor
2. Rename one of the nodes to `abc;def;ghi` (identifier` in Attribute Editor)
3. In the DAV, in the `Split Nodes Plugin`, set the split character as ';' and leave the transaction type empty.
4. Ensure the renamed node is selected and run the plugin
5.  If "Correlation" exists in the  drop down list, the transaction(s) formed from the plugin should be of the type Correlation.
6. Select a  transaction type other than Correlation. In debug mode you should be able to see the text your selected.
7. Run the plugin
8. The transaction(s) formed from the plugin  should be of the type selected above. It should not overwrite the user selection.

9. Similarly in `Extract words from text plugin`  if the "Content" is there in the drop down list, it should not use "Content" instead of the user selected value. 

### Applicable Issues

https://github.com/constellation-app/constellation/issues/742
