### PR TITLE
:art: Implement quality categories

### DIFF
--- a/CoreFunctionality/src/au/gov/asd/tac/constellation/functionality/whatsnew/whatsnew.txt
+++ b/CoreFunctionality/src/au/gov/asd/tac/constellation/functionality/whatsnew/whatsnew.txt
@@ -1,6 +1,18 @@
 == 3030-12-31 Getting Started
 <p>If you're new to CONSTELLATION, read the <a href="" helpId="au.gov.asd.tac.constellation.functionality.introduction">introduction</a>.</p>
 
+== 2020-08-06 Quality Control Categories
+<p>The Quality Control View now ranks and lists the quality of an element as a category instead of a score. This is also implemented in the Data Access View.</p>
+<p>Categories can be mapped to each individual rule through the Quality Control View</p>
+<p><strong>Categories</strong> - from lowest to highest priority.</p>
+<ul>
+<li>Default</li>
+<li>Info</li>
+<li>Warning</li>
+<li>Severe</li>
+<li>Fatal</li>
+</ul>
+
 == 2020-07-23 Delimited File Importer
 <p>Dramatically improve the preview performance of a CSV file import.</p>
 

--- a/CorePreferences/src/au/gov/asd/tac/constellation/preferences/ApplicationPreferenceKeys.java
+++ b/CorePreferences/src/au/gov/asd/tac/constellation/preferences/ApplicationPreferenceKeys.java
@@ -19,6 +19,7 @@ import au.gov.asd.tac.constellation.preferences.rest.RestDirectory;
 import java.io.File;
 import java.util.prefs.Preferences;
 import javax.swing.JFileChooser;
+import org.apache.commons.lang3.StringUtils;
 import org.openide.util.Lookup;
 
 /**
@@ -174,6 +175,11 @@ public final class ApplicationPreferenceKeys {
      */
     public static final String DEFAULT_TEMPLATE = "defaultTemplate";
     public static final String DEFAULT_TEMPLATE_DEFAULT = null;
+
+    /**
+     * Quality Control View Priorities
+     */
+    public static final String RULE_PRIORITIES = StringUtils.EMPTY;
 
     private ApplicationPreferenceKeys() {
     }

--- a/CoreQualityControlView/src/au/gov/asd/tac/constellation/views/qualitycontrol/QualityControlEvent.java
+++ b/CoreQualityControlView/src/au/gov/asd/tac/constellation/views/qualitycontrol/QualityControlEvent.java
@@ -36,11 +36,11 @@ public class QualityControlEvent implements Comparable<QualityControlEvent> {
         SEVERE,
         FATAL
     }
-    public final static int DEFAULT_VALUE = 0;
-    public final static int INFO_VALUE = 10;
-    public final static int WARNING_VALUE = 30;
-    public final static int SEVERE_VALUE = 60;
-    public final static int FATAL_VALUE = 90;
+    public final static int DEFAULT_VALUE = 1;
+    public final static int INFO_VALUE = 30;
+    public final static int WARNING_VALUE = 60;
+    public final static int SEVERE_VALUE = 90;
+    public final static int FATAL_VALUE = 95;
 
     private int quality = 0;
     private final int vertex;
@@ -195,6 +195,6 @@ public class QualityControlEvent implements Comparable<QualityControlEvent> {
 
     @Override
     public int compareTo(final QualityControlEvent o) {
-        return Integer.compare(quality, o.quality);
+        return QualityControlRule.testPriority(o.getCategory(), category);
     }
 }

