### PR TITLE
single choice parameter type not updating fix

### DIFF
--- a/CoreAlgorithmPlugins/src/au/gov/asd/tac/constellation/plugins/algorithms/sna/similarity/LevenshteinDistancePlugin.java
+++ b/CoreAlgorithmPlugins/src/au/gov/asd/tac/constellation/plugins/algorithms/sna/similarity/LevenshteinDistancePlugin.java
@@ -42,6 +42,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import org.apache.commons.lang3.StringUtils;
 import org.openide.DialogDisplayer;
 import org.openide.NotifyDescriptor;
 import org.openide.util.NbBundle;
@@ -156,7 +157,9 @@ public class LevenshteinDistancePlugin extends SimpleEditPlugin {
                 String stringOne = graph.getStringValue(vertexCompareAttributeId, vxOneId);
                 String stringTwo = graph.getStringValue(vertexCompareAttributeId, vxTwoId);
 
-                if (Math.abs(stringOne.length() - stringTwo.length()) > maxDistance) {
+                if (StringUtils.isBlank(stringOne)
+                        || StringUtils.isBlank(stringTwo)
+                        || Math.abs(stringOne.length() - stringTwo.length()) > maxDistance) {
                     continue;
                 }
 

--- a/CorePluginFramework/src/au/gov/asd/tac/constellation/plugins/parameters/types/ParameterValue.java
+++ b/CorePluginFramework/src/au/gov/asd/tac/constellation/plugins/parameters/types/ParameterValue.java
@@ -76,7 +76,8 @@ public abstract class ParameterValue {
     public abstract boolean setStringValue(String s);
 
     /**
-     * Get the current value held by the ParameterValue.
+     * Get the current value held by the ParameterValue. Will retrieve the whole
+     * object when of type Single or MultiChoiceParameterType
      *
      * @return The current value as an arbitrary Object.
      */

--- a/CorePluginFramework/src/au/gov/asd/tac/constellation/plugins/parameters/types/SingleChoiceParameterType.java
+++ b/CorePluginFramework/src/au/gov/asd/tac/constellation/plugins/parameters/types/SingleChoiceParameterType.java
@@ -437,23 +437,33 @@ public class SingleChoiceParameterType extends PluginParameterType<SingleChoiceP
             return false;
         }
 
+        /**
+         * getObjectValue will return the whole SingleChoiceParameterType
+         * similar to how the MultiChoiceParameterType does also.
+         *
+         * @return this whole object.
+         */
         @Override
         public Object getObjectValue() {
-            return choice;
+            return this;
         }
 
         @Override
         public boolean setObjectValue(final Object o) {
-            if (o != null && !innerClass.equals(o.getClass())) {
-                throw new IllegalArgumentException(String.format("Object value [%s] (class %s) must be of class %s", o, o.getClass(), innerClass));
+            boolean valueChanged = false;
+
+            final SingleChoiceParameterValue sc = (SingleChoiceParameterValue) o;
+            if (!Objects.equals(options, sc.options)) {
+                options.clear();
+                options.addAll(sc.options);
+                valueChanged = true;
             }
-            final ParameterValue newChoice = (ParameterValue) o;
-            if (!Objects.equals(choice, newChoice)) {
-                choice = newChoice;
-                return true;
+            if (!Objects.equals(choice, sc.choice)) {
+                choice = sc.choice;
+                valueChanged = true;
             }
 
-            return false;
+            return valueChanged;
         }
 
         @Override


### PR DESCRIPTION
<!--

### Requirements

* Filling out the template is required. Any pull request that does not include
enough information to be reviewed in a timely manner may be closed at the
maintainers' discretion.
* Follow the check list items defined by https://github.com/constellation-app/constellation/blob/master/CONTRIBUTING.md#pull-requests
* All new code requires unit tests to ensure they work as expected and will
continue to work as new code is added in the future (regression testing).
* Make sure your branch name is prefixed by `feature`, `bugfix`, `hotfix` or `release`
* Have you read Constellation's Code of Conduct? By filing an issue, you are
expected to comply with it, including treating everyone with respect:
https://github.com/constellation-app/constellation/blob/master/CODE_OF_CONDUCT.md

-->

### Description of the Change
This change allows the get and set of object value within `SingleChoiceParameterType` to be used to update the `PluginParameter`. Previously, on updating of the plugin parameters through a graph update would cause only the current selection to be updated. Now, it will update all possible choices and the current selection.
This change also includes a null check which was found through testing.
<!--

We must be able to understand the design of your change from this description.
If we can't get a good idea of what the code will be doing from the description
here, the pull request may be closed at the maintainers' discretion. Keep in
mind that the maintainer reviewing this PR may not be familiar with or have
worked with the code here recently, so please walk us through the concepts.

-->

### Alternate Designs
Add an `updateParameters()` method within all `ParameterTypes` which is called on updateParameters calls. This would allow any current usages of `getObjectValue()` to remain unchanged.
<!--

Explain what other alternates were considered and why the proposed version was
selected.

-->

### Why Should This Be In Core?
bugfix
<!--

Explain why this functionality should be in Constellation Core as opposed to a
different module suite. Note that this question is more applicable when adding
new functionality. If this change is a minor update to an exising file then it
is understood that this change has to be to this module suite and a response
and therefore a response to this question is not required.

-->

### Benefits
Fixes the issue where plugin values are not updated on graph changes
<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks
Possible usage of `getObjectValue()` elsewhere
<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process
Tested opening and closing graphs, selecting and running plugin.
<!--

What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (e.g., buttons you clicked, text you typed,
commands you ran, etc.), and describe the results you observed.

-->

### Applicable Issues
#768 
<!-- Link any applicable issues here -->
