### PR TITLE
Add transactions into existing hashmod plugin

### DIFF
--- a/CoreGraphUtilities/src/au/gov/asd/tac/constellation/graph/utilities/hashmod/Bundle.properties
+++ b/CoreGraphUtilities/src/au/gov/asd/tac/constellation/graph/utilities/hashmod/Bundle.properties
@@ -15,3 +15,5 @@ HashmodPanel.hashmodButton1.text=Chained
 HashmodPanel.createAllCheckbox1.text=Create new vertexes for non matching keys
 HashmodPanel.hashmodLabel6.text=Create new attributes from Column Headers:
 HashmodPanel.createAttributesCheckbox.text_1=Create new attributes from names in Column Headers
+HashmodPanel.hashmodLabel7.text=Create new transactions from Column Headers:
+HashmodPanel.createTransactionsCheckbox.text=Create new transactions based on ColumnA...ColumnB

--- a/CoreGraphUtilities/src/au/gov/asd/tac/constellation/graph/utilities/hashmod/Hashmod.java
+++ b/CoreGraphUtilities/src/au/gov/asd/tac/constellation/graph/utilities/hashmod/Hashmod.java
@@ -22,6 +22,8 @@ import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.apache.commons.collections.CollectionUtils;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * A text hashmod based on a supplied CSV file. Will modify attributes specified
@@ -110,12 +112,62 @@ public class Hashmod {
         return keys;
     }
 
