### PR TITLE
Bugfix/issue826 betweeness assertion error

### DIFF
--- a/CoreAlgorithmPlugins/src/au/gov/asd/tac/constellation/plugins/algorithms/sna/centrality/BetweennessCentralityPlugin.java
+++ b/CoreAlgorithmPlugins/src/au/gov/asd/tac/constellation/plugins/algorithms/sna/centrality/BetweennessCentralityPlugin.java
@@ -153,23 +153,31 @@ public class BetweennessCentralityPlugin extends SimpleEditPlugin {
         // update the graph with betweenness values
         for (int vertexPosition = 0; vertexPosition < vertexCount; vertexPosition++) {
             final int vertexId = graph.getVertex(vertexPosition);
+            float betweennessAttributeValue;
             if (normaliseByPossible) {
                 if (normaliseConnectedComponents) {
                     final float subgraphVertexCount = subgraphs[vertexPosition].cardinality();
+                    betweennessAttributeValue = betweennesses[vertexPosition] / (((subgraphVertexCount - 1) * (subgraphVertexCount - 2)) / 2);
                     graph.setFloatValue(betweennessAttribute, vertexId, betweennesses[vertexPosition] / (((subgraphVertexCount - 1) * (subgraphVertexCount - 2)) / 2));
                 } else {
+                    betweennessAttributeValue = betweennesses[vertexPosition] / (((vertexCount - 1) * (vertexCount - 2)) / 2f);
                     graph.setFloatValue(betweennessAttribute, vertexId, betweennesses[vertexPosition] / (((vertexCount - 1) * (vertexCount - 2)) / 2f));
                 }
             } else if (normaliseByAvailable && maxBetweenness > 0) {
                 if (normaliseConnectedComponents) {
                     final float maxBetweennessConnectedComponent = maxBetweennessConnectedComponents.get(subgraphs[vertexPosition]);
+                    betweennessAttributeValue = betweennesses[vertexPosition] / maxBetweennessConnectedComponent;
                     graph.setFloatValue(betweennessAttribute, vertexId, betweennesses[vertexPosition] / maxBetweennessConnectedComponent);
                 } else {
+                    betweennessAttributeValue = betweennesses[vertexPosition] / maxBetweenness;
                     graph.setFloatValue(betweennessAttribute, vertexId, betweennesses[vertexPosition] / maxBetweenness);
                 }
             } else {
+                betweennessAttributeValue = betweennesses[vertexPosition];
                 graph.setFloatValue(betweennessAttribute, vertexId, betweennesses[vertexPosition]);
             }
+            
+            graph.setFloatValue(betweennessAttribute, vertexId, Float.isNaN(betweennessAttributeValue) ? 0 : betweennessAttributeValue);
         }
     }
 }

--- a/CoreAlgorithmPlugins/src/au/gov/asd/tac/constellation/plugins/algorithms/sna/centrality/BetweennessCentralityPlugin.java
+++ b/CoreAlgorithmPlugins/src/au/gov/asd/tac/constellation/plugins/algorithms/sna/centrality/BetweennessCentralityPlugin.java
@@ -153,7 +153,7 @@ public class BetweennessCentralityPlugin extends SimpleEditPlugin {
         // update the graph with betweenness values
         for (int vertexPosition = 0; vertexPosition < vertexCount; vertexPosition++) {
             final int vertexId = graph.getVertex(vertexPosition);
-            float betweennessAttributeValue;
+            final float betweennessAttributeValue;
             if (normaliseByPossible) {
                 if (normaliseConnectedComponents) {
                     final float subgraphVertexCount = subgraphs[vertexPosition].cardinality();

--- a/CoreAlgorithmPlugins/src/au/gov/asd/tac/constellation/plugins/algorithms/sna/centrality/BetweennessCentralityPlugin.java
+++ b/CoreAlgorithmPlugins/src/au/gov/asd/tac/constellation/plugins/algorithms/sna/centrality/BetweennessCentralityPlugin.java
@@ -158,23 +158,18 @@ public class BetweennessCentralityPlugin extends SimpleEditPlugin {
                 if (normaliseConnectedComponents) {
                     final float subgraphVertexCount = subgraphs[vertexPosition].cardinality();
                     betweennessAttributeValue = betweennesses[vertexPosition] / (((subgraphVertexCount - 1) * (subgraphVertexCount - 2)) / 2);
-                    graph.setFloatValue(betweennessAttribute, vertexId, betweennesses[vertexPosition] / (((subgraphVertexCount - 1) * (subgraphVertexCount - 2)) / 2));
                 } else {
                     betweennessAttributeValue = betweennesses[vertexPosition] / (((vertexCount - 1) * (vertexCount - 2)) / 2f);
-                    graph.setFloatValue(betweennessAttribute, vertexId, betweennesses[vertexPosition] / (((vertexCount - 1) * (vertexCount - 2)) / 2f));
                 }
             } else if (normaliseByAvailable && maxBetweenness > 0) {
                 if (normaliseConnectedComponents) {
                     final float maxBetweennessConnectedComponent = maxBetweennessConnectedComponents.get(subgraphs[vertexPosition]);
                     betweennessAttributeValue = betweennesses[vertexPosition] / maxBetweennessConnectedComponent;
-                    graph.setFloatValue(betweennessAttribute, vertexId, betweennesses[vertexPosition] / maxBetweennessConnectedComponent);
                 } else {
                     betweennessAttributeValue = betweennesses[vertexPosition] / maxBetweenness;
-                    graph.setFloatValue(betweennessAttribute, vertexId, betweennesses[vertexPosition] / maxBetweenness);
                 }
             } else {
                 betweennessAttributeValue = betweennesses[vertexPosition];
-                graph.setFloatValue(betweennessAttribute, vertexId, betweennesses[vertexPosition]);
             }
             
             graph.setFloatValue(betweennessAttribute, vertexId, Float.isNaN(betweennessAttributeValue) ? 0 : betweennessAttributeValue);


### PR DESCRIPTION
# Description of the Change

<!--
Added NaN check to BetweenessCentralityPlugin to stop assertion error.

-->

### Alternate Designs

<!--

Considered moving NaN check upstack to where NaN is originally introduced. Check would instead check that the numerator is 0 and then stop the NaN from occurring by saying if numerator is 0 then value is 0. The downside of this is if a NaN occurred for another reason then we would get an error.
I decided to go with the safer option. The downside of this is we may want to know about the NaN occurring (especially if its for a reason other than the numerator being 0.

-->

### Why Should This Be In Core?

<!--
Already in core

-->

### Benefits
Reduced chance for error.

### Possible Drawbacks

May hide an unintended NaN value.

### Verification Process

<!--

Ran betweenness centrality on multiple graphs, including those that originally caused this error.

-->

### Applicable Issues
Fixes #826 
