### PR TITLE
Unfocus Plugin Swing Dialog Ok button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Constellation Changes
 
+## 2020-08-01 Changes in August 2020
+* Updated a number of functions in Core Plugin Framework to include the option to unfocus the Ok button from the plugin swing dialog.
+
 ## 2020-07-01 Changes in July 2020
 * Added `AnalyticSchemaV4UpdateProvider` to upgrade `SchemaVertexType`s that have changed.
 * Added utility class `NotifyDisplayer` and static method `NotifyDisplayer#display` for use when displaying a `NotifyDescriptor` message box.

--- a/CoreDependencies/nbproject/project.xml
+++ b/CoreDependencies/nbproject/project.xml
@@ -2147,18 +2147,6 @@
                 <package>tec.uom.se.unit</package>
             </public-packages>
             <class-path-extension>
-                <runtime-relative-path>ext/FastInfoset-1.2.15.jar</runtime-relative-path>
-                <binary-origin>release/modules/ext/FastInfoset-1.2.15.jar</binary-origin>
-            </class-path-extension>
-            <class-path-extension>
-                <runtime-relative-path>ext/GeographicLib-Java-1.49.jar</runtime-relative-path>
-                <binary-origin>release/modules/ext/GeographicLib-Java-1.49.jar</binary-origin>
-            </class-path-extension>
-            <class-path-extension>
-                <runtime-relative-path>ext/SparseBitSet-1.2.jar</runtime-relative-path>
-                <binary-origin>release/modules/ext/SparseBitSet-1.2.jar</binary-origin>
-            </class-path-extension>
-            <class-path-extension>
                 <runtime-relative-path>ext/activation-1.1.jar</runtime-relative-path>
                 <binary-origin>release/modules/ext/activation-1.1.jar</binary-origin>
             </class-path-extension>
@@ -2275,8 +2263,16 @@
                 <binary-origin>release/modules/ext/failureaccess-1.0.1.jar</binary-origin>
             </class-path-extension>
             <class-path-extension>
+                <runtime-relative-path>ext/FastInfoset-1.2.15.jar</runtime-relative-path>
+                <binary-origin>release/modules/ext/FastInfoset-1.2.15.jar</binary-origin>
+            </class-path-extension>
+            <class-path-extension>
                 <runtime-relative-path>ext/filters-2.0.235.jar</runtime-relative-path>
                 <binary-origin>release/modules/ext/filters-2.0.235.jar</binary-origin>
+            </class-path-extension>
+            <class-path-extension>
+                <runtime-relative-path>ext/GeographicLib-Java-1.49.jar</runtime-relative-path>
+                <binary-origin>release/modules/ext/GeographicLib-Java-1.49.jar</binary-origin>
             </class-path-extension>
             <class-path-extension>
                 <runtime-relative-path>ext/gluegen-rt-natives-linux-amd64.jar</runtime-relative-path>
@@ -2785,6 +2781,10 @@
             <class-path-extension>
                 <runtime-relative-path>ext/si-units-java8-0.7.1.jar</runtime-relative-path>
                 <binary-origin>release/modules/ext/si-units-java8-0.7.1.jar</binary-origin>
+            </class-path-extension>
+            <class-path-extension>
+                <runtime-relative-path>ext/SparseBitSet-1.2.jar</runtime-relative-path>
+                <binary-origin>release/modules/ext/SparseBitSet-1.2.jar</binary-origin>
             </class-path-extension>
             <class-path-extension>
                 <runtime-relative-path>ext/sqlite-jdbc-3.27.2.1.jar</runtime-relative-path>