-    public int getNumberCSVColumns() {
+    public int getNumberCSVDataColumns() {
         final String[] headers = getCSVFileHeaders();
         if (headers != null) {
+            
+            for (int i = 0; i < headers.length; i++) {
+                if (headers[i].matches(".*\\.\\.\\..*")) {
+                    return i;
+                }
+            }
             return headers.length;
         }
         return 0;
+    }
+
+    public int getNumberCSVTransactionColumns() {
+        final String[] headers = getCSVFileHeaders();
+        if (headers != null) {
+            int numTransactions = 0;
+            for (int i = getNumberCSVDataColumns(); i < headers.length; i++) {
+                if (!headers[i].matches(".*\\.\\.\\..*")) {
+                    return numTransactions;
+                }
+                numTransactions++;
+            }
+            return numTransactions;
+        }
+        return 0;
+    }
+
+    private String getColumnOfTransaction(int transactionCol, String regex) {
+        final Pattern cardNamePattern = Pattern.compile(regex);
+
+        final String[] headers = getCSVFileHeaders();
+        if (headers != null) {
+            int numTransactions = 0;
+            for (int i = getNumberCSVDataColumns(); i < headers.length; i++) {
+                if (headers[i].matches(".*\\.\\.\\..*")) {
+                    if (numTransactions == transactionCol) {
+                        Matcher matchPattern = cardNamePattern.matcher(headers[i]);
+                        if (matchPattern.find()) {
+                            return matchPattern.group(1);
+                        }
+                    }
+                }
+                numTransactions++;
+            }
+        }
+        return "";
+    }
+
+    public String getFirstColumnOfTransaction(int transactionCol) {
+        return getColumnOfTransaction(transactionCol, "([^\"]+)\\.\\.\\.");
+    }
+
+    public String getSecondColumnOfTransaction(int transactionCol) {
+        return getColumnOfTransaction(transactionCol, ".*?\\.\\.\\.([^\"]+)");
     }
 
     public String getCSVHeader(final int col) {

--- a/CoreGraphUtilities/src/au/gov/asd/tac/constellation/graph/utilities/hashmod/HashmodAction.java
+++ b/CoreGraphUtilities/src/au/gov/asd/tac/constellation/graph/utilities/hashmod/HashmodAction.java
@@ -74,17 +74,18 @@ public final class HashmodAction implements ActionListener {
                 final Hashmod[] chainedHashmods = hashmodPanel.getChainedHashmods();
                 final int numChainedHashmods = hashmodPanel.numChainedHashmods();
                 final Boolean createNonMatchingKeysVertexes = hashmodPanel.getCreateVertexes();
+                final Boolean createTransactions = hashmodPanel.getCreateTransactions();
                 hashmodPanel.setAttributeNames(hashmod1.getCSVKey(), hashmod1.getCSVHeader(1), hashmod1.getCSVHeader(2));
 
                 PluginExecution.withPlugin(new SimpleEditPlugin(Bundle.CTL_HashmodAction()) {
                     @Override
                     public void edit(final GraphWriteMethods wg, final PluginInteraction interaction, final PluginParameters parameters) throws InterruptedException {
                         if (hashmod1 != null) {
-                            HashmodAction.run(wg, interaction, hashmod1, createNonMatchingKeysVertexes, true, createAttributes);
+                            HashmodAction.run(wg, interaction, hashmod1, createNonMatchingKeysVertexes, createTransactions, true, createAttributes);
                         }
                         if (isChainedHashmods && numChainedHashmods >= 2) {
                             for (int i = 1; i < numChainedHashmods; i++) {
-                                HashmodAction.run(wg, interaction, chainedHashmods[i], false, false, createAttributes);
+                                HashmodAction.run(wg, interaction, chainedHashmods[i], false, false, false, createAttributes);
                             }
                         }
                     }
@@ -94,10 +95,10 @@ public final class HashmodAction implements ActionListener {
         DialogDisplayer.getDefault().notify(dialog);
     }
 
-    private static void run(final GraphWriteMethods wg, final PluginInteraction interaction, final Hashmod hashmod, final Boolean createAllKeys, final Boolean setPrimary, final Boolean createAttributes) throws InterruptedException {
+    private static void run(final GraphWriteMethods wg, final PluginInteraction interaction, final Hashmod hashmod, final Boolean createAllKeys, final Boolean createTransactions, final Boolean setPrimary, final Boolean createAttributes) throws InterruptedException {
 
         if (wg != null && hashmod != null) {
-            if (hashmod.getNumberCSVColumns() < 2) {
+            if (hashmod.getNumberCSVDataColumns() < 2) {
                 interaction.notify(PluginNotificationLevel.ERROR, "CSV file requires at least one key and one value attribute");
                 return;
             }
@@ -105,8 +106,8 @@ public final class HashmodAction implements ActionListener {
             return;
         }
 
-        final int[] attributeValues = new int[hashmod.getNumberCSVColumns() + 1];
-        final int[] csvValues = new int[hashmod.getNumberCSVColumns() + 1];
+        final int[] attributeValues = new int[hashmod.getNumberCSVDataColumns() + 1];
+        final int[] csvValues = new int[hashmod.getNumberCSVDataColumns() + 1];
         String nextAttr;
         int i = 0;
         int attrCount = 0;
@@ -146,10 +147,10 @@ public final class HashmodAction implements ActionListener {
         String keyValue;
         int numberSuccessful = 0;
 
+        final int[] vxOrder = new int[vxCount];
+        int vxPos = 0;
         if (vxCount > 0) {
             final BitSet vertices = HashmodUtilities.vertexBits(wg);
-            int vxPos = 0;
-            final int[] vxOrder = new int[vxCount];
             for (int vxId = vertices.nextSetBit(0); vxId >= 0; vxId = vertices.nextSetBit(vxId + 1)) {
                 if (Thread.interrupted()) {
                     throw new InterruptedException();
@@ -197,6 +198,53 @@ public final class HashmodAction implements ActionListener {
                 wg.setPrimaryKey(GraphElementType.VERTEX, attributeValues[0]);
             }
             interaction.notify(PluginNotificationLevel.WARNING, "Successfully added in " + numberSuccessful + " new nodes");
+        }
+
+        if (createTransactions) {
+            final BitSet vertices = HashmodUtilities.vertexBits(wg);
+
+            final int vxCount2 = wg.getVertexCount();
+            final int[] vxOrder2 = new int[vxCount2];
+            for (int vxId = vertices.nextSetBit(0); vxId >= 0; vxId = vertices.nextSetBit(vxId + 1)) {
+                if (Thread.interrupted()) {
+                    throw new InterruptedException();
+                }
+                vxOrder2[vxPos++] = vxId;
+                vertices.clear(vxId);
+            }
+
+            numberSuccessful = 0;
+            for (int transaction = 0; transaction < hashmod.getNumberCSVTransactionColumns(); transaction++) {
+                String attribute1 = hashmod.getFirstColumnOfTransaction(transaction);
+                String attribute2 = hashmod.getSecondColumnOfTransaction(transaction);
+
+                final int transaction1Attribute = wg.getSchema().getFactory().ensureAttribute(wg, GraphElementType.VERTEX, attribute1);
+                final int transaction2Attribute = wg.getSchema().getFactory().ensureAttribute(wg, GraphElementType.VERTEX, attribute2);
+
+                if (transaction1Attribute != Graph.NOT_FOUND && transaction2Attribute != Graph.NOT_FOUND) {
+                    for (int j = 0; j < vxPos; j++) {
+                        if (Thread.interrupted()) {
+                            throw new InterruptedException();
+                        }
+                        final int vxId = vxOrder2[j];
+
+                        String attr1Value = wg.getObjectValue(transaction1Attribute, vxId);
+                        for (int k = 0; k < vxPos && attr1Value != null && attr1Value.length() > 0; k++) {
+                            if (Thread.interrupted()) {
+                                throw new InterruptedException();
+                            }
+                            final int vx2Id = vxOrder2[k];
+
+                            String attr2Value = wg.getObjectValue(transaction2Attribute, vx2Id);
+                            if (attr1Value.equals(attr2Value) && vxId != vx2Id) {
+                                wg.addTransaction(vxId, vx2Id, false);
+                            }
+                        }
+                    }
+                }
+            }
+
+            interaction.notify(PluginNotificationLevel.WARNING, "Successfully added in " + numberSuccessful + " new transactions");
         }
     }
 }

--- a/CoreGraphUtilities/src/au/gov/asd/tac/constellation/graph/utilities/hashmod/HashmodPanel.form
+++ b/CoreGraphUtilities/src/au/gov/asd/tac/constellation/graph/utilities/hashmod/HashmodPanel.form
@@ -41,6 +41,7 @@
                           <Component id="hashmodLabel4" alignment="0" min="-2" max="-2" attributes="0"/>
                           <Component id="hashmodLabel5" alignment="0" min="-2" max="-2" attributes="0"/>
                           <Component id="hashmodLabel6" alignment="0" min="-2" max="-2" attributes="0"/>
+                          <Component id="hashmodLabel7" alignment="0" min="-2" max="-2" attributes="0"/>
                       </Group>
                       <EmptySpace max="-2" attributes="0"/>
                       <Group type="103" groupAlignment="0" attributes="0">
@@ -50,6 +51,7 @@
                               <Group type="103" groupAlignment="0" attributes="0">
                                   <Component id="createAttributesCheckbox" min="-2" max="-2" attributes="0"/>
                                   <Component id="createAllCheckbox" min="-2" max="-2" attributes="0"/>
+                                  <Component id="createTransactionsCheckbox" min="-2" max="-2" attributes="0"/>
                               </Group>
                               <EmptySpace min="0" pref="0" max="32767" attributes="0"/>
                           </Group>
@@ -98,6 +100,11 @@
               <Group type="103" groupAlignment="3" attributes="0">
                   <Component id="createAttributesCheckbox" alignment="3" min="-2" max="-2" attributes="0"/>
                   <Component id="hashmodLabel6" alignment="3" min="-2" max="-2" attributes="0"/>
+              </Group>
+              <EmptySpace max="-2" attributes="0"/>
+              <Group type="103" groupAlignment="3" attributes="0">
+                  <Component id="createTransactionsCheckbox" alignment="3" min="-2" max="-2" attributes="0"/>
+                  <Component id="hashmodLabel7" alignment="3" min="-2" max="-2" attributes="0"/>
               </Group>
               <EmptySpace max="-2" attributes="0"/>
               <Group type="103" groupAlignment="0" attributes="0">
@@ -250,6 +257,23 @@
       </Properties>
       <Events>
         <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="createAttributesCheckboxActionPerformed"/>
+      </Events>
+    </Component>
+    <Component class="javax.swing.JLabel" name="hashmodLabel7">
+      <Properties>
+        <Property name="text" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
+          <ResourceString bundle="au/gov/asd/tac/constellation/graph/utilities/hashmod/Bundle.properties" key="HashmodPanel.hashmodLabel7.text" replaceFormat="org.openide.util.NbBundle.getMessage({sourceFileName}.class, &quot;{key}&quot;)"/>
+        </Property>
+      </Properties>
+    </Component>
+    <Component class="javax.swing.JCheckBox" name="createTransactionsCheckbox">
+      <Properties>
+        <Property name="text" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
+          <ResourceString bundle="au/gov/asd/tac/constellation/graph/utilities/hashmod/Bundle.properties" key="HashmodPanel.createTransactionsCheckbox.text" replaceFormat="org.openide.util.NbBundle.getMessage({sourceFileName}.class, &quot;{key}&quot;)"/>
+        </Property>
+      </Properties>
+      <Events>
+        <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="createTransactionsCheckboxActionPerformed"/>
       </Events>
     </Component>
   </SubComponents>

--- a/CoreGraphUtilities/src/au/gov/asd/tac/constellation/graph/utilities/hashmod/HashmodPanel.java
+++ b/CoreGraphUtilities/src/au/gov/asd/tac/constellation/graph/utilities/hashmod/HashmodPanel.java
@@ -48,9 +48,10 @@ public class HashmodPanel extends javax.swing.JPanel {
 
     private static final String HASHMOD_CSV_FILE = "user.home";
     private String hashmodCSVFileStr = "";
+    private String hashmodCSVChainStr = "";
     private Boolean isChainedHashmods = false;
     private int numChainedHashmods = 0;
-    private final Hashmod[] chainedHashmods = new Hashmod[10];
+    private Hashmod[] chainedHashmods = new Hashmod[10];
 
     /**
      * Creates new form HashmodPanel.
@@ -115,6 +116,10 @@ public class HashmodPanel extends javax.swing.JPanel {
         return createAttributesCheckbox.isSelected();
     }
 
+    public boolean getCreateTransactions() {
+        return createTransactionsCheckbox.isSelected();
+    }
+
     /**
      * This method is called from within the constructor to initialize the form.
      * WARNING: Do NOT modify this code. The content of this method is always
@@ -140,6 +145,8 @@ public class HashmodPanel extends javax.swing.JPanel {
         hashmodButton1 = new JButton();
         hashmodLabel6 = new JLabel();
         createAttributesCheckbox = new JCheckBox();
+        hashmodLabel7 = new JLabel();
+        createTransactionsCheckbox = new JCheckBox();
 
         Mnemonics.setLocalizedText(hashmodLabel, NbBundle.getMessage(HashmodPanel.class, "Hashmod.csv.label")); // NOI18N
 
@@ -198,6 +205,15 @@ public class HashmodPanel extends javax.swing.JPanel {
             }
         });
 
+        Mnemonics.setLocalizedText(hashmodLabel7, NbBundle.getMessage(HashmodPanel.class, "HashmodPanel.hashmodLabel7.text")); // NOI18N
+
+        Mnemonics.setLocalizedText(createTransactionsCheckbox, NbBundle.getMessage(HashmodPanel.class, "HashmodPanel.createTransactionsCheckbox.text")); // NOI18N
+        createTransactionsCheckbox.addActionListener(new ActionListener() {
+            public void actionPerformed(ActionEvent evt) {
+                createTransactionsCheckboxActionPerformed(evt);
+            }
+        });
+
         GroupLayout layout = new GroupLayout(this);
         this.setLayout(layout);
         layout.setHorizontalGroup(layout.createParallelGroup(GroupLayout.Alignment.LEADING)
@@ -221,7 +237,8 @@ public class HashmodPanel extends javax.swing.JPanel {
                             .addComponent(hashmodLabel3)
                             .addComponent(hashmodLabel4)
                             .addComponent(hashmodLabel5)
-                            .addComponent(hashmodLabel6))
+                            .addComponent(hashmodLabel6)
+                            .addComponent(hashmodLabel7))
                         .addPreferredGap(LayoutStyle.ComponentPlacement.RELATED)
                         .addGroup(layout.createParallelGroup(GroupLayout.Alignment.LEADING)
                             .addComponent(value2AttributeTextField)
@@ -229,7 +246,8 @@ public class HashmodPanel extends javax.swing.JPanel {
                             .addGroup(layout.createSequentialGroup()
                                 .addGroup(layout.createParallelGroup(GroupLayout.Alignment.LEADING)
                                     .addComponent(createAttributesCheckbox)
-                                    .addComponent(createAllCheckbox))
+                                    .addComponent(createAllCheckbox)
+                                    .addComponent(createTransactionsCheckbox))
                                 .addGap(0, 0, Short.MAX_VALUE)))))
                 .addPreferredGap(LayoutStyle.ComponentPlacement.RELATED)
                 .addGroup(layout.createParallelGroup(GroupLayout.Alignment.LEADING)
@@ -264,6 +282,10 @@ public class HashmodPanel extends javax.swing.JPanel {
                 .addGroup(layout.createParallelGroup(GroupLayout.Alignment.BASELINE)
                     .addComponent(createAttributesCheckbox)
                     .addComponent(hashmodLabel6))
+                .addPreferredGap(LayoutStyle.ComponentPlacement.RELATED)
+                .addGroup(layout.createParallelGroup(GroupLayout.Alignment.BASELINE)
+                    .addComponent(createTransactionsCheckbox)
+                    .addComponent(hashmodLabel7))
                 .addPreferredGap(LayoutStyle.ComponentPlacement.RELATED)
                 .addGroup(layout.createParallelGroup(GroupLayout.Alignment.LEADING)
                     .addComponent(hashmodLabel5)
@@ -311,9 +333,14 @@ public class HashmodPanel extends javax.swing.JPanel {
         // TODO add your handling code here:
     }//GEN-LAST:event_createAttributesCheckboxActionPerformed
 
+    private void createTransactionsCheckboxActionPerformed(ActionEvent evt) {//GEN-FIRST:event_createTransactionsCheckboxActionPerformed
+        // TODO add your handling code here:
+    }//GEN-LAST:event_createTransactionsCheckboxActionPerformed
+
     // Variables declaration - do not modify//GEN-BEGIN:variables
     private JCheckBox createAllCheckbox;
     private JCheckBox createAttributesCheckbox;
+    private JCheckBox createTransactionsCheckbox;
     private JButton hashmodButton;
     private JButton hashmodButton1;
     private JTextField hashmodCSVFile;
@@ -324,6 +351,7 @@ public class HashmodPanel extends javax.swing.JPanel {
     private JLabel hashmodLabel4;
     private JLabel hashmodLabel5;
     private JLabel hashmodLabel6;
+    private JLabel hashmodLabel7;
     private JTextArea jCSVFileList;
     private JScrollPane jScrollPane1;
     private JTextField keyAttributeTextField;


### PR DESCRIPTION
### Description of the Change

Modifies HashMod to be able to specify that a certain field in a vertix should be matched to another field in a vertex (and hence draw a transaction between them) if the values match.  Essentially a foreign key type arrangement (ManagerId -> EmployeeId for example)

### Alternate Designs

To do things manually 

### Why Should This Be In Core?

Hashmod is already in the core and this is extending it to allow transactions to be put into the mix as well as vertices.

### Benefits

Users will be able to specify that a field in a vertex should match another field's value and then a transaction will be created.

### Possible Drawbacks

None foreseen (as the user controls what gets linked in)

### Verification Process

Have implemented it twice actually and have checked it against a few different data sets that I can think of (floor plans and a made up manager-employee structure)

### Applicable Issues

Nil known. 
