### PR TITLE
Bugfix/issue727 conversation clear content

### DIFF
--- a/CoreConversationView/src/au/gov/asd/tac/constellation/views/conversationview/Conversation.java
+++ b/CoreConversationView/src/au/gov/asd/tac/constellation/views/conversationview/Conversation.java
@@ -189,7 +189,7 @@ public class Conversation {
 
         @Override
         protected boolean update(GraphReadMethods graph) {
-            return Objects.isNull(graph);
+            return graph == null;
         }
     };
     /**
@@ -203,9 +203,8 @@ public class Conversation {
 
             
             ConversationState newConversationState;
-            int conversationStateAttribute;
             if (Objects.nonNull(graph)) {
-                conversationStateAttribute = ConversationViewConcept.MetaAttribute.CONVERSATION_VIEW_STATE.get(graph);
+                int conversationStateAttribute = ConversationViewConcept.MetaAttribute.CONVERSATION_VIEW_STATE.get(graph);
                 if (conversationStateAttribute == Graph.NOT_FOUND) {
                     newConversationState = new ConversationState();
                     newConversationState.setSenderAttributesToKeys(graph);
@@ -435,10 +434,6 @@ public class Conversation {
     private UpdateComponent<GraphReadMethods> senderUpdater = new UpdateComponent<GraphReadMethods>("Senders", LOCK_STAGE) {
         @Override
         protected boolean update(GraphReadMethods graph) {
-//            if (graph == null) {
-//                return false;
-//            }
-
             try {
                 final CountDownLatch latch = new CountDownLatch(1);
 

--- a/CoreConversationView/src/au/gov/asd/tac/constellation/views/conversationview/Conversation.java
+++ b/CoreConversationView/src/au/gov/asd/tac/constellation/views/conversationview/Conversation.java
@@ -203,8 +203,8 @@ public class Conversation {
 
             
             ConversationState newConversationState;
-            if (Objects.nonNull(graph)) {
-                int conversationStateAttribute = ConversationViewConcept.MetaAttribute.CONVERSATION_VIEW_STATE.get(graph);
+            if (graph != null) {
+                final int conversationStateAttribute = ConversationViewConcept.MetaAttribute.CONVERSATION_VIEW_STATE.get(graph);
                 if (conversationStateAttribute == Graph.NOT_FOUND) {
                     newConversationState = new ConversationState();
                     newConversationState.setSenderAttributesToKeys(graph);

--- a/CoreConversationView/src/au/gov/asd/tac/constellation/views/conversationview/Conversation.java
+++ b/CoreConversationView/src/au/gov/asd/tac/constellation/views/conversationview/Conversation.java
@@ -34,6 +34,7 @@ import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.TreeSet;
@@ -122,18 +123,24 @@ public class Conversation {
      * Create a new Conversation.
      */
     public Conversation() {
+        conversationExistanceUpdater.dependOn(graphUpdateController.getNewGraphUpdateComponent());  
+        
+        conversationStateUpdater.dependOn(conversationExistanceUpdater);
         conversationStateUpdater.dependOn(graphUpdateController.createAttributeUpdateComponent(ConversationViewConcept.MetaAttribute.CONVERSATION_VIEW_STATE));
+        
+        possibleSenderAttributeUpdater.dependOn(conversationExistanceUpdater);
+        possibleSenderAttributeUpdater.dependOn(graphUpdateController.getAttributeUpdateComponent());
 
+        senderAttributeUpdater.dependOn(possibleSenderAttributeUpdater);
         senderAttributeUpdater.dependOn(graphUpdateController.getAttributeUpdateComponent());
 
-        possibleSenderAttributeUpdater.dependOn(graphUpdateController.getAttributeUpdateComponent());
-        senderAttributeUpdater.dependOn(possibleSenderAttributeUpdater);
-
+        contributionProviderUpdater.dependOn(conversationExistanceUpdater);
         contributionProviderUpdater.dependOn(graphUpdateController.getAttributeUpdateComponent());
-
+        
+        messageUpdater.dependOn(conversationExistanceUpdater);
         messageUpdater.dependOn(graphUpdateController.createAttributeUpdateComponent(VisualConcept.VertexAttribute.SELECTED));
         messageUpdater.dependOn(graphUpdateController.createAttributeUpdateComponent(VisualConcept.TransactionAttribute.SELECTED));
-
+        
         contributionUpdater.dependOn(messageUpdater);
 
         datetimeUpdater.dependOn(contributionUpdater);
@@ -178,22 +185,39 @@ public class Conversation {
      * Inspects the contents of the conversation state and registers any changes
      * that have occurred.
      */
+    private UpdateComponent<GraphReadMethods> conversationExistanceUpdater = new UpdateComponent<GraphReadMethods>("Existance State", LOCK_STAGE) {
+
+        @Override
+        protected boolean update(GraphReadMethods graph) {
+            return Objects.isNull(graph);
+        }
+    };
+    /**
+     * Inspects the contents of the conversation state and registers any changes
+     * that have occurred.
+     */
     private UpdateComponent<GraphReadMethods> conversationStateUpdater = new UpdateComponent<GraphReadMethods>("Conversation State", LOCK_STAGE) {
 
         @Override
         protected boolean update(GraphReadMethods graph) {
 
+            
             ConversationState newConversationState;
-            int conversationStateAttribute = ConversationViewConcept.MetaAttribute.CONVERSATION_VIEW_STATE.get(graph);
-            if (conversationStateAttribute == Graph.NOT_FOUND) {
-                newConversationState = new ConversationState();
-                newConversationState.setSenderAttributesToKeys(graph);
-            } else {
-                newConversationState = (ConversationState) graph.getObjectValue(conversationStateAttribute, 0);
-                if (newConversationState == null) {
+            int conversationStateAttribute;
+            if (Objects.nonNull(graph)) {
+                conversationStateAttribute = ConversationViewConcept.MetaAttribute.CONVERSATION_VIEW_STATE.get(graph);
+                if (conversationStateAttribute == Graph.NOT_FOUND) {
                     newConversationState = new ConversationState();
                     newConversationState.setSenderAttributesToKeys(graph);
+                } else {
+                    newConversationState = (ConversationState) graph.getObjectValue(conversationStateAttribute, 0);
+                    if (newConversationState == null) {
+                        newConversationState = new ConversationState();
+                        newConversationState.setSenderAttributesToKeys(graph);
+                    }
                 }
+            } else {
+                newConversationState = new ConversationState();
             }
 
             if (!conversationState.getHiddenContributionProviders().equals(newConversationState.getHiddenContributionProviders())) {
@@ -222,12 +246,14 @@ public class Conversation {
         @Override
         protected boolean update(GraphReadMethods graph) {
             possibleSenderAttributes.clear();
-            final int attributeCount = graph.getAttributeCount(GraphElementType.VERTEX);
-            for (int i = 0; i < attributeCount; i++) {
-                final int attributeId = graph.getAttribute(GraphElementType.VERTEX, i);
-                final Attribute attribute = new GraphAttribute(graph, attributeId);
-                if (!ObjectAttributeDescription.class.isAssignableFrom(attribute.getDataType())) {
-                    possibleSenderAttributes.add(attribute.getName());
+            if (Objects.nonNull(graph)) {
+                final int attributeCount = graph.getAttributeCount(GraphElementType.VERTEX);
+                for (int i = 0; i < attributeCount; i++) {
+                    final int attributeId = graph.getAttribute(GraphElementType.VERTEX, i);
+                    final Attribute attribute = new GraphAttribute(graph, attributeId);
+                    if (!ObjectAttributeDescription.class.isAssignableFrom(attribute.getDataType())) {
+                        possibleSenderAttributes.add(attribute.getName());
+                    }
                 }
             }
             return true;
@@ -286,7 +312,6 @@ public class Conversation {
                 final Thread thread = new Thread(CONVERSATION_VIEW_UPDATE_MESSAGE_THREAD_NAME) {
                     @Override
                     public void run() {
-                        allMessages.clear();
                         messageProvider.getMessages(graph, allMessages);
                         latch.countDown();
                     }
@@ -410,9 +435,9 @@ public class Conversation {
     private UpdateComponent<GraphReadMethods> senderUpdater = new UpdateComponent<GraphReadMethods>("Senders", LOCK_STAGE) {
         @Override
         protected boolean update(GraphReadMethods graph) {
-            if (graph == null) {
-                return false;
-            }
+//            if (graph == null) {
+//                return false;
+//            }
 
             try {
                 final CountDownLatch latch = new CountDownLatch(1);

--- a/CoreConversationView/src/au/gov/asd/tac/constellation/views/conversationview/Conversation.java
+++ b/CoreConversationView/src/au/gov/asd/tac/constellation/views/conversationview/Conversation.java
@@ -34,7 +34,6 @@ import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.TreeSet;

--- a/CoreConversationView/src/au/gov/asd/tac/constellation/views/conversationview/Conversation.java
+++ b/CoreConversationView/src/au/gov/asd/tac/constellation/views/conversationview/Conversation.java
@@ -245,7 +245,7 @@ public class Conversation {
         @Override
         protected boolean update(GraphReadMethods graph) {
             possibleSenderAttributes.clear();
-            if (Objects.nonNull(graph)) {
+            if (graph != null) {
                 final int attributeCount = graph.getAttributeCount(GraphElementType.VERTEX);
                 for (int i = 0; i < attributeCount; i++) {
                     final int attributeId = graph.getAttribute(GraphElementType.VERTEX, i);

--- a/CoreConversationView/src/au/gov/asd/tac/constellation/views/conversationview/ConversationContributionProvider.java
+++ b/CoreConversationView/src/au/gov/asd/tac/constellation/views/conversationview/ConversationContributionProvider.java
@@ -134,7 +134,7 @@ public abstract class ConversationContributionProvider implements Comparable<Con
      */
     public static List<ConversationContributionProvider> getCompatibleProviders(GraphReadMethods graph) {
         final List<ConversationContributionProvider> compatibleProviders = new ArrayList<>();
-        if (Objects.nonNull(graph)) {
+        if (graph != null) {
             for (ConversationContributionProvider provider : getProviders()) {
                 if (provider.isCompatibleWithGraph(graph)) {
                     compatibleProviders.add(provider);

--- a/CoreConversationView/src/au/gov/asd/tac/constellation/views/conversationview/ConversationContributionProvider.java
+++ b/CoreConversationView/src/au/gov/asd/tac/constellation/views/conversationview/ConversationContributionProvider.java
@@ -133,7 +133,7 @@ public abstract class ConversationContributionProvider implements Comparable<Con
      * @return A list of all providers that are compatible with the given graph.
      */
     public static List<ConversationContributionProvider> getCompatibleProviders(GraphReadMethods graph) {
-        List<ConversationContributionProvider> compatibleProviders = new ArrayList<>();
+        final List<ConversationContributionProvider> compatibleProviders = new ArrayList<>();
         if (Objects.nonNull(graph)) {
             for (ConversationContributionProvider provider : getProviders()) {
                 if (provider.isCompatibleWithGraph(graph)) {

--- a/CoreConversationView/src/au/gov/asd/tac/constellation/views/conversationview/ConversationContributionProvider.java
+++ b/CoreConversationView/src/au/gov/asd/tac/constellation/views/conversationview/ConversationContributionProvider.java
@@ -19,7 +19,6 @@ import au.gov.asd.tac.constellation.graph.GraphReadMethods;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.Objects;
 import org.openide.util.Lookup;
 
 /**

--- a/CoreConversationView/src/au/gov/asd/tac/constellation/views/conversationview/ConversationContributionProvider.java
+++ b/CoreConversationView/src/au/gov/asd/tac/constellation/views/conversationview/ConversationContributionProvider.java
@@ -19,6 +19,7 @@ import au.gov.asd.tac.constellation.graph.GraphReadMethods;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 import org.openide.util.Lookup;
 
 /**
@@ -133,9 +134,11 @@ public abstract class ConversationContributionProvider implements Comparable<Con
      */
     public static List<ConversationContributionProvider> getCompatibleProviders(GraphReadMethods graph) {
         List<ConversationContributionProvider> compatibleProviders = new ArrayList<>();
-        for (ConversationContributionProvider provider : getProviders()) {
-            if (provider.isCompatibleWithGraph(graph)) {
-                compatibleProviders.add(provider);
+        if (Objects.nonNull(graph)) {
+            for (ConversationContributionProvider provider : getProviders()) {
+                if (provider.isCompatibleWithGraph(graph)) {
+                    compatibleProviders.add(provider);
+                }
             }
         }
         return compatibleProviders;

--- a/CoreConversationView/src/au/gov/asd/tac/constellation/views/conversationview/DefaultConversationColorProvider.java
+++ b/CoreConversationView/src/au/gov/asd/tac/constellation/views/conversationview/DefaultConversationColorProvider.java
@@ -17,7 +17,6 @@ package au.gov.asd.tac.constellation.views.conversationview;
 
 import au.gov.asd.tac.constellation.graph.GraphReadMethods;
 import java.util.List;
-import java.util.Objects;
 import javafx.scene.paint.Color;
 import javax.swing.SwingUtilities;
 

--- a/CoreConversationView/src/au/gov/asd/tac/constellation/views/conversationview/DefaultConversationColorProvider.java
+++ b/CoreConversationView/src/au/gov/asd/tac/constellation/views/conversationview/DefaultConversationColorProvider.java
@@ -35,7 +35,7 @@ public class DefaultConversationColorProvider implements ConversationColorProvid
     public void updateMessageColors(GraphReadMethods graph, List<ConversationMessage> messages) {
         assert !SwingUtilities.isEventDispatchThread();
         
-        if (Objects.isNull(graph) || messages.isEmpty()) {
+        if (graph == null || messages.isEmpty()) {
             return; // Nothing to do.
         }
         

--- a/CoreConversationView/src/au/gov/asd/tac/constellation/views/conversationview/DefaultConversationColorProvider.java
+++ b/CoreConversationView/src/au/gov/asd/tac/constellation/views/conversationview/DefaultConversationColorProvider.java
@@ -17,6 +17,7 @@ package au.gov.asd.tac.constellation.views.conversationview;
 
 import au.gov.asd.tac.constellation.graph.GraphReadMethods;
 import java.util.List;
+import java.util.Objects;
 import javafx.scene.paint.Color;
 import javax.swing.SwingUtilities;
 
@@ -33,7 +34,11 @@ public class DefaultConversationColorProvider implements ConversationColorProvid
     @Override
     public void updateMessageColors(GraphReadMethods graph, List<ConversationMessage> messages) {
         assert !SwingUtilities.isEventDispatchThread();
-
+        
+        if (Objects.isNull(graph) || messages.isEmpty()) {
+            return; // Nothing to do.
+        }
+        
         final DefaultConversationColor color = new DefaultConversationColor(0.3f, 0.8f);
 
         // The position in the vertexColors array of each vertex (by position)

--- a/CoreConversationView/src/au/gov/asd/tac/constellation/views/conversationview/DefaultConversationDatetimeProvider.java
+++ b/CoreConversationView/src/au/gov/asd/tac/constellation/views/conversationview/DefaultConversationDatetimeProvider.java
@@ -22,7 +22,6 @@ import au.gov.asd.tac.constellation.utilities.temporal.TemporalFormatting;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
-import java.util.Objects;
 import javafx.scene.layout.Region;
 import javax.swing.SwingUtilities;
 

--- a/CoreConversationView/src/au/gov/asd/tac/constellation/views/conversationview/DefaultConversationDatetimeProvider.java
+++ b/CoreConversationView/src/au/gov/asd/tac/constellation/views/conversationview/DefaultConversationDatetimeProvider.java
@@ -22,6 +22,7 @@ import au.gov.asd.tac.constellation.utilities.temporal.TemporalFormatting;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
+import java.util.Objects;
 import javafx.scene.layout.Region;
 import javax.swing.SwingUtilities;
 
@@ -36,7 +37,9 @@ public class DefaultConversationDatetimeProvider implements ConversationDatetime
     @Override
     public void updateDatetimes(GraphReadMethods graph, List<ConversationMessage> messages) {
         assert !SwingUtilities.isEventDispatchThread();
-
+        if (messages.isEmpty()) {
+            return; // No messages means nothing to do.
+        }
         final int datetimeAttribute = TemporalConcept.TransactionAttribute.DATETIME.get(graph);
         if (datetimeAttribute == Graph.NOT_FOUND) {
             for (ConversationMessage message : messages) {

--- a/CoreConversationView/src/au/gov/asd/tac/constellation/views/conversationview/DefaultConversationMessageProvider.java
+++ b/CoreConversationView/src/au/gov/asd/tac/constellation/views/conversationview/DefaultConversationMessageProvider.java
@@ -40,7 +40,7 @@ public class DefaultConversationMessageProvider implements ConversationMessagePr
     public void getMessages(GraphReadMethods graph, List<ConversationMessage> messages) {
         assert !SwingUtilities.isEventDispatchThread();
         messages.clear();
-        if (Objects.isNull(graph)) {
+        if (graph == null) {
             return; // Null graph means no messages.
         }
         final int vertexSelectedAttribute = VisualConcept.VertexAttribute.SELECTED.get(graph);

--- a/CoreConversationView/src/au/gov/asd/tac/constellation/views/conversationview/DefaultConversationMessageProvider.java
+++ b/CoreConversationView/src/au/gov/asd/tac/constellation/views/conversationview/DefaultConversationMessageProvider.java
@@ -21,7 +21,6 @@ import au.gov.asd.tac.constellation.graph.GraphReadMethods;
 import au.gov.asd.tac.constellation.graph.schema.visual.concept.VisualConcept;
 import au.gov.asd.tac.constellation.graph.utilities.GraphIndexUtilities;
 import java.util.List;
-import java.util.Objects;
 import javax.swing.SwingUtilities;
 
 /**

--- a/CoreConversationView/src/au/gov/asd/tac/constellation/views/conversationview/DefaultConversationMessageProvider.java
+++ b/CoreConversationView/src/au/gov/asd/tac/constellation/views/conversationview/DefaultConversationMessageProvider.java
@@ -21,6 +21,7 @@ import au.gov.asd.tac.constellation.graph.GraphReadMethods;
 import au.gov.asd.tac.constellation.graph.schema.visual.concept.VisualConcept;
 import au.gov.asd.tac.constellation.graph.utilities.GraphIndexUtilities;
 import java.util.List;
+import java.util.Objects;
 import javax.swing.SwingUtilities;
 
 /**
@@ -38,7 +39,10 @@ public class DefaultConversationMessageProvider implements ConversationMessagePr
     @Override
     public void getMessages(GraphReadMethods graph, List<ConversationMessage> messages) {
         assert !SwingUtilities.isEventDispatchThread();
-
+        messages.clear();
+        if (Objects.isNull(graph)) {
+            return; // Null graph means no messages.
+        }
         final int vertexSelectedAttribute = VisualConcept.VertexAttribute.SELECTED.get(graph);
         if (vertexSelectedAttribute != Graph.NOT_FOUND) {
             final GraphIndexResult selectedVertices = GraphIndexUtilities.filterElements(graph, vertexSelectedAttribute, true);

--- a/CoreConversationView/src/au/gov/asd/tac/constellation/views/conversationview/DefaultConversationSenderProvider.java
+++ b/CoreConversationView/src/au/gov/asd/tac/constellation/views/conversationview/DefaultConversationSenderProvider.java
@@ -25,6 +25,7 @@ import au.gov.asd.tac.constellation.utilities.text.SeparatorConstants;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javafx.geometry.Pos;
@@ -51,6 +52,9 @@ public class DefaultConversationSenderProvider implements ConversationSenderProv
     public void updateMessageSenders(GraphReadMethods graph, List<ConversationMessage> messages, List<String> senderAttributes) {
         assert !SwingUtilities.isEventDispatchThread();
 
+        if(Objects.isNull(graph) || messages.isEmpty()){
+            return; //Nothing to do
+        }
         try {
             // Get the icon attribute if it exists
             final int iconAttribute = VisualConcept.VertexAttribute.FOREGROUND_ICON.get(graph);

--- a/CoreConversationView/src/au/gov/asd/tac/constellation/views/conversationview/DefaultConversationSenderProvider.java
+++ b/CoreConversationView/src/au/gov/asd/tac/constellation/views/conversationview/DefaultConversationSenderProvider.java
@@ -52,7 +52,7 @@ public class DefaultConversationSenderProvider implements ConversationSenderProv
     public void updateMessageSenders(GraphReadMethods graph, List<ConversationMessage> messages, List<String> senderAttributes) {
         assert !SwingUtilities.isEventDispatchThread();
 
-        if(Objects.isNull(graph) || messages.isEmpty()){
+        if(graph == null || messages.isEmpty()){
             return; //Nothing to do
         }
         try {

--- a/CoreConversationView/src/au/gov/asd/tac/constellation/views/conversationview/DefaultConversationSenderProvider.java
+++ b/CoreConversationView/src/au/gov/asd/tac/constellation/views/conversationview/DefaultConversationSenderProvider.java
@@ -25,7 +25,6 @@ import au.gov.asd.tac.constellation.utilities.text.SeparatorConstants;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Objects;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javafx.geometry.Pos;


### PR DESCRIPTION

### Description of the Change

<!--

Added new updateComponent and modified methods to enable refresh of the conversation view when a graph is closed and the ability to handle a null graph.

-->

### Alternate Designs

<!--

Considered handling the null case for all methods in the Conversation class to keep all changes to one class. Decided instead to handle null values within methods that have graph as an argument so that the null case is handled if these methods are called from elsewhere.

-->

### Why Should This Be In Core?

<!--

Already in core.

-->

### Benefits
Previous conversation will no longer linger when a graph is closed.

### Possible Drawbacks

Unknown / NA

### Verification Process

Tested opening, modifying and closing graphs in various orders.

### Applicable Issues

fixes #727 