--- a/CoreGraphNode/src/au/gov/asd/tac/constellation/graph/node/plugins/DefaultPluginEnvironment.java
+++ b/CoreGraphNode/src/au/gov/asd/tac/constellation/graph/node/plugins/DefaultPluginEnvironment.java
@@ -58,7 +58,7 @@ public class DefaultPluginEnvironment extends PluginEnvironment {
     private static final String GRAPH_NULL_WARNING_MESSAGE = "{0} plugin was executed on a graph which was null";
 
     @Override
-    public Future<?> executePluginLater(final Graph graph, final Plugin plugin, final PluginParameters parameters, final boolean interactive, final List<Future<?>> async, final PluginSynchronizer synchronizer) {
+    public Future<?> executePluginLater(final Graph graph, final Plugin plugin, final PluginParameters parameters, final boolean interactive, final boolean okButtonFocused, final List<Future<?>> async, final PluginSynchronizer synchronizer) {
 
         if (graph == null) {
             LOGGER.log(Level.FINE, GRAPH_NULL_WARNING_MESSAGE, plugin.getName());
@@ -109,7 +109,7 @@ public class DefaultPluginEnvironment extends PluginEnvironment {
                     plugin.updateParameters(graph, parameters);
                 }
                 if (interactive && parameters != null) {
-                    if (interaction.prompt(plugin.getName(), parameters)) {
+                    if (interaction.prompt(plugin.getName(), parameters, okButtonFocused)) {
                         ThreadConstraints calledConstraints = ThreadConstraints.getConstraints();
                         calledConstraints.setAlwaysSilent(alwaysSilent);
                         try {
@@ -174,7 +174,7 @@ public class DefaultPluginEnvironment extends PluginEnvironment {
     }
 
     @Override
-    public Object executePluginNow(final Graph graph, final Plugin plugin, final PluginParameters parameters, final boolean interactive) throws InterruptedException, PluginException {
+    public Object executePluginNow(final Graph graph, final Plugin plugin, final PluginParameters parameters, final boolean interactive, final boolean okButtonFocused) throws InterruptedException, PluginException {
 
         if (graph == null) {
             LOGGER.log(Level.FINE, GRAPH_NULL_WARNING_MESSAGE, plugin.getName());
@@ -212,7 +212,7 @@ public class DefaultPluginEnvironment extends PluginEnvironment {
                 plugin.updateParameters(graph, parameters);
             }
             if (interactive && parameters != null) {
-                if (interaction.prompt(plugin.getName(), parameters)) {
+                if (interaction.prompt(plugin.getName(), parameters, okButtonFocused)) {
                     plugin.run(graphs, interaction, parameters);
                 }
             } else {

--- a/CoreGraphNode/src/au/gov/asd/tac/constellation/graph/node/plugins/DefaultPluginInteraction.java
+++ b/CoreGraphNode/src/au/gov/asd/tac/constellation/graph/node/plugins/DefaultPluginInteraction.java
@@ -236,7 +236,7 @@ public class DefaultPluginInteraction implements PluginInteraction, Cancellable 
     }
 
     @Override
-    public boolean prompt(final String promptName, final PluginParameters parameters) {
+    public boolean prompt(final String promptName, final PluginParameters parameters, final boolean okButtonFocused) {
         if (SwingUtilities.isEventDispatchThread()) {
             throw new IllegalStateException("Plugins should not be run on the EDT!");
         }
@@ -244,7 +244,11 @@ public class DefaultPluginInteraction implements PluginInteraction, Cancellable 
         boolean result = false;
 
         final PluginParametersSwingDialog dialog = new PluginParametersSwingDialog(promptName, parameters);
-        dialog.showAndWait();
+        if (okButtonFocused) {
+            dialog.showAndWait();
+        } else {
+            dialog.showAndWaitNoFocus();
+        }
         if (PluginParametersDialog.OK.equals(dialog.getResult())) {
             result = true;
         }

--- a/CorePluginFramework/src/au/gov/asd/tac/constellation/plugins/PluginEnvironment.java
+++ b/CorePluginFramework/src/au/gov/asd/tac/constellation/plugins/PluginEnvironment.java
@@ -50,6 +50,8 @@ public abstract class PluginEnvironment {
      * plugin.
      * @param interactive should the framework involve the user when running
      * this plugin or run the plugin programmatically.
+     * @param okButtonFocused if the user should be involved, should the ok
+     * button in the dialog be focused
      * @param async The plugin will not begin to execute until all of these
      * Futures have completed. If this Future is null, the plugin will execute
      * without waiting.
@@ -58,7 +60,7 @@ public abstract class PluginEnvironment {
      *
      * @return A Future representing the result of the asynchronous plugin.
      */
-    public abstract Future<?> executePluginLater(final Graph graph, final Plugin plugin, final PluginParameters parameters, final boolean interactive, final List<Future<?>> async, final PluginSynchronizer synchronizer);
+    public abstract Future<?> executePluginLater(final Graph graph, final Plugin plugin, final PluginParameters parameters, final boolean interactive, final boolean okButtonFocused, final List<Future<?>> async, final PluginSynchronizer synchronizer);
 
     /**
      * Execute a plugin synchronously on the current thread.
@@ -69,13 +71,15 @@ public abstract class PluginEnvironment {
      * plugin.
      * @param interactive should the framework involve the user when running
      * this plugin or run the plugin programmatically.
+     * @param okButtonFocused if the user should be involved, should the ok
+     * button in the dialog be focused
      * @return an object representing the result of this plugin run.
      * @throws InterruptedException if the plugin run is canceled or
      * interrupted.
      * @throws PluginException if a well understood problem occurs during the
      * running of the plugin.
      */
-    public abstract Object executePluginNow(final Graph graph, final Plugin plugin, final PluginParameters parameters, final boolean interactive) throws InterruptedException, PluginException;
+    public abstract Object executePluginNow(final Graph graph, final Plugin plugin, final PluginParameters parameters, final boolean interactive, final boolean okButtonFocused) throws InterruptedException, PluginException;
 
     /**
      * Execute a plugin synchronously on the current thread using the supplied

--- a/CorePluginFramework/src/au/gov/asd/tac/constellation/plugins/PluginExecution.java
+++ b/CorePluginFramework/src/au/gov/asd/tac/constellation/plugins/PluginExecution.java
@@ -51,6 +51,7 @@ public class PluginExecution {
     private final Plugin plugin;
 
     private boolean interactive = false;
+    private boolean okButtonFocused = true;
     private PluginParameters parameters = null;
     private List<Future<?>> futures = null;
     private PluginSynchronizer synchronizer = null;
@@ -138,6 +139,20 @@ public class PluginExecution {
      */
     public PluginExecution interactively(final boolean interactive) {
         this.interactive = interactive;
+        return this;
+    }
+    
+    /**
+     * Sets whether the Ok button in the Swing dialog is focused or not.
+     * NOTE: This plugin is only relevant when {@link PluginExecution.interactive}
+     * is set to true.
+     * 
+     * @param okButtonFocused whether the Swing dialog Ok button is focused
+     * 
+     * @return this to allow chaining of configuration calls.
+     */
+    public PluginExecution withOkButtonFocused(final boolean okButtonFocused) {
+        this.okButtonFocused = okButtonFocused;
         return this;
     }
 
@@ -286,7 +301,7 @@ public class PluginExecution {
         if (parameters == null) {
             parameters = DefaultPluginParameters.getDefaultParameters(plugin);
         }
-        return environment.executePluginLater(graph, plugin, parameters, interactive, futures, synchronizer);
+        return environment.executePluginLater(graph, plugin, parameters, interactive, okButtonFocused, futures, synchronizer);
     }
 
     /**
@@ -307,7 +322,7 @@ public class PluginExecution {
         if (parameters == null) {
             parameters = DefaultPluginParameters.getDefaultParameters(plugin);
         }
-        return environment.executePluginNow(graph, plugin, parameters, interactive);
+        return environment.executePluginNow(graph, plugin, parameters, interactive, okButtonFocused);
     }
 
     /**

--- a/CorePluginFramework/src/au/gov/asd/tac/constellation/plugins/PluginExecutor.java
+++ b/CorePluginFramework/src/au/gov/asd/tac/constellation/plugins/PluginExecutor.java
@@ -381,6 +381,7 @@ public class PluginExecutor {
     private static class PluginEntry {
 
         private final boolean interactive;
+        private final boolean okButtonFocused;
         private final Plugin plugin;
         private final PluginParameters parameters;
 
@@ -390,6 +391,18 @@ public class PluginExecutor {
 
         public PluginEntry(final Plugin plugin, final boolean interactive) {
             this.interactive = interactive;
+            this.okButtonFocused = true;
+            this.plugin = plugin;
+            this.parameters = DefaultPluginParameters.getDefaultParameters(plugin);
+        }
+        
+        public PluginEntry(final String pluginId, final boolean interactive, final boolean okButtonFocused) {
+            this(PluginRegistry.get(pluginId), interactive, okButtonFocused);
+        }
+
+        public PluginEntry(final Plugin plugin, final boolean interactive, final boolean okButtonFocused) {
+            this.interactive = interactive;
+            this.okButtonFocused = okButtonFocused;
             this.plugin = plugin;
             this.parameters = DefaultPluginParameters.getDefaultParameters(plugin);
         }
@@ -403,7 +416,7 @@ public class PluginExecutor {
         }
 
         public Object executeNow(final Graph graph) throws InterruptedException, PluginException {
-            return PluginEnvironment.getDefault().executePluginNow(graph, plugin, parameters, interactive);
+            return PluginEnvironment.getDefault().executePluginNow(graph, plugin, parameters, interactive, okButtonFocused);
         }
 
         public Object executeNow(final GraphWriteMethods graph) throws InterruptedException, PluginException {
@@ -412,7 +425,7 @@ public class PluginExecutor {
 
         public Future<?> executeLater(final Graph graph, final Future<?> future) {
             final List<Future<?>> futures = future == null ? null : Arrays.asList(future);
-            return PluginEnvironment.getDefault().executePluginLater(graph, plugin, parameters, interactive, futures, null);
+            return PluginEnvironment.getDefault().executePluginLater(graph, plugin, parameters, interactive, okButtonFocused, futures, null);
         }
     }
 }

--- a/CorePluginFramework/src/au/gov/asd/tac/constellation/plugins/PluginInteraction.java
+++ b/CorePluginFramework/src/au/gov/asd/tac/constellation/plugins/PluginInteraction.java
@@ -87,8 +87,9 @@ public interface PluginInteraction {
      *
      * @param promptName the name of the dialog box.
      * @param parameters the parameters to be displayed and edited.
+     * @param okButtonFocused whether the ok button should be focused
      * @return true if the user selected "Ok" or false if the user selected
      * "Cancel".
      */
-    boolean prompt(final String promptName, final PluginParameters parameters);
+    boolean prompt(final String promptName, final PluginParameters parameters, final boolean okButtonFocused);
 }

--- a/CorePluginFramework/src/au/gov/asd/tac/constellation/plugins/gui/PluginParametersSwingDialog.java
+++ b/CorePluginFramework/src/au/gov/asd/tac/constellation/plugins/gui/PluginParametersSwingDialog.java
@@ -141,6 +141,13 @@ public class PluginParametersSwingDialog {
         final Object r = DialogDisplayer.getDefault().notify(dd);
         result = r == DialogDescriptor.OK_OPTION ? OK : r == DialogDescriptor.CANCEL_OPTION ? CANCEL : null;
     }
+    
+    public void showAndWaitNoFocus() {
+        //Having 'No' button as initial value means focus is off of 'Ok' and 'Cancel' buttons
+        final DialogDescriptor dd = new DialogDescriptor(xp, title, true, DialogDescriptor.OK_CANCEL_OPTION, DialogDescriptor.NO_OPTION, null);
+        final Object r = DialogDisplayer.getDefault().notify(dd);
+        result = r == DialogDescriptor.OK_OPTION ? OK : r == DialogDescriptor.CANCEL_OPTION ? CANCEL : null;
+    }
 
     /**
      * The option that was selected by the user.

--- a/CorePluginFramework/src/au/gov/asd/tac/constellation/plugins/text/TextPluginInteraction.java
+++ b/CorePluginFramework/src/au/gov/asd/tac/constellation/plugins/text/TextPluginInteraction.java
@@ -68,7 +68,7 @@ public class TextPluginInteraction implements PluginInteraction {
     }
 
     @Override
-    public boolean prompt(String promptName, PluginParameters parameters) {
+    public boolean prompt(String promptName, PluginParameters parameters, boolean okButtonFocused) {
         throw new UnsupportedOperationException(NOT_SUPPORTED); //To change body of generated methods, choose Tools | Templates.
     }
 


### PR DESCRIPTION
<!--

### Requirements

* Filling out the template is required. Any pull request that does not include
enough information to be reviewed in a timely manner may be closed at the
maintainers' discretion.
* Follow the check list items defined by https://github.com/constellation-app/constellation/blob/master/CONTRIBUTING.md#pull-requests
* All new code requires unit tests to ensure they work as expected and will
continue to work as new code is added in the future (regression testing).
* Make sure your branch name is prefixed by `feature`, `bugfix`, `hotfix` or `release`
* Have you read Constellation's Code of Conduct? By filing an issue, you are
expected to comply with it, including treating everyone with respect:
https://github.com/constellation-app/constellation/blob/master/CODE_OF_CONDUCT.md

-->

### Description of the Change

This change adds the option when running a plugin interactively (i.e. through a swing dialog) to have the ok button unfocused in the dialog box. This enables the possibility of enter being able to be used to create a new line in a multi-line string parameter rather than simply executing the plugin.

### Alternate Designs

<!--

Explain what other alternates were considered and why the proposed version was
selected.

-->

### Why Should This Be In Core?

This enables a new way to engage with plugins loaded up through a swing dialog.

### Benefits

Enables possibility of enter being used to create a new line

### Possible Drawbacks

Users used to hitting enter to execute the plugin may suffer some initial UX troubles if the ok button is unfocused. This is why I have made it an option rather than simply replacing the old way (so the ok button only needs to be unfocused as needed).

### Verification Process

1) Open Constellation and create a new graph
2) Go to build a sphere graph
3) Verify that the ok button is focused (and pressing enter runs the plugin)
4) Close Constellation
5) In the code, go to `SphereGraphBuilderAction.java` and at the PluginExecution line add `.withOkButtonFocused(false)`
6) Clean and build constellation
7) Repeat steps 1-2
8) Verify that ok is unfocused (and pressing enter doesn't run the plugin)

### Applicable Issues

#757 