--- a/CoreQualityControlView/src/au/gov/asd/tac/constellation/views/qualitycontrol/QualityControlEvent.java
+++ b/CoreQualityControlView/src/au/gov/asd/tac/constellation/views/qualitycontrol/QualityControlEvent.java
@@ -29,18 +29,18 @@ import java.util.List;
  */
 public class QualityControlEvent implements Comparable<QualityControlEvent> {
 
-    public static enum QualityCategory {
+    public enum QualityCategory {
         DEFAULT,
         INFO,
         WARNING,
         SEVERE,
         FATAL
     }
-    public final static int DEFAULT_VALUE = 1;
-    public final static int INFO_VALUE = 30;
-    public final static int WARNING_VALUE = 60;
-    public final static int SEVERE_VALUE = 90;
-    public final static int FATAL_VALUE = 95;
+    public static final int DEFAULT_VALUE = 1;
+    public static final int INFO_VALUE = 30;
+    public static final int WARNING_VALUE = 60;
+    public static final int SEVERE_VALUE = 90;
+    public static final int FATAL_VALUE = 95;
 
     private int quality = 0;
     private final int vertex;

--- a/CoreQualityControlView/src/au/gov/asd/tac/constellation/views/qualitycontrol/QualityControlEvent.java
+++ b/CoreQualityControlView/src/au/gov/asd/tac/constellation/views/qualitycontrol/QualityControlEvent.java
@@ -20,6 +20,7 @@ import au.gov.asd.tac.constellation.views.qualitycontrol.rules.QualityControlRul
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import org.apache.commons.lang3.StringUtils;
 
 /**
  * QualityControlEvent for estimating the quality of the data encompassed by a
@@ -105,6 +106,50 @@ public class QualityControlEvent implements Comparable<QualityControlEvent> {
                 }
             }
         }
+    }
+
+    /**
+     * Grabs the QualityCategory represented by the string value
+     *
+     * @param category the String representation of the category
+     * @return QualityCategory enum result
+     */
+    public static QualityCategory getCategoryFromString(final String category) {
+        if (StringUtils.isNotEmpty(category)) {
+            switch (category.toLowerCase()) {
+                case "default":
+                    return QualityCategory.DEFAULT;
+                case "info":
+                    return QualityCategory.INFO;
+                case "warning":
+                    return QualityCategory.WARNING;
+                case "severe":
+                    return QualityCategory.SEVERE;
+                case "fatal":
+                    return QualityCategory.FATAL;
+                default:
+                    // default to default case when not readable.
+                    return QualityCategory.DEFAULT;
+            }
+        }
+        return QualityCategory.DEFAULT;
+    }
+
+    /**
+     * Grabs the rule loaded by lookup, if one exists with the same name.
+     *
+     * @param ruleName the name of the rule to return
+     * @return the rule object which has the same name. Null if it doesn't exist
+     */
+    public static QualityControlRule getRuleByString(final String ruleName) {
+        if (StringUtils.isNotEmpty(ruleName)) {
+            for (final QualityControlRule rule : QualityControlViewPane.getLookup().lookupAll(QualityControlRule.class)) {
+                if (ruleName.equals(rule.getName())) {
+                    return rule;
+                }
+            }
+        }
+        return null;
     }
 
     /**

--- a/CoreQualityControlView/src/au/gov/asd/tac/constellation/views/qualitycontrol/QualityControlEvent.java
+++ b/CoreQualityControlView/src/au/gov/asd/tac/constellation/views/qualitycontrol/QualityControlEvent.java
@@ -29,12 +29,26 @@ import java.util.List;
  */
 public class QualityControlEvent implements Comparable<QualityControlEvent> {
 
+    public static enum QualityCategory {
+        DEFAULT,
+        INFO,
+        WARNING,
+        SEVERE,
+        FATAL
+    }
+    public final static int DEFAULT_VALUE = 0;
+    public final static int INFO_VALUE = 10;
+    public final static int WARNING_VALUE = 30;
+    public final static int SEVERE_VALUE = 60;
+    public final static int FATAL_VALUE = 90;
+
     private int quality = 0;
     private final int vertex;
     private final String identifier;
     private final String type;
     private final List<QualityControlRule> rules;
     private final List<String> reasons;
+    private QualityCategory category = QualityCategory.DEFAULT;
 
     /**
      * Constructor for QualityControlEvent.
@@ -56,7 +70,8 @@ public class QualityControlEvent implements Comparable<QualityControlEvent> {
     /**
      * Of the given rules, find all for which the vertex might be considered to
      * have low quality, as well as the lowest quality associated with these
-     * rules.
+     * rules. Stores the category which is the new highest priority as the event
+     * basis.
      *
      * @param rules the list of rules to consider.
      * @return a list of rules that are relevant.
@@ -65,8 +80,28 @@ public class QualityControlEvent implements Comparable<QualityControlEvent> {
         for (final QualityControlRule rule : rules) {
             if (rule.getResults().contains(vertex)) {
                 reasons.add(rule.getName());
-                if (rule.getQuality(vertex) > quality) {
-                    quality = rule.getQuality(vertex);
+                if (QualityControlRule.testPriority(QualityControlViewPane.getPriorities().get(rule), category) < 0) {
+                    category = QualityControlViewPane.getPriorities().get(rule);
+
+                    switch (category) {
+                        case DEFAULT:
+                            quality = DEFAULT_VALUE;
+                            break;
+                        case INFO:
+                            quality = INFO_VALUE;
+                            break;
+                        case WARNING:
+                            quality = WARNING_VALUE;
+                            break;
+                        case SEVERE:
+                            quality = SEVERE_VALUE;
+                            break;
+                        case FATAL:
+                            quality = FATAL_VALUE;
+                            break;
+                        default:
+                            break;
+                    }
                 }
             }
         }
@@ -140,6 +175,17 @@ public class QualityControlEvent implements Comparable<QualityControlEvent> {
      */
     public int getQuality() {
         return quality;
+    }
+
+    /**
+     * Get the QualityCategory related to the category of this
+     * QualityControlEvent.
+     *
+     * @return the QualityCategory of the quality associated with this
+     * QualityControlEvent.
+     */
+    public QualityCategory getCategory() {
+        return category;
     }
 
     @Override

--- a/CoreQualityControlView/src/au/gov/asd/tac/constellation/views/qualitycontrol/QualityControlViewPane.java
+++ b/CoreQualityControlView/src/au/gov/asd/tac/constellation/views/qualitycontrol/QualityControlViewPane.java
@@ -384,13 +384,13 @@ public final class QualityControlViewPane extends BorderPane {
     private static void showPriorityDialog() {
         final ScrollPane rulesScrollPane = new ScrollPane();
         rulesScrollPane.setPrefHeight(240);
-        rulesScrollPane.setPrefWidth(500);
+        rulesScrollPane.setPrefWidth(700);
         rulesScrollPane.setVbarPolicy(ScrollPane.ScrollBarPolicy.ALWAYS);
         rulesScrollPane.setHbarPolicy(ScrollPane.ScrollBarPolicy.NEVER);
 
         final GridPane buttonGrid = new GridPane();
         buttonGrid.prefWidthProperty().bind(rulesScrollPane.widthProperty());
-        buttonGrid.setPadding(Insets.EMPTY);
+        buttonGrid.setPadding(new Insets(5, 0, 5, 0));
 
         // Setting headings
         int rowCount = 0;
@@ -428,6 +428,28 @@ public final class QualityControlViewPane extends BorderPane {
             final RadioButton warningButton = new RadioButton();
             final RadioButton severeButton = new RadioButton();
             final RadioButton fatalButton = new RadioButton();
+            final Button resetButton = new Button("Reset");
+            resetButton.setOnAction(event -> {
+                switch (rule.getCategory(0)) {
+                    case DEFAULT:
+                        defaultButton.setSelected(true);
+                        break;
+                    case INFO:
+                        infoButton.setSelected(true);
+                        break;
+                    case WARNING:
+                        warningButton.setSelected(true);
+                        break;
+                    case SEVERE:
+                        severeButton.setSelected(true);
+                        break;
+                    case FATAL:
+                        fatalButton.setSelected(true);
+                        break;
+                    default:
+                        break;
+                }
+            });
 
             getPriorities().putIfAbsent(rule, rule.getCategory(0));
             // setting the selection based on the current priority
@@ -459,6 +481,7 @@ public final class QualityControlViewPane extends BorderPane {
             GridPane.setHalignment(warningButton, HPos.CENTER);
             GridPane.setHalignment(severeButton, HPos.CENTER);
             GridPane.setHalignment(fatalButton, HPos.CENTER);
+            GridPane.setHalignment(resetButton, HPos.CENTER);
 
             ruleName.setPadding(new Insets(0, 0, 5, 5));
             defaultButton.setPadding(new Insets(0, 10, 5, 10));
@@ -466,6 +489,7 @@ public final class QualityControlViewPane extends BorderPane {
             warningButton.setPadding(new Insets(0, 10, 5, 10));
             severeButton.setPadding(new Insets(0, 10, 5, 10));
             fatalButton.setPadding(new Insets(0, 10, 5, 10));
+            resetButton.setPadding(new Insets(5, 10, 5, 10));
 
             defaultButton.setUserData(QualityCategory.DEFAULT);
             infoButton.setUserData(QualityCategory.INFO);
@@ -487,6 +511,7 @@ public final class QualityControlViewPane extends BorderPane {
             buttonGrid.add(warningButton, 3, rowCount);
             buttonGrid.add(severeButton, 4, rowCount);
             buttonGrid.add(fatalButton, 5, rowCount);
+            buttonGrid.add(resetButton, 6, rowCount);
 
             rowCount++;
         }
@@ -496,7 +521,8 @@ public final class QualityControlViewPane extends BorderPane {
         final Alert alert = new Alert(Alert.AlertType.INFORMATION,
                 "Select Rule Priorities",
                 ButtonType.OK, ButtonType.CANCEL);
-        alert.setHeaderText("Priority defines category levels for each rule");
+        alert.setTitle("Select Rule Priorities");
+        alert.setHeaderText("Customise the priority of rules");
         alert.getDialogPane().setContent(rulesScrollPane);
         alert.setResizable(true);
 

--- a/CoreQualityControlView/src/au/gov/asd/tac/constellation/views/qualitycontrol/QualityControlViewPane.java
+++ b/CoreQualityControlView/src/au/gov/asd/tac/constellation/views/qualitycontrol/QualityControlViewPane.java
@@ -44,7 +44,6 @@ import javafx.collections.FXCollections;
 import javafx.geometry.HPos;
 import javafx.geometry.Insets;
 import javafx.geometry.Pos;
-import javafx.scene.Node;
 import javafx.scene.control.Alert;
 import javafx.scene.control.Button;
 import javafx.scene.control.ButtonType;
@@ -232,7 +231,7 @@ public final class QualityControlViewPane extends BorderPane {
                     if (value.getClickCount() == 2) {
                         @SuppressWarnings("unchecked") //sourceCell will be a Table cell of quality control events which extends from object type
                         final TableCell<QualityControlEvent, QualityControlEvent> sourceCell = (TableCell<QualityControlEvent, QualityControlEvent>) value.getSource();
-                        showRuleDialog(qualityTable, sourceCell);
+                        showRuleDialog(sourceCell);
                     }
                 });
 
@@ -255,7 +254,7 @@ public final class QualityControlViewPane extends BorderPane {
                     if (value.getClickCount() == 2) {
                         @SuppressWarnings("unchecked") //sourceCell will be a Table cell of quality control events which extends from object type
                         final TableCell<QualityControlEvent, QualityControlEvent> sourceCell = (TableCell<QualityControlEvent, QualityControlEvent>) value.getSource();
-                        showRuleDialog(qualityTable, sourceCell);
+                        showRuleDialog(sourceCell);
                     }
                 });
 
@@ -279,7 +278,7 @@ public final class QualityControlViewPane extends BorderPane {
                     if (value.getClickCount() == 2) {
                         @SuppressWarnings("unchecked") //sourceCell will be a Table cell of quality control events which extends from object type
                         final TableCell<QualityControlEvent, QualityControlEvent> sourceCell = (TableCell<QualityControlEvent, QualityControlEvent>) value.getSource();
-                        showRuleDialog(qualityTable, sourceCell);
+                        showRuleDialog(sourceCell);
                     }
                 });
 
@@ -302,7 +301,7 @@ public final class QualityControlViewPane extends BorderPane {
                     if (value.getClickCount() == 2) {
                         @SuppressWarnings("unchecked") //sourceCell will be a Table cell of quality control events which extends from object type
                         final TableCell<QualityControlEvent, QualityControlEvent> sourceCell = (TableCell<QualityControlEvent, QualityControlEvent>) value.getSource();
-                        showRuleDialog(qualityTable, sourceCell);
+                        showRuleDialog(sourceCell);
                     }
                 });
 
@@ -340,16 +339,13 @@ public final class QualityControlViewPane extends BorderPane {
      * @return a javafx style based on the given quality and alpha values.
      */
     public static String qualityStyle(final QualityCategory category, final float alpha) {
+        final String whiteText = "-fx-text-fill: rgb(0,0,0);-fx-background-color: rgba(%d,%d,255,%f);";
         final int intensity;
         final String style;
         switch (category) {
-            case DEFAULT:
-                intensity = 255 - (255 * QualityControlEvent.DEFAULT_VALUE) / 100;
-                style = String.format("-fx-text-fill: rgb(0,0,0);-fx-background-color: rgba(%d,%d,255,%f);", intensity, intensity, alpha);
-                break;
             case INFO:
                 intensity = 255 - (255 * QualityControlEvent.INFO_VALUE) / 100;
-                style = String.format("-fx-text-fill: rgb(0,0,0);-fx-background-color: rgba(%d,%d,255,%f);", intensity, intensity, alpha);
+                style = String.format(whiteText, intensity, intensity, alpha);
                 break;
             case WARNING:
                 intensity = 255 - (255 * QualityControlEvent.WARNING_VALUE) / 100;
@@ -364,9 +360,9 @@ public final class QualityControlViewPane extends BorderPane {
                 style = String.format("-fx-text-fill: rgb(255,255,255);-fx-background-color: rgba(0,%d,%d,%f);", intensity, intensity, alpha);
                 break;
             default:
-                // Default case
+                // DEFAULT case
                 intensity = 255 - (255 * QualityControlEvent.DEFAULT_VALUE) / 100;
-                style = String.format("-fx-text-fill: rgb(0,0,0);-fx-background-color: rgba(%d,%d,255,%f);", intensity, intensity, alpha);
+                style = String.format(whiteText, intensity, intensity, alpha);
                 break;
         }
 
@@ -515,7 +511,7 @@ public final class QualityControlViewPane extends BorderPane {
      * @param owner
      * @param qcevent
      */
-    private static void showRuleDialog(final Node owner, final TableCell<QualityControlEvent, QualityControlEvent> qcevent) {
+    private static void showRuleDialog(final TableCell<QualityControlEvent, QualityControlEvent> qcevent) {
         if (qcevent.getItem() != null) {
             final int vxId = qcevent.getItem().getVertex();
             final String identifier = qcevent.getItem().getIdentifier();
@@ -538,7 +534,7 @@ public final class QualityControlViewPane extends BorderPane {
                 return compare;
             });
 
-            showRuleDialog(owner, identifier, rules);
+            showRuleDialog(identifier, rules);
         }
     }
 
@@ -550,7 +546,7 @@ public final class QualityControlViewPane extends BorderPane {
      * @param identifier The identifier of the graph node being displayed.
      * @param rules The list of rules measured against this graph node.
      */
-    private static void showRuleDialog(final Node owner, final String identifier, final List<Pair<QualityCategory, String>> rules) {
+    private static void showRuleDialog(final String identifier, final List<Pair<QualityCategory, String>> rules) {
         final ScrollPane sp = new ScrollPane();
         sp.setPrefHeight(512);
         sp.setPrefWidth(512);

--- a/CoreQualityControlView/src/au/gov/asd/tac/constellation/views/qualitycontrol/QualityControlViewPane.java
+++ b/CoreQualityControlView/src/au/gov/asd/tac/constellation/views/qualitycontrol/QualityControlViewPane.java
@@ -71,6 +71,7 @@ import javafx.scene.layout.VBox;
 import javafx.scene.text.Text;
 import javafx.util.Callback;
 import javafx.util.Pair;
+import org.apache.commons.collections.MapUtils;
 import org.openide.util.Exceptions;
 import org.openide.util.Lookup;
 import org.openide.util.NbBundle.Messages;
@@ -633,7 +634,7 @@ public final class QualityControlViewPane extends BorderPane {
      * categories
      */
     public static Map<QualityControlRule, QualityCategory> getPriorities() {
-        if (rulePriorities == null) {
+        if (MapUtils.isEmpty(rulePriorities)) {
             rulePriorities = new HashMap<>();
             for (final QualityControlRule rule : getLookup().lookupAll(QualityControlRule.class)) {
                 rulePriorities.put(rule, rule.getCategory(0));

--- a/CoreQualityControlView/src/au/gov/asd/tac/constellation/views/qualitycontrol/QualityControlViewPane.java
+++ b/CoreQualityControlView/src/au/gov/asd/tac/constellation/views/qualitycontrol/QualityControlViewPane.java
@@ -223,7 +223,7 @@ public final class QualityControlViewPane extends BorderPane {
                         super.updateItem(item, empty);
                         if (item != null) {
                             setText(item.getIdentifier());
-                            setStyle(qualityStyle(item.getQuality()));
+                            setStyle(qualityStyle(item.getCategory()));
                         }
                     }
                 };
@@ -246,7 +246,7 @@ public final class QualityControlViewPane extends BorderPane {
                         super.updateItem(item, empty);
                         if (item != null) {
                             setText(item.getType());
-                            setStyle(qualityStyle(item.getQuality()));
+                            setStyle(qualityStyle(item.getCategory()));
                         }
                     }
                 };
@@ -270,7 +270,7 @@ public final class QualityControlViewPane extends BorderPane {
                         if (item != null) {
                             setText(item.getCategory() == QualityCategory.DEFAULT ? Bundle.MSG_NotApplicable() : String.valueOf(item.getCategory().name()));
                             setAlignment(Pos.CENTER);
-                            setStyle(qualityStyle(item.getQuality()));
+                            setStyle(qualityStyle(item.getCategory()));
                         }
                     }
                 };
@@ -293,7 +293,7 @@ public final class QualityControlViewPane extends BorderPane {
                         super.updateItem(item, empty);
                         if (item != null) {
                             setText(item.getReasons());
-                            setStyle(qualityStyle(item.getQuality()));
+                            setStyle(qualityStyle(item.getCategory()));
                         }
                     }
                 };
@@ -328,8 +328,8 @@ public final class QualityControlViewPane extends BorderPane {
      * @param quality the quality.
      * @return a javafx style based on the given quality value.
      */
-    public static String qualityStyle(final int quality) {
-        return qualityStyle(quality, 0.75f);
+    public static String qualityStyle(final QualityCategory category) {
+        return qualityStyle(category, 0.75f);
     }
 
     /**
@@ -339,18 +339,35 @@ public final class QualityControlViewPane extends BorderPane {
      * @param alpha the alpha value.
      * @return a javafx style based on the given quality and alpha values.
      */
-    public static String qualityStyle(final int quality, final float alpha) {
-        final int intensity = 255 - (255 * quality) / 100;
+    public static String qualityStyle(final QualityCategory category, final float alpha) {
+        final int intensity;
         final String style;
-
-        if (quality >= 60 && quality < 90) {
-            style = String.format("-fx-text-fill: rgb(255,255,255);-fx-background-color: rgba(%d,%d,255,%f);", intensity, intensity, alpha);
-        } else if (quality >= 95) {
-            style = String.format("-fx-text-fill: rgb(255,255,255);-fx-background-color: rgba(0,%d,%d,%f);", intensity, intensity, alpha);
-        } else if (quality >= 90) {
-            style = String.format("-fx-text-fill: rgb(0,0,0);-fx-background-color: rgba(255,%d,%d,%f);", intensity, intensity, alpha);
-        } else {
-            style = String.format("-fx-text-fill: rgb(0,0,0);-fx-background-color: rgba(%d,%d,255,%f);", intensity, intensity, alpha);
+        switch (category) {
+            case DEFAULT:
+                intensity = 255 - (255 * QualityControlEvent.DEFAULT_VALUE) / 100;
+                style = String.format("-fx-text-fill: rgb(0,0,0);-fx-background-color: rgba(%d,%d,255,%f);", intensity, intensity, alpha);
+                break;
+            case INFO:
+                intensity = 255 - (255 * QualityControlEvent.INFO_VALUE) / 100;
+                style = String.format("-fx-text-fill: rgb(0,0,0);-fx-background-color: rgba(%d,%d,255,%f);", intensity, intensity, alpha);
+                break;
+            case WARNING:
+                intensity = 255 - (255 * QualityControlEvent.WARNING_VALUE) / 100;
+                style = String.format("-fx-text-fill: rgb(255,255,255);-fx-background-color: rgba(%d,%d,255,%f);", intensity, intensity, alpha);
+                break;
+            case SEVERE:
+                intensity = 255 - (255 * QualityControlEvent.SEVERE_VALUE) / 100;
+                style = String.format("-fx-text-fill: rgb(0,0,0);-fx-background-color: rgba(255,%d,%d,%f);", intensity, intensity, alpha);
+                break;
+            case FATAL:
+                intensity = 255 - (255 * QualityControlEvent.FATAL_VALUE) / 100;
+                style = String.format("-fx-text-fill: rgb(255,255,255);-fx-background-color: rgba(0,%d,%d,%f);", intensity, intensity, alpha);
+                break;
+            default:
+                // Default case
+                intensity = 255 - (255 * QualityControlEvent.DEFAULT_VALUE) / 100;
+                style = String.format("-fx-text-fill: rgb(0,0,0);-fx-background-color: rgba(%d,%d,255,%f);", intensity, intensity, alpha);
+                break;
         }
 
         return style;
@@ -476,9 +493,9 @@ public final class QualityControlViewPane extends BorderPane {
         rulesScrollPane.setContent(buttonGrid);
 
         final Alert alert = new Alert(Alert.AlertType.INFORMATION,
-                "Priority defines severity levels for each rule",
+                "Select Rule Priorities",
                 ButtonType.OK, ButtonType.CANCEL);
-        alert.setTitle("Select Rule Priorities");
+        alert.setHeaderText("Priority defines category levels for each rule");
         alert.getDialogPane().setContent(rulesScrollPane);
         alert.setResizable(true);
 

--- a/CoreQualityControlView/src/au/gov/asd/tac/constellation/views/qualitycontrol/QualityControlViewTopComponent.java
+++ b/CoreQualityControlView/src/au/gov/asd/tac/constellation/views/qualitycontrol/QualityControlViewTopComponent.java
@@ -62,7 +62,7 @@ public final class QualityControlViewTopComponent extends JavaFxTopComponent<Qua
 
         initComponents();
 
-        qualityControlViewPane = new QualityControlViewPane(QualityControlViewTopComponent.this);
+        qualityControlViewPane = new QualityControlViewPane();
         initContent();
     }
 

--- a/CoreQualityControlView/src/au/gov/asd/tac/constellation/views/qualitycontrol/daemon/QualityControlAutoVetter.java
+++ b/CoreQualityControlView/src/au/gov/asd/tac/constellation/views/qualitycontrol/daemon/QualityControlAutoVetter.java
@@ -164,6 +164,23 @@ public final class QualityControlAutoVetter implements GraphManagerListener, Gra
     }
 
     /**
+     * Triggers an update of the QualityControlEvent as well as notifies
+     * listeners. This is used when the priority of categories is changed.
+     */
+    public void updateQualityEvents() {
+        final Graph graph = currentGraph;
+        if (graph != null) {
+            final ReadableGraph readableGraph = graph.getReadableGraph();
+            try {
+                updateQualityControlState(graph);
+            } finally {
+                readableGraph.release();
+            }
+            listeners.stream().forEach(listener -> listener.qualityControlChanged(state));
+        }
+    }
+
+    /**
      * Build a new QualityControlState with an updated list of
      * QualityControlEvent.
      *

--- a/CoreQualityControlView/src/au/gov/asd/tac/constellation/views/qualitycontrol/rules/QualityControlRule.java
+++ b/CoreQualityControlView/src/au/gov/asd/tac/constellation/views/qualitycontrol/rules/QualityControlRule.java
@@ -31,9 +31,9 @@ import org.openide.util.Lookup;
  */
 public abstract class QualityControlRule {
 
-    private final static int CATEGORY_1_HIGHER = -1;
-    private final static int CATEGORY_2_HIGHER = 1;
-    private final static int CATEGORIES_EQUAL = 0;
+    private static final int CATEGORY_1_HIGHER = -1;
+    private static final int CATEGORY_2_HIGHER = 1;
+    private static final int CATEGORIES_EQUAL = 0;
 
     /**
      * Test the priority between the two categories and determine which priority

--- a/CoreQualityControlView/src/au/gov/asd/tac/constellation/views/qualitycontrol/rules/QualityControlRule.java
+++ b/CoreQualityControlView/src/au/gov/asd/tac/constellation/views/qualitycontrol/rules/QualityControlRule.java
@@ -16,6 +16,8 @@
 package au.gov.asd.tac.constellation.views.qualitycontrol.rules;
 
 import au.gov.asd.tac.constellation.graph.GraphReadMethods;
+import au.gov.asd.tac.constellation.views.qualitycontrol.QualityControlEvent;
+import au.gov.asd.tac.constellation.views.qualitycontrol.QualityControlEvent.QualityCategory;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -28,6 +30,73 @@ import org.openide.util.Lookup;
  * @author cygnus_x-1
  */
 public abstract class QualityControlRule {
+
+    private final static int CATEGORY_1_HIGHER = -1;
+    private final static int CATEGORY_2_HIGHER = 1;
+    private final static int CATEGORIES_EQUAL = 0;
+
+    /**
+     * Test the priority between the two categories and determine which priority
+     * is highest.
+     *
+     * @param category1 the QualityCategory to compare with category2
+     * @param category2 the QualityCategory to compare with category1
+     * @return an Integer as follows below.
+     * <p>
+     * -1 if category1 is higher priority
+     * <p>
+     * 0 if both categories are the same priority
+     * <p>
+     * 1 if category2 is higher priority
+     */
+    public static int testPriority(final QualityCategory category1, final QualityCategory category2) {
+        // both same category
+        if (category1 == category2) {
+            return CATEGORIES_EQUAL;
+        }
+        // rule1 is never going to be higher than rule 2
+        if (category1 == QualityCategory.DEFAULT) {
+            return CATEGORY_2_HIGHER;
+        }
+        // rule2 is never going to be higher than rule 1
+        if (category2 == QualityCategory.DEFAULT) {
+            return CATEGORY_1_HIGHER;
+        }
+
+        // rule1 is always going to be higher than rule 2
+        if (category1 == QualityCategory.FATAL) {
+            return CATEGORY_1_HIGHER;
+        }
+        // rule2 is always going to be higher than rule 1
+        if (category2 == QualityCategory.FATAL) {
+            return CATEGORY_2_HIGHER;
+        }
+
+        // rule1 is info, so rule 2 cannot be default, and is not info because
+        // it is not equal to rule 1.
+        if (category1 == QualityCategory.INFO) {
+            return CATEGORY_2_HIGHER;
+        }
+        // rule 1 is warning, so rule 2 could be info, severe or fatal
+        if (category1 == QualityCategory.WARNING) {
+            if (category2 == QualityCategory.INFO) {
+                return CATEGORY_1_HIGHER;
+            }
+            // if not info, then it is higher than warning
+            return CATEGORY_2_HIGHER;
+        }
+        // if severe, rule2 could be info, warning, fatal
+        if (category1 == QualityCategory.SEVERE) {
+            // if rule2 is fatal, it is higher priority
+            if (category2 == QualityCategory.FATAL) {
+                return CATEGORY_2_HIGHER;
+            }
+            // if not fatal, must be lower.
+            return CATEGORY_1_HIGHER;
+        }
+        // default return false
+        return CATEGORY_2_HIGHER;
+    }
 
     protected Set<Integer> results;
 
@@ -98,6 +167,22 @@ public abstract class QualityControlRule {
      * vertex.
      */
     public abstract int getQuality(final int vertexId);
+
+    public QualityCategory getCategory(final int vertexId) {
+        final int qualityScore = getQuality(vertexId);
+        if (qualityScore >= QualityControlEvent.FATAL_VALUE) {
+            return QualityCategory.FATAL;
+        } else if (qualityScore >= QualityControlEvent.SEVERE_VALUE) {
+            return QualityCategory.SEVERE;
+        } else if (qualityScore >= QualityControlEvent.WARNING_VALUE) {
+            return QualityCategory.WARNING;
+        } else if (qualityScore >= QualityControlEvent.INFO_VALUE) {
+            return QualityCategory.INFO;
+        } else {
+            return QualityCategory.DEFAULT;
+        }
+
+    }
 
     /**
      * Execute the logic of this Rule against a single vertex and return a

--- a/CoreQualityControlView/src/au/gov/asd/tac/constellation/views/qualitycontrol/rules/QualityControlRule.java
+++ b/CoreQualityControlView/src/au/gov/asd/tac/constellation/views/qualitycontrol/rules/QualityControlRule.java
@@ -168,8 +168,33 @@ public abstract class QualityControlRule {
      */
     public abstract int getQuality(final int vertexId);
 
+    /**
+     * Overridden toString() used for serializing objects
+     *
+     * @return the String representation of this object
+     */
+    @Override
+    public String toString() {
+        return getName();
+    }
+
+    /**
+     * Get the QualityCategory which maps to the current score
+     *
+     * @param vertexId the vertex to fetch the quality for
+     * @return QualityCategory for the vertex
+     */
     public QualityCategory getCategory(final int vertexId) {
-        final int qualityScore = getQuality(vertexId);
+        return getCategoryByScore(getQuality(vertexId));
+    }
+
+    /**
+     * Get the QualityCategory which maps to the int qualityScore
+     *
+     * @param qualityScore the int value of the rule
+     * @return QualityCategory relating to the qualityScore given.
+     */
+    public static QualityCategory getCategoryByScore(final int qualityScore) {
         if (qualityScore >= QualityControlEvent.FATAL_VALUE) {
             return QualityCategory.FATAL;
         } else if (qualityScore >= QualityControlEvent.SEVERE_VALUE) {
@@ -181,7 +206,6 @@ public abstract class QualityControlRule {
         } else {
             return QualityCategory.DEFAULT;
         }
-
     }
 
     /**

--- a/CoreQualityControlView/src/au/gov/asd/tac/constellation/views/qualitycontrol/widget/DefaultQualityControlAutoButton.java
+++ b/CoreQualityControlView/src/au/gov/asd/tac/constellation/views/qualitycontrol/widget/DefaultQualityControlAutoButton.java
@@ -82,7 +82,7 @@ public final class DefaultQualityControlAutoButton extends QualityControlAutoBut
         final String styleText;
         final String tooltipText;
         if (event != null && event.getQuality() > 0) {
-            riskText = String.format(QUALITY_CONTROL_WIDGET_TEXT, String.valueOf(event.getQuality()));
+            riskText = String.format(QUALITY_CONTROL_WIDGET_TEXT, String.valueOf(event.getCategory().name()));
             styleText = QualityControlViewPane.qualityStyle(event.getQuality(), 1);
             tooltipText = event.getReasons();
         } else {

--- a/CoreQualityControlView/src/au/gov/asd/tac/constellation/views/qualitycontrol/widget/DefaultQualityControlAutoButton.java
+++ b/CoreQualityControlView/src/au/gov/asd/tac/constellation/views/qualitycontrol/widget/DefaultQualityControlAutoButton.java
@@ -18,6 +18,7 @@ package au.gov.asd.tac.constellation.views.qualitycontrol.widget;
 import au.gov.asd.tac.constellation.utilities.font.FontUtilities;
 import au.gov.asd.tac.constellation.utilities.javafx.JavafxStyleManager;
 import au.gov.asd.tac.constellation.views.qualitycontrol.QualityControlEvent;
+import au.gov.asd.tac.constellation.views.qualitycontrol.QualityControlEvent.QualityCategory;
 import au.gov.asd.tac.constellation.views.qualitycontrol.QualityControlViewPane;
 import au.gov.asd.tac.constellation.views.qualitycontrol.QualityControlViewTopComponent;
 import au.gov.asd.tac.constellation.views.qualitycontrol.daemon.QualityControlAutoVetter;
@@ -81,9 +82,9 @@ public final class DefaultQualityControlAutoButton extends QualityControlAutoBut
         final String riskText;
         final String styleText;
         final String tooltipText;
-        if (event != null && event.getQuality() > 0) {
+        if (event != null && event.getCategory() != QualityCategory.DEFAULT) {
             riskText = String.format(QUALITY_CONTROL_WIDGET_TEXT, String.valueOf(event.getCategory().name()));
-            styleText = QualityControlViewPane.qualityStyle(event.getQuality(), 1);
+            styleText = QualityControlViewPane.qualityStyle(event.getCategory(), 1);
             tooltipText = event.getReasons();
         } else {
             riskText = String.format(QUALITY_CONTROL_WIDGET_TEXT, Bundle.MSG_NoRisk());

--- a/CoreQualityControlView/test/unit/src/au/gov/asd/tac/constellation/views/qualitycontrol/event/QualityControlEventNGTest.java
+++ b/CoreQualityControlView/test/unit/src/au/gov/asd/tac/constellation/views/qualitycontrol/event/QualityControlEventNGTest.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2010-2020 Australian Signals Directorate
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package au.gov.asd.tac.constellation.views.qualitycontrol.event;
+
+import au.gov.asd.tac.constellation.views.qualitycontrol.QualityControlEvent;
+import au.gov.asd.tac.constellation.views.qualitycontrol.rules.*;
+import org.testng.Assert;
+import static org.testng.Assert.assertEquals;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+/**
+ * QualityControlEvent Test.
+ *
+ * @author aldebaran30701
+ */
+public class QualityControlEventNGTest {
+
+    private final static QualityControlEvent.QualityCategory DEFAULT = QualityControlEvent.QualityCategory.DEFAULT;
+    private final static QualityControlEvent.QualityCategory INFO = QualityControlEvent.QualityCategory.INFO;
+    private final static QualityControlEvent.QualityCategory WARNING = QualityControlEvent.QualityCategory.WARNING;
+    private final static QualityControlEvent.QualityCategory SEVERE = QualityControlEvent.QualityCategory.SEVERE;
+    private final static QualityControlEvent.QualityCategory FATAL = QualityControlEvent.QualityCategory.FATAL;
+
+    public QualityControlEventNGTest() {
+    }
+
+    @BeforeClass
+    public static void setUpClass() throws Exception {
+    }
+
+    @AfterClass
+    public static void tearDownClass() throws Exception {
+    }
+
+    @BeforeMethod
+    public void setUpMethod() throws Exception {
+    }
+
+    @AfterMethod
+    public void tearDownMethod() throws Exception {
+    }
+
+    /**
+     * Test of getCategoryFromString method, of class QualityControlEvent.
+     */
+    @Test
+    public void testGetCategoryFromString() {
+        String categoryString = "default";
+
+        // DEFAULT test
+        assertEquals(QualityControlEvent.getCategoryFromString(categoryString), DEFAULT);
+        categoryString = "DEFAULT";
+        assertEquals(QualityControlEvent.getCategoryFromString(categoryString), DEFAULT);
+        categoryString = "DEFAULTA";
+        assertEquals(QualityControlEvent.getCategoryFromString(categoryString), DEFAULT);
+        categoryString = "ADEFAULT";
+        assertEquals(QualityControlEvent.getCategoryFromString(categoryString), DEFAULT);
+
+        // INFO test
+        categoryString = "info";
+        assertEquals(QualityControlEvent.getCategoryFromString(categoryString), INFO);
+        categoryString = "INFO";
+        assertEquals(QualityControlEvent.getCategoryFromString(categoryString), INFO);
+        categoryString = "INFOA";
+        assertEquals(QualityControlEvent.getCategoryFromString(categoryString), DEFAULT);
+        categoryString = "AINFO";
+        assertEquals(QualityControlEvent.getCategoryFromString(categoryString), DEFAULT);
+
+        // WARNING test
+        categoryString = "warning";
+        assertEquals(QualityControlEvent.getCategoryFromString(categoryString), WARNING);
+        categoryString = "WARNING";
+        assertEquals(QualityControlEvent.getCategoryFromString(categoryString), WARNING);
+        categoryString = "WARNINGA";
+        assertEquals(QualityControlEvent.getCategoryFromString(categoryString), DEFAULT);
+        categoryString = "AWARNING";
+        assertEquals(QualityControlEvent.getCategoryFromString(categoryString), DEFAULT);
+
+        // SEVERE test
+        categoryString = "severe";
+        assertEquals(QualityControlEvent.getCategoryFromString(categoryString), SEVERE);
+        categoryString = "SEVERE";
+        assertEquals(QualityControlEvent.getCategoryFromString(categoryString), SEVERE);
+        categoryString = "SEVEREA";
+        assertEquals(QualityControlEvent.getCategoryFromString(categoryString), DEFAULT);
+        categoryString = "ASEVERE";
+        assertEquals(QualityControlEvent.getCategoryFromString(categoryString), DEFAULT);
+
+        // FATAL test
+        categoryString = "fatal";
+        assertEquals(QualityControlEvent.getCategoryFromString(categoryString), FATAL);
+        categoryString = "FATAL";
+        assertEquals(QualityControlEvent.getCategoryFromString(categoryString), FATAL);
+        categoryString = "FATALA";
+        assertEquals(QualityControlEvent.getCategoryFromString(categoryString), DEFAULT);
+        categoryString = "AFATAL";
+        assertEquals(QualityControlEvent.getCategoryFromString(categoryString), DEFAULT);
+    }
+
+    /**
+     * Test of getRuleByString method, of class QualityControlRule.
+     *
+     */
+    @Test
+    public void testGetRuleByString() {
+
+        // Test missing type rule
+        MissingTypeRule missingRule = new MissingTypeRule();
+        String ruleName = missingRule.getName();
+        assertEquals(QualityControlEvent.getRuleByString(ruleName).getClass(), missingRule.getClass());
+
+        // Test unknown type rule
+        UnknownTypeRule unknownRule = new UnknownTypeRule();
+        ruleName = unknownRule.getName();
+        assertEquals(QualityControlEvent.getRuleByString(ruleName).getClass(), unknownRule.getClass());
+
+        // Test IdentifierInconsistentWithTypeRule
+        IdentifierInconsistentWithTypeRule inconsistentRule = new IdentifierInconsistentWithTypeRule();
+        ruleName = inconsistentRule.getName();
+        assertEquals(QualityControlEvent.getRuleByString(ruleName).getClass(), inconsistentRule.getClass());
+
+        // Test empty string
+        Assert.assertNull(QualityControlEvent.getRuleByString(""));
+
+        // Test blank string
+        Assert.assertNull(QualityControlEvent.getRuleByString(" "));
+    }
+}

--- a/CoreQualityControlView/test/unit/src/au/gov/asd/tac/constellation/views/qualitycontrol/rules/QualityControlRuleNGTest.java
+++ b/CoreQualityControlView/test/unit/src/au/gov/asd/tac/constellation/views/qualitycontrol/rules/QualityControlRuleNGTest.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright 2010-2020 Australian Signals Directorate
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package au.gov.asd.tac.constellation.views.qualitycontrol.rules;
+
+import au.gov.asd.tac.constellation.views.qualitycontrol.QualityControlEvent;
+import static org.testng.Assert.assertEquals;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+/**
+ * QualityControlRule Test.
+ *
+ * @author aldebaran30701
+ */
+public class QualityControlRuleNGTest {
+
+    public QualityControlRuleNGTest() {
+    }
+
+    @BeforeClass
+    public static void setUpClass() throws Exception {
+    }
+
+    @AfterClass
+    public static void tearDownClass() throws Exception {
+    }
+
+    @BeforeMethod
+    public void setUpMethod() throws Exception {
+    }
+
+    @AfterMethod
+    public void tearDownMethod() throws Exception {
+    }
+
+    /**
+     * Test of testPriority method, of class QualityControlRule.
+     */
+    @Test
+    public void testPriority() {
+        final int cat1Higher = -1;
+        final int catEqual = 0;
+        final int cat2Higher = 1;
+
+        // Test categories are equal
+        assertEquals(QualityControlRule.testPriority(QualityControlEvent.QualityCategory.FATAL,
+                QualityControlEvent.QualityCategory.FATAL), catEqual);
+        assertEquals(QualityControlRule.testPriority(QualityControlEvent.QualityCategory.SEVERE,
+                QualityControlEvent.QualityCategory.SEVERE), catEqual);
+        assertEquals(QualityControlRule.testPriority(QualityControlEvent.QualityCategory.WARNING,
+                QualityControlEvent.QualityCategory.WARNING), catEqual);
+        assertEquals(QualityControlRule.testPriority(QualityControlEvent.QualityCategory.INFO,
+                QualityControlEvent.QualityCategory.INFO), catEqual);
+        assertEquals(QualityControlRule.testPriority(QualityControlEvent.QualityCategory.DEFAULT,
+                QualityControlEvent.QualityCategory.DEFAULT), catEqual);
+
+        // Test category 1 is higher
+        assertEquals(QualityControlRule.testPriority(QualityControlEvent.QualityCategory.FATAL,
+                QualityControlEvent.QualityCategory.SEVERE), cat1Higher);
+        assertEquals(QualityControlRule.testPriority(QualityControlEvent.QualityCategory.SEVERE,
+                QualityControlEvent.QualityCategory.WARNING), cat1Higher);
+        assertEquals(QualityControlRule.testPriority(QualityControlEvent.QualityCategory.WARNING,
+                QualityControlEvent.QualityCategory.INFO), cat1Higher);
+        assertEquals(QualityControlRule.testPriority(QualityControlEvent.QualityCategory.INFO,
+                QualityControlEvent.QualityCategory.DEFAULT), cat1Higher);
+        assertEquals(QualityControlRule.testPriority(QualityControlEvent.QualityCategory.FATAL,
+                QualityControlEvent.QualityCategory.WARNING), cat1Higher);
+        assertEquals(QualityControlRule.testPriority(QualityControlEvent.QualityCategory.SEVERE,
+                QualityControlEvent.QualityCategory.INFO), cat1Higher);
+        assertEquals(QualityControlRule.testPriority(QualityControlEvent.QualityCategory.WARNING,
+                QualityControlEvent.QualityCategory.DEFAULT), cat1Higher);
+        assertEquals(QualityControlRule.testPriority(QualityControlEvent.QualityCategory.FATAL,
+                QualityControlEvent.QualityCategory.INFO), cat1Higher);
+        assertEquals(QualityControlRule.testPriority(QualityControlEvent.QualityCategory.SEVERE,
+                QualityControlEvent.QualityCategory.DEFAULT), cat1Higher);
+        assertEquals(QualityControlRule.testPriority(QualityControlEvent.QualityCategory.FATAL,
+                QualityControlEvent.QualityCategory.DEFAULT), cat1Higher);
+
+        // Test category 2 is higher
+        assertEquals(QualityControlRule.testPriority(QualityControlEvent.QualityCategory.SEVERE,
+                QualityControlEvent.QualityCategory.FATAL), cat2Higher);
+        assertEquals(QualityControlRule.testPriority(QualityControlEvent.QualityCategory.WARNING,
+                QualityControlEvent.QualityCategory.SEVERE), cat2Higher);
+        assertEquals(QualityControlRule.testPriority(QualityControlEvent.QualityCategory.INFO,
+                QualityControlEvent.QualityCategory.WARNING), cat2Higher);
+        assertEquals(QualityControlRule.testPriority(QualityControlEvent.QualityCategory.DEFAULT,
+                QualityControlEvent.QualityCategory.INFO), cat2Higher);
+        assertEquals(QualityControlRule.testPriority(QualityControlEvent.QualityCategory.WARNING,
+                QualityControlEvent.QualityCategory.FATAL), cat2Higher);
+        assertEquals(QualityControlRule.testPriority(QualityControlEvent.QualityCategory.INFO,
+                QualityControlEvent.QualityCategory.SEVERE), cat2Higher);
+        assertEquals(QualityControlRule.testPriority(QualityControlEvent.QualityCategory.DEFAULT,
+                QualityControlEvent.QualityCategory.WARNING), cat2Higher);
+        assertEquals(QualityControlRule.testPriority(QualityControlEvent.QualityCategory.INFO,
+                QualityControlEvent.QualityCategory.FATAL), cat2Higher);
+        assertEquals(QualityControlRule.testPriority(QualityControlEvent.QualityCategory.DEFAULT,
+                QualityControlEvent.QualityCategory.SEVERE), cat2Higher);
+        assertEquals(QualityControlRule.testPriority(QualityControlEvent.QualityCategory.DEFAULT,
+                QualityControlEvent.QualityCategory.FATAL), cat2Higher);
+    }
+
+    /**
+     * Test of getCategoryByScore method, of class QualityControlRule.
+     *
+     */
+    @Test
+    public void testGetCategoryByScore() {
+        assertEquals(QualityControlRule.getCategoryByScore(QualityControlEvent.DEFAULT_VALUE - 1),
+                QualityControlEvent.QualityCategory.DEFAULT); // ONE BELOW
+        assertEquals(QualityControlRule.getCategoryByScore(QualityControlEvent.DEFAULT_VALUE),
+                QualityControlEvent.QualityCategory.DEFAULT); // ON VALUE
+        assertEquals(QualityControlRule.getCategoryByScore(QualityControlEvent.DEFAULT_VALUE + 1),
+                QualityControlEvent.QualityCategory.DEFAULT); // ONE ABOVE
+
+        assertEquals(QualityControlRule.getCategoryByScore(QualityControlEvent.INFO_VALUE - 1),
+                QualityControlEvent.QualityCategory.DEFAULT); // ONE BELOW
+        assertEquals(QualityControlRule.getCategoryByScore(QualityControlEvent.INFO_VALUE),
+                QualityControlEvent.QualityCategory.INFO); // ON VALUE
+        assertEquals(QualityControlRule.getCategoryByScore(QualityControlEvent.INFO_VALUE + 1),
+                QualityControlEvent.QualityCategory.INFO); // ONE ABOVE
+
+        assertEquals(QualityControlRule.getCategoryByScore(QualityControlEvent.WARNING_VALUE - 1),
+                QualityControlEvent.QualityCategory.INFO); // ONE BELOW
+        assertEquals(QualityControlRule.getCategoryByScore(QualityControlEvent.WARNING_VALUE),
+                QualityControlEvent.QualityCategory.WARNING); // ON VALUE
+        assertEquals(QualityControlRule.getCategoryByScore(QualityControlEvent.WARNING_VALUE + 1),
+                QualityControlEvent.QualityCategory.WARNING); // ONE ABOVE
+
+        assertEquals(QualityControlRule.getCategoryByScore(QualityControlEvent.SEVERE_VALUE - 1),
+                QualityControlEvent.QualityCategory.WARNING); // ONE BELOW
+        assertEquals(QualityControlRule.getCategoryByScore(QualityControlEvent.SEVERE_VALUE),
+                QualityControlEvent.QualityCategory.SEVERE); // ON VALUE
+        assertEquals(QualityControlRule.getCategoryByScore(QualityControlEvent.SEVERE_VALUE + 1),
+                QualityControlEvent.QualityCategory.SEVERE); // ONE ABOVE
+
+        assertEquals(QualityControlRule.getCategoryByScore(QualityControlEvent.FATAL_VALUE - 1),
+                QualityControlEvent.QualityCategory.SEVERE); // ONE BELOW
+        assertEquals(QualityControlRule.getCategoryByScore(QualityControlEvent.FATAL_VALUE),
+                QualityControlEvent.QualityCategory.FATAL); // ON VALUE
+        assertEquals(QualityControlRule.getCategoryByScore(QualityControlEvent.FATAL_VALUE + 1),
+                QualityControlEvent.QualityCategory.FATAL); // ONE ABOVE
+    }
+}

--- a/CoreUtilities/src/au/gov/asd/tac/constellation/utilities/json/JsonUtilities.java
+++ b/CoreUtilities/src/au/gov/asd/tac/constellation/utilities/json/JsonUtilities.java
@@ -15,11 +15,22 @@
  */
 package au.gov.asd.tac.constellation.utilities.json;
 
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
 import java.util.Iterator;
+import java.util.Map;
 import java.util.NoSuchElementException;
+import org.apache.commons.collections.MapUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.openide.util.Exceptions;
 
 /**
  * JSON Utilities
@@ -315,5 +326,69 @@ public class JsonUtilities {
             // If there is a formatting issue, just return the raw JSON as it was passed in
             return rawString;
         }
+    }
+
+    /**
+     * Converts a map to JSON String. Will return an empty string if no entries
+     * are valid in the map.
+     *
+     * @param <K> the key type of the map
+     * @param <V> the value type of the map
+     * @param factory the jsonFactory object to use
+     * @param map the map to convert to a json string
+     * @return the JSON String representation of the map
+     */
+    public static <K, V> String getMapAsString(final JsonFactory factory, final Map<K, V> map) {
+        if (MapUtils.isNotEmpty(map)) {
+            final ByteArrayOutputStream json = new ByteArrayOutputStream();
+            try (final JsonGenerator jg = factory.createGenerator(json)) {
+                jg.writeStartObject();
+                for (final Map.Entry<K, V> entry : map.entrySet()) {
+                    final K key = entry.getKey();
+                    final V value = entry.getValue();
+                    if (key != null && value != null) {
+                        jg.writeStringField(key.toString(), value.toString());
+                    }
+                }
+                jg.writeEndObject();
+                jg.flush();
+                return json.toString(StandardCharsets.UTF_8.name());
+
+            } catch (IOException ex) {
+                Exceptions.printStackTrace(ex);
+            }
+        }
+
+        return StringUtils.EMPTY;
+    }
+
+    /**
+     * Converts a JSON String to a String, String map. Will return an empty Map
+     * if no valid items within the String
+     *
+     * @param factory the jsonFactory object to use
+     * @param mapAsString the JSON String representation of the map
+     * @return A String, String map based on the JSON String
+     */
+    public static Map<String, String> getStringAsMap(final JsonFactory factory, final String mapAsString) {
+        if (StringUtils.isNotEmpty(mapAsString)) {
+            Map<String, String> map = new HashMap<>();
+            try (final JsonParser jp = factory.createParser(mapAsString)) {
+                if (jp.nextToken() == JsonToken.START_OBJECT) {
+                    while (jp.nextToken() != JsonToken.END_OBJECT) {
+                        if (jp.getCurrentToken() == JsonToken.FIELD_NAME) {
+                            final String fieldName = jp.getText();
+                            jp.nextToken();
+                            final String fieldValue = jp.getText();
+                            map.put(fieldName, fieldValue);
+                        }
+                    }
+                }
+                return map;
+            } catch (IOException ex) {
+                Exceptions.printStackTrace(ex);
+            }
+        }
+        return MapUtils.EMPTY_MAP;
     }
 }

--- a/CoreUtilities/test/unit/src/au/gov/asd/tac/constellation/utilities/json/JsonUtilitiesNGTest.java
+++ b/CoreUtilities/test/unit/src/au/gov/asd/tac/constellation/utilities/json/JsonUtilitiesNGTest.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2010-2020 Australian Signals Directorate
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package au.gov.asd.tac.constellation.utilities.json;
+
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.databind.MappingJsonFactory;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.commons.collections.MapUtils;
+import org.apache.commons.lang3.StringUtils;
+import static org.testng.Assert.assertEquals;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+/**
+ * Json Utilities Test
+ *
+ * @author aldebaran30701
+ */
+public class JsonUtilitiesNGTest {
+
+    private static final JsonFactory FACTORY = new MappingJsonFactory();
+    private final Map<String, String> map = new HashMap<>();
+    private final String expectedResult = "{\"key1\":\"value1\",\"key2\":\"value2\",\"key3\":\"value3\"}";
+    private final String key1 = "key1";
+    private final String key2 = "key2";
+    private final String key3 = "key3";
+    private final String value1 = "value1";
+    private final String value2 = "value2";
+    private final String value3 = "value3";
+
+    public JsonUtilitiesNGTest() {
+        map.put(key1, value1);
+        map.put(key2, value2);
+        map.put(key3, value3);
+    }
+
+    @BeforeClass
+    public static void setUpClass() throws Exception {
+    }
+
+    @AfterClass
+    public static void tearDownClass() throws Exception {
+    }
+
+    @BeforeMethod
+    public void setUpMethod() throws Exception {
+    }
+
+    @AfterMethod
+    public void tearDownMethod() throws Exception {
+    }
+
+    /**
+     * Test of getMapAsString method, of class JsonUtilities.
+     */
+    @Test
+    public void testGetMapAsString() {
+        // Test null
+        assertEquals(JsonUtilities.getMapAsString(FACTORY, null), StringUtils.EMPTY);
+
+        // Test empty map
+        final Map<String, String> emptyMap = new HashMap<>();
+        assertEquals(JsonUtilities.getMapAsString(FACTORY, emptyMap), StringUtils.EMPTY);
+
+        // Test null map
+        final Map<String, String> emptyNullMap = new HashMap<>();
+        emptyNullMap.put(null, null);
+        emptyNullMap.put(null, null);
+        emptyNullMap.put(null, null);
+        assertEquals(JsonUtilities.getMapAsString(FACTORY, emptyMap), StringUtils.EMPTY);
+
+        // Test full map
+        assertEquals(JsonUtilities.getMapAsString(FACTORY, map), expectedResult);
+    }
+
+    /**
+     * Test of getStringAsMap method, of class JsonUtilities.
+     */
+    @Test
+    public void testGetStringAsMap() {
+        // Test null
+        assertEquals(JsonUtilities.getStringAsMap(FACTORY, null), MapUtils.EMPTY_MAP);
+
+        // Test empty String
+        final String emptyString = StringUtils.EMPTY;
+        assertEquals(JsonUtilities.getStringAsMap(FACTORY, emptyString), MapUtils.EMPTY_MAP);
+
+        // Test full String
+        assertEquals(JsonUtilities.getStringAsMap(FACTORY, expectedResult), map);
+    }
+}


### PR DESCRIPTION
<!--

### Requirements

* Filling out the template is required. Any pull request that does not include
enough information to be reviewed in a timely manner may be closed at the
maintainers' discretion.
* Follow the check list items defined by https://github.com/constellation-app/constellation/blob/master/CONTRIBUTING.md#pull-requests
* All new code requires unit tests to ensure they work as expected and will
continue to work as new code is added in the future (regression testing).
* Make sure your branch name is prefixed by `feature`, `bugfix`, `hotfix` or `release`
* Have you read Constellation's Code of Conduct? By filing an issue, you are
expected to comply with it, including treating everyone with respect:
https://github.com/constellation-app/constellation/blob/master/CODE_OF_CONDUCT.md

-->

### Description of the Change
This PR adds Quality categories to replace the visual representation of quality scores. 
It does not completely rid the code of "scores", as completely getting rid of the abstract
`getQuality()` method would cause other rules to break.

The QualityControlView table and the Data access view will now show categories of quality, as opposed to scores.

The categories map to int values which are representative of the old values. for example, the quality score previously used will map to a category. 
* MissingTypeRule RISK = 90 , maps to SEVERE.

DEFAULT = 1 - 29
INFO = 30 - 59
WARNING = 60 - 89
SEVERE = 90 - 94
FATAL = 95 +

An alert box now is implemented to map rules to each priority level. Allowing for manual overriding of specific rules or rules which are important to the user.
![image](https://user-images.githubusercontent.com/58677759/89250960-0f91d080-d655-11ea-8abe-0d8b44002ffd.png)

Highest priority rule in violation gets that label added.
![image](https://user-images.githubusercontent.com/58677759/89251039-3c45e800-d655-11ea-8598-2872179a5fab.png)

Rule dialog shows in categories and also ranks highest priority category first.
![image](https://user-images.githubusercontent.com/58677759/89251071-4bc53100-d655-11ea-9770-1241716b9999.png)

Can map a rule to the default category, allowing that rule to be completely ignored.
![image](https://user-images.githubusercontent.com/58677759/89251104-5c75a700-d655-11ea-9b17-b57f8c350fde.png)

Highest priority category in action gets added to the DAV button
![image](https://user-images.githubusercontent.com/58677759/89251124-68f9ff80-d655-11ea-833e-47efa7769aa1.png)


<!--

We must be able to understand the design of your change from this description.
If we can't get a good idea of what the code will be doing from the description
here, the pull request may be closed at the maintainers' discretion. Keep in
mind that the maintainer reviewing this PR may not be familiar with or have
worked with the code here recently, so please walk us through the concepts.

-->

### Alternate Designs
N/A
<!--

Explain what other alternates were considered and why the proposed version was
selected.

-->

### Why Should This Be In Core?
Feature allows user to easily read the quality of the data
<!--

Explain why this functionality should be in Constellation Core as opposed to a
different module suite. Note that this question is more applicable when adding
new functionality. If this change is a minor update to an exising file then it
is understood that this change has to be to this module suite and a response
and therefore a response to this question is not required.

-->

### Benefits
Feature allows user to easily read the quality of the data
<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks
None realised
<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process
loading different data, testing sort order, testing any place score was used previously.
opening up dialog boxes, switching priorities.
<!--

What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (e.g., buttons you clicked, text you typed,
commands you ran, etc.), and describe the results you observed.

-->

### Applicable Issues
#378 
<!-- Link any applicable issues here -->
