### PR TITLE
Bugfix/issue793 class cast exception

### DIFF
--- a/CorePluginFramework/src/au/gov/asd/tac/constellation/plugins/parameters/types/ElementTypeParameterValue.java
+++ b/CorePluginFramework/src/au/gov/asd/tac/constellation/plugins/parameters/types/ElementTypeParameterValue.java
@@ -82,4 +82,28 @@ public class ElementTypeParameterValue extends ParameterValue {
     public String toString() {
         return elementType == null ? "No Value" : elementType.getShortLabel();
     }
+
+    @Override
+    public int hashCode() {
+        int hash = 5;
+        hash = 41 * hash + Objects.hashCode(this.elementType);
+        return hash;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        final ElementTypeParameterValue other = (ElementTypeParameterValue) obj;
+        return this.elementType == other.elementType;
+    }
+    
+    
 }

--- a/CorePluginFramework/src/au/gov/asd/tac/constellation/plugins/parameters/types/SingleChoiceParameterType.java
+++ b/CorePluginFramework/src/au/gov/asd/tac/constellation/plugins/parameters/types/SingleChoiceParameterType.java
@@ -451,16 +451,24 @@ public class SingleChoiceParameterType extends PluginParameterType<SingleChoiceP
         @Override
         public boolean setObjectValue(final Object o) {
             boolean valueChanged = false;
-
-            final SingleChoiceParameterValue sc = (SingleChoiceParameterValue) o;
-            if (!Objects.equals(options, sc.options)) {
-                options.clear();
-                options.addAll(sc.options);
+            if (o instanceof SingleChoiceParameterValue) {
+                final SingleChoiceParameterValue sc = (SingleChoiceParameterValue) o;
+                if (!Objects.equals(options, sc.options)) {
+                    options.clear();
+                    options.addAll(sc.options);
+                    valueChanged = true;
+                }
+                if (!Objects.equals(choice, sc.choice)) {
+                    choice = sc.choice;
+                    valueChanged = true;
+                }
+            } 
+            else if (o instanceof ParameterValue) {
+                setChoiceData(this.innerClass.cast(o)); 
                 valueChanged = true;
             }
-            if (!Objects.equals(choice, sc.choice)) {
-                choice = sc.choice;
-                valueChanged = true;
+            else {
+                throw new IllegalArgumentException("Invalid argument");
             }
 
             return valueChanged;


### PR DESCRIPTION
<!--

### Requirements

* Filling out the template is required. Any pull request that does not include
enough information to be reviewed in a timely manner may be closed at the
maintainers' discretion.
* Follow the check list items defined by https://github.com/constellation-app/constellation/blob/master/CONTRIBUTING.md#pull-requests
* All new code requires unit tests to ensure they work as expected and will
continue to work as new code is added in the future (regression testing).
* Make sure your branch name is prefixed by `feature`, `bugfix`, `hotfix` or `release`
* Have you read Constellation's Code of Conduct? By filing an issue, you are
expected to comply with it, including treating everyone with respect:
https://github.com/constellation-app/constellation/blob/master/CODE_OF_CONDUCT.md

-->

### Description of the Change

<!--

Addition of checks and logic to setObjectValues method in SingleChoiceParameterValue class. This should stop classCast exceptions from occurring.

-->

### Alternate Designs

<!--

In discussion about the relevance of get/setObjectValue and whether they should be removed in favour of more direct/specific getter/setter methods.

-->

### Why Should This Be In Core?

<!--

Already in core.

-->

### Benefits

Fixes common classCastException bug.

### Possible Drawbacks

May not fix all classCastException bugs. setObjectValue now performs to functions, both which essentially already exist in other methods.

### Verification Process

<!--

Tested the ability to select nodes in the scatter plot view.

-->

### Applicable Issues

https://github.com/constellation-app/constellation/issues/793
