### PR TITLE
:bug: Alternate minimal value for empty graph in logarithmic axis.

### DIFF
--- a/CoreScatterPlotView/src/au/gov/asd/tac/constellation/views/scatterplot/axis/LogarithmicAxis.java
+++ b/CoreScatterPlotView/src/au/gov/asd/tac/constellation/views/scatterplot/axis/LogarithmicAxis.java
@@ -58,6 +58,9 @@ public class LogarithmicAxis extends ValueAxis<Number> {
     @Override
     protected Object autoRange(double minValue, double maxValue, double length, double labelSize) {
         if (isAutoRanging()) {
+            if (minValue == 0){ // Can only be reached if graph is empty due to ChartBuilder:77,85 checks.
+                minValue = 1; //When graph is empty set override default minimum of 0 (which is incomaptible with the logartihmic axis) and set it to 1. This results in behaviour similiar to that of the non-log axis for an empty chart.
+            }
             return new double[]{minValue, maxValue};
         } else {
             return getRange();


### PR DESCRIPTION
Add an if statement which will change the default minimum value from 0
to 1 if the logarithmic axis is called for an empty graph.

### Description of the Change

<!--

Add an if statement which will change the default minimum value from 0
to 1 if the logarithmic axis is called for an empty graph. This will help avoid an out of memory exception that occurs in calculateTickValues when the minimum is 0.

-->


### Why Should This Be In Core?

<!--

Already in core

-->

### Benefits

Stops an out of memory exception from occuring when a logarithmic axis is selected for a plot with no nodes.

### Possible Drawbacks

Unknown

### Verification Process

<!--

Tested use of scatterplot with various combination of selected nodes, the selected toggle, axis etc

-->

### Applicable Issues

https://github.com/constellation-app/constellation/issues/815
