### PR TITLE
:bug: updateSelectablePluginsParameters() now updates aggregator param.

### DIFF
--- a/CoreAnalyticView/src/au/gov/asd/tac/constellation/views/analyticview/AnalyticConfigurationPane.java
+++ b/CoreAnalyticView/src/au/gov/asd/tac/constellation/views/analyticview/AnalyticConfigurationPane.java
@@ -508,7 +508,7 @@ public class AnalyticConfigurationPane extends VBox {
     }
 
     public final void updateSelectablePluginsParameters() {
-        if (categoryListPane.isExpanded()) {
+         if (categoryListPane.isExpanded()) {
             LOGGER.log(Level.INFO, "Update selectable plugins parameters in analytic config pane.");
             pluginList.getItems().forEach(selectablePlugin -> {
                 selectablePlugin.parameters.updateParameterValues(selectablePlugin.updatedParameters);
@@ -520,6 +520,7 @@ public class AnalyticConfigurationPane extends VBox {
                 currentQuestion.initialiseParameters(selectablePlugin.plugin, selectablePlugin.parameters);
             });
         }
+         updateGlobalParameters();
     }
 
     public final List<SelectableAnalyticPlugin> getAllSelectablePlugins() {


### PR DESCRIPTION
### Description of the Change

<!--

It appears that whenever a change is made that could affect one of the analytic parameters all of the parameters are being recreated from scratch. When making a box selection on the graph the aggregator parameter was not being recreated, this change will now cause it to be created. This stops a bug causing an error to occur when someone selects an analytic, changes the selection on the graph and then changes the aggregation method.
Note: I'm not sure why it needs to be rebuilt. I'm sure there is a better more correct way to fix this but as this is a blocking bug I want to get it fixed. Given this bug and performance problems I think really the analytic view needs a complete overhaul. Ill add a ticket for this.

-->

### Alternate Designs

<!--

I think a complete refactor of the analytic view is required. Either to make wholesale changes or confirm that the current method of writing it is the best way,

-->

### Why Should This Be In Core?

<!--

Fixes bug in core module.

-->

### Benefits

Stops analytic view breaking bug.

### Possible Drawbacks

Side effects yet to be discovered by fairly minimal testing.

### Verification Process

<!--

Performed reproducer back to back with and without changes to confirm changes fix the bug. Then randomly did things with the analytic view to confirm correct behaviour.

-->

### Applicable Issues

https://github.com/constellation-app/constellation/issues/891
