### PR TITLE
[Load times] Icon atlas caching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ makefile
 build
 dist
 endorsed
+cache
 /nbproject/private
 /*/nbproject/private
 */.jacocoverage/

--- a/CoreVulkanDisplay/src/au/gov/asd/tac/constellation/visual/vulkan/renderables/CVKFPSRenderable.java
+++ b/CoreVulkanDisplay/src/au/gov/asd/tac/constellation/visual/vulkan/renderables/CVKFPSRenderable.java
@@ -547,9 +547,9 @@ public class CVKFPSRenderable extends CVKRenderable {
         // set the number of pixels per world unit at distance 1
         geometryUBO.pixelDensity      = cvkVisualProcessor.GetPixelDensity();
         geometryUBO.pScale            = pyScale;
-        geometryUBO.iconsPerRowColumn = CVKIconTextureAtlas.GetInstance().iconsPerRowColumn;
-        geometryUBO.iconsPerLayer     = CVKIconTextureAtlas.GetInstance().iconsPerLayer;
-        geometryUBO.atlas2DDimension  = CVKIconTextureAtlas.GetInstance().texture2DDimension;                      
+        geometryUBO.iconsPerRowColumn = CVKIconTextureAtlas.GetInstance().serializableData.iconsPerRowColumn;
+        geometryUBO.iconsPerLayer     = CVKIconTextureAtlas.GetInstance().serializableData.iconsPerLayer;
+        geometryUBO.atlas2DDimension  = CVKIconTextureAtlas.GetInstance().serializableData.texture2DDimension;                      
         geometryUBO.pMatrix.set(cvkVisualProcessor.GetProjectionMatrix());        
 
         // Fill of the geometry uniform buffer

--- a/CoreVulkanDisplay/src/au/gov/asd/tac/constellation/visual/vulkan/renderables/CVKIconsRenderable.java
+++ b/CoreVulkanDisplay/src/au/gov/asd/tac/constellation/visual/vulkan/renderables/CVKIconsRenderable.java
@@ -813,9 +813,9 @@ public class CVKIconsRenderable extends CVKRenderable {
         geometryUBO.pMatrix.set(cvkVisualProcessor.GetProjectionMatrix());
         geometryUBO.pixelDensity = cvkVisualProcessor.GetPixelDensity();
         geometryUBO.highlightColor.set(mtxHighlightColour);
-        geometryUBO.iconsPerRowColumn = CVKIconTextureAtlas.GetInstance().iconsPerRowColumn;
-        geometryUBO.iconsPerLayer     = CVKIconTextureAtlas.GetInstance().iconsPerLayer;
-        geometryUBO.atlas2DDimension  = CVKIconTextureAtlas.GetInstance().texture2DDimension;        
+        geometryUBO.iconsPerRowColumn = CVKIconTextureAtlas.GetInstance().serializableData.iconsPerRowColumn;
+        geometryUBO.iconsPerLayer     = CVKIconTextureAtlas.GetInstance().serializableData.iconsPerLayer;
+        geometryUBO.atlas2DDimension  = CVKIconTextureAtlas.GetInstance().serializableData.texture2DDimension;        
         
         // Staging buffer so our VBO can be device local (most performant memory)
         ByteBuffer pMemory = cvkGeometryUBStagingBuffer.StartMemoryMap(0, GeometryUniformBufferObject.SizeOf());

--- a/CoreVulkanDisplay/src/au/gov/asd/tac/constellation/visual/vulkan/renderables/CVKLoopsRenderable.java
+++ b/CoreVulkanDisplay/src/au/gov/asd/tac/constellation/visual/vulkan/renderables/CVKLoopsRenderable.java
@@ -626,9 +626,9 @@ public class CVKLoopsRenderable extends CVKRenderable {
         geometryUBO.pMatrix.set(cvkVisualProcessor.GetProjectionMatrix());
         geometryUBO.visibilityLow = cvkVisualProcessor.getDisplayCamera().getVisibilityLow();
         geometryUBO.visibilityHigh = cvkVisualProcessor.getDisplayCamera().getVisibilityHigh();            
-        geometryUBO.iconsPerRowColumn = CVKIconTextureAtlas.GetInstance().iconsPerRowColumn;
-        geometryUBO.iconsPerLayer     = CVKIconTextureAtlas.GetInstance().iconsPerLayer;
-        geometryUBO.atlas2DDimension  = CVKIconTextureAtlas.GetInstance().texture2DDimension;           
+        geometryUBO.iconsPerRowColumn = CVKIconTextureAtlas.GetInstance().serializableData.iconsPerRowColumn;
+        geometryUBO.iconsPerLayer     = CVKIconTextureAtlas.GetInstance().serializableData.iconsPerLayer;
+        geometryUBO.atlas2DDimension  = CVKIconTextureAtlas.GetInstance().serializableData.texture2DDimension;           
         
         // Staging buffer so our VBO can be device local (most performant memory)
         ByteBuffer pMemory = cvkGeometryUBStagingBuffer.StartMemoryMap(0, GeometryUniformBufferObject.SizeOf());

--- a/CoreVulkanDisplay/src/au/gov/asd/tac/constellation/visual/vulkan/resourcetypes/CVKIconAtlasSerializable.java
+++ b/CoreVulkanDisplay/src/au/gov/asd/tac/constellation/visual/vulkan/resourcetypes/CVKIconAtlasSerializable.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2010-2020 Australian Signals Directorate
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package au.gov.asd.tac.constellation.visual.vulkan.resourcetypes;
+
+import java.awt.image.BufferedImage;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import javax.imageio.ImageIO;
+
+
+/**
+ * This class stores the minimal set of data needed to cache the icon atlas
+ * textures and dimensions to and from disk.  This improves load times 
+ * significantly.
+ */
+public class CVKIconAtlasSerializable implements Serializable {
+    public transient List<BufferedImage> layers = new ArrayList<>();
+    public final LinkedHashMap<String, Integer> loadedIcons = new LinkedHashMap<>();
+    public int texture2DDimension = 0;  
+    public int iconsPerLayer      = 0;
+    public int iconsPerRowColumn  = 0;
+    public int maxIcons           = Short.MAX_VALUE; 
+    
+    
+    public void Reset() {
+        texture2DDimension = 0;
+        iconsPerLayer = 0;
+        iconsPerRowColumn = 0;
+        maxIcons = Short.MAX_VALUE;
+        layers.clear();
+        loadedIcons.clear();
+    }
+    
+
+    /**
+     * BufferedImages don't implement Serializable and therefore must be manually
+     * serialised.  To do this we mark it transient so defaultWriteObject doesn't
+     * attempt to serialise it.  We then use the ImageIO to serialize to or from
+     * the iostream.
+     * 
+     * @param out: stream this object is serialized to
+     * @throws IOException 
+     */
+    private void writeObject(ObjectOutputStream out) throws IOException {
+        out.defaultWriteObject();
+        out.writeInt(layers.size());
+        for (BufferedImage eachImage : layers) {
+            ImageIO.write(eachImage, "png", out); // png is lossless
+        }        
+    }
+    
+    /**
+     * BufferedImages don't implement Serializable and therefore must be manually
+     * serialised.  To do this we mark it transient so defaultWriteObject doesn't
+     * attempt to serialise it.  We then use the ImageIO to serialize to or from
+     * the iostream.
+     * 
+     * @param in: stream this object is serialized from
+     * @throws IOException 
+     */    
+    private void readObject(ObjectInputStream in) throws IOException, ClassNotFoundException {
+        in.defaultReadObject();
+        final int imageCount = in.readInt();
+        layers = new ArrayList<>(imageCount);
+        for (int i = 0; i < imageCount; ++i) {
+            BufferedImage image = ImageIO.read(in);
+            layers.add(image);
+        }
+    }
+}

--- a/CoreVulkanDisplay/src/au/gov/asd/tac/constellation/visual/vulkan/utils/CVKUtils.java
+++ b/CoreVulkanDisplay/src/au/gov/asd/tac/constellation/visual/vulkan/utils/CVKUtils.java
@@ -81,14 +81,51 @@ public class CVKUtils {
     public static final int CVK_ERROR_ICON_ATLAS_UNSUPPORTED_ICON_FORMAT        = 0xFFFF0018;
     
     // Enable this for additional logging, thread verification and other checks
-    public static final boolean CVK_DEBUGGING = Boolean.parseBoolean(System.getProperty("debug_renderer"));
-    public static final Level CVK_ALLOCATION_LOG_LEVEL = System.getProperty("renderer_allocation_log_level") != null ? 
-            Level.parse(System.getProperty("renderer_allocation_log_level")) :
-            Level.OFF;  
-    public static final Level CVK_DEFAULT_LOG_LEVEL = System.getProperty("renderer_log_level") != null ? 
-            Level.parse(System.getProperty("renderer_log_level")) :
-            Level.OFF;  
+    public static final boolean CVK_DEBUGGING;
+    public static final Level CVK_ALLOCATION_LOG_LEVEL;
+    public static final Level CVK_DEFAULT_LOG_LEVEL;
     public static int CVK_VKALLOCATIONS = 0;
+    public static final boolean CVK_ICON_ATLAS_CACHING;
+    
+    
+    // Initialise static vars from config
+    static {
+        boolean debugging;
+        try {
+            debugging = Boolean.parseBoolean(System.getProperty("debug_renderer"));
+        } catch (Throwable t) {
+            debugging = false;
+        }
+        CVK_DEBUGGING = debugging; 
+        
+        Level allocationLogLevel;
+        try {
+            allocationLogLevel = System.getProperty("renderer_allocation_log_level") != null ? 
+                Level.parse(System.getProperty("renderer_allocation_log_level").toUpperCase()) :
+                Level.OFF;  
+        } catch (Throwable t) {
+            allocationLogLevel = Level.OFF;
+        }
+        CVK_ALLOCATION_LOG_LEVEL = allocationLogLevel;    
+        
+        Level defaultLogLevel;
+        try {
+            defaultLogLevel = System.getProperty("renderer_log_level") != null ? 
+                Level.parse(System.getProperty("renderer_log_level").toUpperCase()) :
+                Level.OFF;  
+        } catch (Throwable t) {
+            defaultLogLevel = Level.OFF;
+        }
+        CVK_DEFAULT_LOG_LEVEL = defaultLogLevel;      
+        
+        boolean iconCaching;
+        try {
+            iconCaching = Boolean.parseBoolean(System.getProperty("cache_icon_atlas"));
+        } catch (Throwable t) {
+            iconCaching = false;
+        }
+        CVK_ICON_ATLAS_CACHING = iconCaching;         
+    }
    
 
     public static void LogStackTrace(Level level) {

--- a/renderer.conf
+++ b/renderer.conf
@@ -2,3 +2,4 @@ factory=au.gov.asd.tac.constellation.graph.interaction.visual.VKInteractiveVisua
 debug_renderer=false
 renderer_log_level=OFF
 renderer_allocation_log_level=FINEST
+cache_icon_atlas=true


### PR DESCRIPTION
[Load times] Icon atlas caching

* Added new flag to renderer.conf to allow caching icon atlas to and from disk.
* Fixed CVKImage only ever writing and mapping the first layer.
* Made renderer.conf variable parsing exception tolerant.
* Some TODOs in this MR that need to be addressed before this feature could be called robust.