### PR TITLE
bugfix remember-dropdownlist-options for Valueinputpane

### DIFF
--- a/CorePluginFramework/src/au/gov/asd/tac/constellation/plugins/gui/ValueInputPane.java
+++ b/CorePluginFramework/src/au/gov/asd/tac/constellation/plugins/gui/ValueInputPane.java
@@ -140,7 +140,7 @@ public class ValueInputPane extends HBox implements RecentValuesListener {
                 }
 
                 if (recentValues != null) {
-                    parameter.setStringValue(recentValues.get(recentValues.size() > 1 ? 1 : 0));
+                    parameter.setStringValue(recentValues.get(0));
                 }
 
                 ListCell<String> button = new ListCell<String>() {


### PR DESCRIPTION
<!--

### Requirements

* Filling out the template is required. Any pull request that does not include
enough information to be reviewed in a timely manner may be closed at the
maintainers' discretion.
* Follow the check list items defined by https://github.com/constellation-app/constellation/blob/master/CONTRIBUTING.md#pull-requests
* All new code requires unit tests to ensure they work as expected and will
continue to work as new code is added in the future (regression testing).
* Make sure your branch name is prefixed by `feature`, `bugfix`, `hotfix` or `release`
* Have you read Constellation's Code of Conduct? By filing an issue, you are
expected to comply with it, including treating everyone with respect:
https://github.com/constellation-app/constellation/blob/master/CODE_OF_CONDUCT.md

-->

### Description of the Change

Fixed a bug for Remember-dropdownlist-options feature. The value input pane needs to pickup first element
from the recent values list.

### Alternate Designs

<!--

Explain what other alternates were considered and why the proposed version was
selected.

-->

### Why Should This Be In Core?

To display the previous value of the text correctly.

### Benefits

To display the previous value of the text correctly.

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process

1.Open DA view and run a plugin which uses a text input.
2.Close DA view
3.Open DA view and verify the previous value of the text displayed.

### Applicable Issues

<!-- Link any applicable issues here -->
