### PR TITLE
Performance/28 aggregation speed

### DIFF
--- a/CoreAnalyticView/src/au/gov/asd/tac/constellation/views/analyticview/aggregators/AppendScoreAggregator.java
+++ b/CoreAnalyticView/src/au/gov/asd/tac/constellation/views/analyticview/aggregators/AppendScoreAggregator.java
@@ -17,6 +17,7 @@ package au.gov.asd.tac.constellation.views.analyticview.aggregators;
 
 import au.gov.asd.tac.constellation.views.analyticview.results.AnalyticResult;
 import au.gov.asd.tac.constellation.views.analyticview.results.ScoreResult;
+import au.gov.asd.tac.constellation.views.analyticview.results.ScoreResult.ElementScore;
 import au.gov.asd.tac.constellation.views.analyticview.utilities.AnalyticException;
 import java.util.List;
 import org.apache.commons.collections4.CollectionUtils;
@@ -41,7 +42,7 @@ public class AppendScoreAggregator implements AnalyticAggregator<ScoreResult> {
         aggregateResult.setIgnoreNullResults(results.stream()
                 .anyMatch(result -> result.getIgnoreNullResults()));
 
-        results.forEach(result -> aggregateResult.combine(result));
+        results.forEach(scoreResult -> aggregateResult.combine(scoreResult, ElementScore::combineReplace));
         
         return aggregateResult;
     }

--- a/CoreAnalyticView/src/au/gov/asd/tac/constellation/views/analyticview/aggregators/AppendScoreAggregator.java
+++ b/CoreAnalyticView/src/au/gov/asd/tac/constellation/views/analyticview/aggregators/AppendScoreAggregator.java
@@ -15,17 +15,10 @@
  */
 package au.gov.asd.tac.constellation.views.analyticview.aggregators;
 
-import au.gov.asd.tac.constellation.graph.GraphElementType;
-import au.gov.asd.tac.constellation.utilities.datastructure.ThreeTuple;
 import au.gov.asd.tac.constellation.views.analyticview.results.AnalyticResult;
 import au.gov.asd.tac.constellation.views.analyticview.results.ScoreResult;
-import au.gov.asd.tac.constellation.views.analyticview.results.ScoreResult.ElementScore;
 import au.gov.asd.tac.constellation.views.analyticview.utilities.AnalyticException;
-import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
-import java.util.Set;
 import org.apache.commons.collections4.CollectionUtils;
 import org.openide.util.lookup.ServiceProvider;
 
@@ -48,42 +41,8 @@ public class AppendScoreAggregator implements AnalyticAggregator<ScoreResult> {
         aggregateResult.setIgnoreNullResults(results.stream()
                 .anyMatch(result -> result.getIgnoreNullResults()));
 
-        final Set<ThreeTuple<GraphElementType, Integer, String>> elements = new HashSet<>();
-        for (final ScoreResult result : results) {
-            for (final ElementScore score : result.get()) {
-                elements.add(ThreeTuple.create(score.getElementType(), score.getElementId(), score.getIdentifier()));
-            }
-        }
-
-        boolean isNull;
-        Map<String, Float> namedScores = new HashMap<>();
-        for (final ThreeTuple<GraphElementType, Integer, String> element : elements) {
-            final GraphElementType type = element.getFirst();
-            final int id = element.getSecond();
-            final String identifier = element.getThird();
-            isNull = false;
-            namedScores.clear();
-
-            for (final ScoreResult result : results) {
-                result.setIgnoreNullResults(false);
-                for (final ElementScore score : result.get()) {
-                    if (type == score.getElementType() && id == score.getElementId()) {
-                        for (final String scoreName : score.getNamedScores().keySet()) {
-                            if (namedScores.containsKey(scoreName)) {
-                                throw new AnalyticException("AppendScoreAggregator cannot combine multiple scores with the same name [" + scoreName + "]");
-                            }
-                            isNull |= score.isNull();
-                            namedScores.put(scoreName, score.getNamedScore(scoreName));
-                        }
-                    }
-                }
-            }
-
-            final Map<String, Float> aggregateScores = new HashMap<>(namedScores);
-
-            aggregateResult.add(new ElementScore(type, id, identifier, isNull, aggregateScores));
-        }
-
+        results.forEach(result -> aggregateResult.combine(result));
+        
         return aggregateResult;
     }
 

--- a/CoreAnalyticView/src/au/gov/asd/tac/constellation/views/analyticview/aggregators/AppendScoreAggregator.java
+++ b/CoreAnalyticView/src/au/gov/asd/tac/constellation/views/analyticview/aggregators/AppendScoreAggregator.java
@@ -42,7 +42,7 @@ public class AppendScoreAggregator implements AnalyticAggregator<ScoreResult> {
         aggregateResult.setIgnoreNullResults(results.stream()
                 .anyMatch(result -> result.getIgnoreNullResults()));
 
-        results.forEach(scoreResult -> aggregateResult.combine(scoreResult, ElementScore::combineReplace));
+        results.forEach(scoreResult -> aggregateResult.combine(scoreResult));
         
         return aggregateResult;
     }

--- a/CoreAnalyticView/src/au/gov/asd/tac/constellation/views/analyticview/aggregators/MaxScoreAggregator.java
+++ b/CoreAnalyticView/src/au/gov/asd/tac/constellation/views/analyticview/aggregators/MaxScoreAggregator.java
@@ -46,7 +46,7 @@ public class MaxScoreAggregator implements AnalyticAggregator<ScoreResult> {
         aggregateResult.setIgnoreNullResults(results.stream()
                 .anyMatch(result -> result.getIgnoreNullResults()));
 
-        results.forEach(scoreResult -> combinedResults.combine(scoreResult, ElementScore::combineReplace));
+        results.forEach(scoreResult -> combinedResults.combine(scoreResult));
         combinedResults.getResult().forEach((IdentificationData key, ElementScore value) -> {
             final Map<String, Float> aggregateScores = new HashMap<>();
             aggregateScores.put(SCORE_NAME, value.getNamedScores().values().stream().reduce(Math::max).orElse((float) 0.0));

--- a/CoreAnalyticView/src/au/gov/asd/tac/constellation/views/analyticview/aggregators/MaxScoreAggregator.java
+++ b/CoreAnalyticView/src/au/gov/asd/tac/constellation/views/analyticview/aggregators/MaxScoreAggregator.java
@@ -16,7 +16,6 @@
 package au.gov.asd.tac.constellation.views.analyticview.aggregators;
 
 import au.gov.asd.tac.constellation.views.analyticview.results.AnalyticResult;
-import au.gov.asd.tac.constellation.views.analyticview.results.IdentificationData;
 import au.gov.asd.tac.constellation.views.analyticview.results.ScoreResult;
 import au.gov.asd.tac.constellation.views.analyticview.results.ScoreResult.ElementScore;
 import java.util.HashMap;
@@ -47,9 +46,9 @@ public class MaxScoreAggregator implements AnalyticAggregator<ScoreResult> {
                 .anyMatch(result -> result.getIgnoreNullResults()));
 
         results.forEach(scoreResult -> combinedResults.combine(scoreResult));
-        combinedResults.getResult().forEach((IdentificationData key, ElementScore value) -> {
+        combinedResults.getResult().forEach((key, value) -> {
             final Map<String, Float> aggregateScores = new HashMap<>();
-            aggregateScores.put(SCORE_NAME, value.getNamedScores().values().stream().reduce(Math::max).orElse((float) 0.0));
+            aggregateScores.put(SCORE_NAME, value.getNamedScores().values().stream().reduce(Math::max).orElse(0.0f));
             aggregateResult.add(new ElementScore(key.getElementType(), key.getElementId(), key.getIdentifier(), false, aggregateScores));
         });
         

--- a/CoreAnalyticView/src/au/gov/asd/tac/constellation/views/analyticview/aggregators/MaxScoreAggregator.java
+++ b/CoreAnalyticView/src/au/gov/asd/tac/constellation/views/analyticview/aggregators/MaxScoreAggregator.java
@@ -15,17 +15,13 @@
  */
 package au.gov.asd.tac.constellation.views.analyticview.aggregators;
 
-import au.gov.asd.tac.constellation.graph.GraphElementType;
-import au.gov.asd.tac.constellation.utilities.datastructure.ThreeTuple;
 import au.gov.asd.tac.constellation.views.analyticview.results.AnalyticResult;
+import au.gov.asd.tac.constellation.views.analyticview.results.IdentificationData;
 import au.gov.asd.tac.constellation.views.analyticview.results.ScoreResult;
 import au.gov.asd.tac.constellation.views.analyticview.results.ScoreResult.ElementScore;
-import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import org.apache.commons.collections4.CollectionUtils;
 import org.openide.util.lookup.ServiceProvider;
 
@@ -40,6 +36,7 @@ public class MaxScoreAggregator implements AnalyticAggregator<ScoreResult> {
 
     @Override
     public ScoreResult aggregate(final List<ScoreResult> results) {
+        final ScoreResult combinedResults = new ScoreResult();
         final ScoreResult aggregateResult = new ScoreResult();
 
         if (CollectionUtils.isEmpty(results)) {
@@ -49,43 +46,16 @@ public class MaxScoreAggregator implements AnalyticAggregator<ScoreResult> {
         aggregateResult.setIgnoreNullResults(results.stream()
                 .anyMatch(result -> result.getIgnoreNullResults()));
 
-        final Set<ThreeTuple<GraphElementType, Integer, String>> elements = new HashSet<>();
-        for (final ScoreResult result : results) {
-            for (final ElementScore score : result.get()) {
-                elements.add(ThreeTuple.create(score.getElementType(), score.getElementId(), score.getIdentifier()));
-            }
-        }
-
-        boolean isNull;
-        final List<Float> scores = new ArrayList<>();
-        for (final ThreeTuple<GraphElementType, Integer, String> element : elements) {
-            final GraphElementType type = element.getFirst();
-            final int id = element.getSecond();
-            final String identifier = element.getThird();
-            isNull = false;
-            scores.clear();
-
-            for (final ScoreResult result : results) {
-                result.setIgnoreNullResults(false);
-                for (final ElementScore score : result.get()) {
-                    if (type == score.getElementType() && id == score.getElementId()) {
-                        for (final String scoreName : score.getNamedScores().keySet()) {
-                            isNull |= score.isNull();
-                            scores.add(score.getNamedScore(scoreName));
-                        }
-                    }
-                }
-            }
-
+        results.forEach(scoreResult -> combinedResults.combine(scoreResult, ElementScore::combineReplace));
+        combinedResults.getResult().forEach((IdentificationData key, ElementScore value) -> {
             final Map<String, Float> aggregateScores = new HashMap<>();
-            aggregateScores.put(SCORE_NAME, scores.stream().reduce(Math::max).orElse((float) 0.0));
-
-            aggregateResult.add(new ElementScore(type, id, identifier, isNull, aggregateScores));
-        }
-
+            aggregateScores.put(SCORE_NAME, value.getNamedScores().values().stream().reduce(Math::max).orElse((float) 0.0));
+            aggregateResult.add(new ElementScore(key.getElementType(), key.getElementId(), key.getIdentifier(), false, aggregateScores));
+        });
+        
         return aggregateResult;
     }
-
+  
     @Override
     public String getName() {
         return SCORE_NAME;

--- a/CoreAnalyticView/src/au/gov/asd/tac/constellation/views/analyticview/aggregators/MeanScoreAggregator.java
+++ b/CoreAnalyticView/src/au/gov/asd/tac/constellation/views/analyticview/aggregators/MeanScoreAggregator.java
@@ -16,7 +16,6 @@
 package au.gov.asd.tac.constellation.views.analyticview.aggregators;
 
 import au.gov.asd.tac.constellation.views.analyticview.results.AnalyticResult;
-import au.gov.asd.tac.constellation.views.analyticview.results.IdentificationData;
 import au.gov.asd.tac.constellation.views.analyticview.results.ScoreResult;
 import au.gov.asd.tac.constellation.views.analyticview.results.ScoreResult.ElementScore;
 import java.util.HashMap;
@@ -47,9 +46,9 @@ public class MeanScoreAggregator implements AnalyticAggregator<ScoreResult> {
                 .anyMatch(result -> result.getIgnoreNullResults()));
 
         results.forEach(scoreResult -> combinedResults.combine(scoreResult));
-        combinedResults.getResult().forEach((IdentificationData key, ElementScore value) -> {
+        combinedResults.getResult().forEach((key, value) -> {
             final Map<String, Float> aggregateScores = new HashMap<>();
-            aggregateScores.put(SCORE_NAME, value.getNamedScores().values().stream().reduce((x,y) -> x+y).orElse((float) 0.0) / value.getNamedScores().size());
+            aggregateScores.put(SCORE_NAME, value.getNamedScores().values().stream().reduce((x,y) -> x+y).orElse(0.0f) / value.getNamedScores().size());
             aggregateResult.add(new ElementScore(key.getElementType(), key.getElementId(), key.getIdentifier(), false, aggregateScores));
         });
         

--- a/CoreAnalyticView/src/au/gov/asd/tac/constellation/views/analyticview/aggregators/MeanScoreAggregator.java
+++ b/CoreAnalyticView/src/au/gov/asd/tac/constellation/views/analyticview/aggregators/MeanScoreAggregator.java
@@ -15,17 +15,13 @@
  */
 package au.gov.asd.tac.constellation.views.analyticview.aggregators;
 
-import au.gov.asd.tac.constellation.graph.GraphElementType;
-import au.gov.asd.tac.constellation.utilities.datastructure.ThreeTuple;
 import au.gov.asd.tac.constellation.views.analyticview.results.AnalyticResult;
+import au.gov.asd.tac.constellation.views.analyticview.results.IdentificationData;
 import au.gov.asd.tac.constellation.views.analyticview.results.ScoreResult;
 import au.gov.asd.tac.constellation.views.analyticview.results.ScoreResult.ElementScore;
-import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import org.apache.commons.collections4.CollectionUtils;
 import org.openide.util.lookup.ServiceProvider;
 
@@ -40,6 +36,7 @@ public class MeanScoreAggregator implements AnalyticAggregator<ScoreResult> {
 
     @Override
     public ScoreResult aggregate(final List<ScoreResult> results) {
+        final ScoreResult combinedResults = new ScoreResult();
         final ScoreResult aggregateResult = new ScoreResult();
 
         if (CollectionUtils.isEmpty(results)) {
@@ -49,40 +46,13 @@ public class MeanScoreAggregator implements AnalyticAggregator<ScoreResult> {
         aggregateResult.setIgnoreNullResults(results.stream()
                 .anyMatch(result -> result.getIgnoreNullResults()));
 
-        final Set<ThreeTuple<GraphElementType, Integer, String>> elements = new HashSet<>();
-        for (final ScoreResult result : results) {
-            for (final ElementScore score : result.get()) {
-                elements.add(ThreeTuple.create(score.getElementType(), score.getElementId(), score.getIdentifier()));
-            }
-        }
-
-        boolean isNull;
-        final List<Float> scores = new ArrayList<>();
-        for (final ThreeTuple<GraphElementType, Integer, String> element : elements) {
-            final GraphElementType type = element.getFirst();
-            final int id = element.getSecond();
-            final String identifier = element.getThird();
-            isNull = false;
-            scores.clear();
-
-            for (final ScoreResult result : results) {
-                result.setIgnoreNullResults(false);
-                for (final ElementScore score : result.get()) {
-                    if (type == score.getElementType() && id == score.getElementId()) {
-                        for (final String scoreName : score.getNamedScores().keySet()) {
-                            isNull |= score.isNull();
-                            scores.add(score.getNamedScore(scoreName));
-                        }
-                    }
-                }
-            }
-
+        results.forEach(scoreResult -> combinedResults.combine(scoreResult, ElementScore::combineReplace));
+        combinedResults.getResult().forEach((IdentificationData key, ElementScore value) -> {
             final Map<String, Float> aggregateScores = new HashMap<>();
-            aggregateScores.put(SCORE_NAME, scores.stream().reduce((x, y) -> x + y).orElse((float) 0.0) / scores.size());
-
-            aggregateResult.add(new ElementScore(type, id, identifier, isNull, aggregateScores));
-        }
-
+            aggregateScores.put(SCORE_NAME, value.getNamedScores().values().stream().reduce((x,y) -> x+y).orElse((float) 0.0) / value.getNamedScores().size());
+            aggregateResult.add(new ElementScore(key.getElementType(), key.getElementId(), key.getIdentifier(), false, aggregateScores));
+        });
+        
         return aggregateResult;
     }
 

--- a/CoreAnalyticView/src/au/gov/asd/tac/constellation/views/analyticview/aggregators/MeanScoreAggregator.java
+++ b/CoreAnalyticView/src/au/gov/asd/tac/constellation/views/analyticview/aggregators/MeanScoreAggregator.java
@@ -46,7 +46,7 @@ public class MeanScoreAggregator implements AnalyticAggregator<ScoreResult> {
         aggregateResult.setIgnoreNullResults(results.stream()
                 .anyMatch(result -> result.getIgnoreNullResults()));
 
-        results.forEach(scoreResult -> combinedResults.combine(scoreResult, ElementScore::combineReplace));
+        results.forEach(scoreResult -> combinedResults.combine(scoreResult));
         combinedResults.getResult().forEach((IdentificationData key, ElementScore value) -> {
             final Map<String, Float> aggregateScores = new HashMap<>();
             aggregateScores.put(SCORE_NAME, value.getNamedScores().values().stream().reduce((x,y) -> x+y).orElse((float) 0.0) / value.getNamedScores().size());

--- a/CoreAnalyticView/src/au/gov/asd/tac/constellation/views/analyticview/aggregators/MinScoreAggregator.java
+++ b/CoreAnalyticView/src/au/gov/asd/tac/constellation/views/analyticview/aggregators/MinScoreAggregator.java
@@ -16,7 +16,6 @@
 package au.gov.asd.tac.constellation.views.analyticview.aggregators;
 
 import au.gov.asd.tac.constellation.views.analyticview.results.AnalyticResult;
-import au.gov.asd.tac.constellation.views.analyticview.results.IdentificationData;
 import au.gov.asd.tac.constellation.views.analyticview.results.ScoreResult;
 import au.gov.asd.tac.constellation.views.analyticview.results.ScoreResult.ElementScore;
 import java.util.HashMap;
@@ -47,9 +46,9 @@ public class MinScoreAggregator implements AnalyticAggregator<ScoreResult> {
                 .anyMatch(result -> result.getIgnoreNullResults()));
 
         results.forEach(scoreResult -> combinedResults.combine(scoreResult));
-        combinedResults.getResult().forEach((IdentificationData key, ElementScore value) -> {
+        combinedResults.getResult().forEach((key, value) -> {
             final Map<String, Float> aggregateScores = new HashMap<>();
-            aggregateScores.put(SCORE_NAME, value.getNamedScores().values().stream().reduce(Math::min).orElse((float) 0.0));
+            aggregateScores.put(SCORE_NAME, value.getNamedScores().values().stream().reduce(Math::min).orElse(0.0f));
             aggregateResult.add(new ElementScore(key.getElementType(), key.getElementId(), key.getIdentifier(), false, aggregateScores));
         });
         

--- a/CoreAnalyticView/src/au/gov/asd/tac/constellation/views/analyticview/aggregators/MinScoreAggregator.java
+++ b/CoreAnalyticView/src/au/gov/asd/tac/constellation/views/analyticview/aggregators/MinScoreAggregator.java
@@ -15,17 +15,13 @@
  */
 package au.gov.asd.tac.constellation.views.analyticview.aggregators;
 
-import au.gov.asd.tac.constellation.graph.GraphElementType;
-import au.gov.asd.tac.constellation.utilities.datastructure.ThreeTuple;
 import au.gov.asd.tac.constellation.views.analyticview.results.AnalyticResult;
+import au.gov.asd.tac.constellation.views.analyticview.results.IdentificationData;
 import au.gov.asd.tac.constellation.views.analyticview.results.ScoreResult;
 import au.gov.asd.tac.constellation.views.analyticview.results.ScoreResult.ElementScore;
-import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import org.apache.commons.collections4.CollectionUtils;
 import org.openide.util.lookup.ServiceProvider;
 
@@ -40,6 +36,7 @@ public class MinScoreAggregator implements AnalyticAggregator<ScoreResult> {
 
     @Override
     public ScoreResult aggregate(final List<ScoreResult> results) {
+        final ScoreResult combinedResults = new ScoreResult();
         final ScoreResult aggregateResult = new ScoreResult();
 
         if (CollectionUtils.isEmpty(results)) {
@@ -49,40 +46,13 @@ public class MinScoreAggregator implements AnalyticAggregator<ScoreResult> {
         aggregateResult.setIgnoreNullResults(results.stream()
                 .anyMatch(result -> result.getIgnoreNullResults()));
 
-        final Set<ThreeTuple<GraphElementType, Integer, String>> elements = new HashSet<>();
-        for (final ScoreResult result : results) {
-            for (final ElementScore score : result.get()) {
-                elements.add(ThreeTuple.create(score.getElementType(), score.getElementId(), score.getIdentifier()));
-            }
-        }
-
-        boolean isNull;
-        List<Float> scores = new ArrayList<>();
-        for (final ThreeTuple<GraphElementType, Integer, String> element : elements) {
-            final GraphElementType type = element.getFirst();
-            final int id = element.getSecond();
-            final String identifier = element.getThird();
-            isNull = false;
-            scores.clear();
-
-            for (final ScoreResult result : results) {
-                result.setIgnoreNullResults(false);
-                for (final ElementScore score : result.get()) {
-                    if (type == score.getElementType() && id == score.getElementId()) {
-                        for (final String scoreName : score.getNamedScores().keySet()) {
-                            isNull |= score.isNull();
-                            scores.add(score.getNamedScore(scoreName));
-                        }
-                    }
-                }
-            }
-
+        results.forEach(scoreResult -> combinedResults.combine(scoreResult, ElementScore::combineReplace));
+        combinedResults.getResult().forEach((IdentificationData key, ElementScore value) -> {
             final Map<String, Float> aggregateScores = new HashMap<>();
-            aggregateScores.put(SCORE_NAME, scores.stream().reduce(Math::min).orElse((float) 0.0));
-
-            aggregateResult.add(new ElementScore(type, id, identifier, isNull, aggregateScores));
-        }
-
+            aggregateScores.put(SCORE_NAME, value.getNamedScores().values().stream().reduce(Math::min).orElse((float) 0.0));
+            aggregateResult.add(new ElementScore(key.getElementType(), key.getElementId(), key.getIdentifier(), false, aggregateScores));
+        });
+        
         return aggregateResult;
     }
 

--- a/CoreAnalyticView/src/au/gov/asd/tac/constellation/views/analyticview/aggregators/MinScoreAggregator.java
+++ b/CoreAnalyticView/src/au/gov/asd/tac/constellation/views/analyticview/aggregators/MinScoreAggregator.java
@@ -46,7 +46,7 @@ public class MinScoreAggregator implements AnalyticAggregator<ScoreResult> {
         aggregateResult.setIgnoreNullResults(results.stream()
                 .anyMatch(result -> result.getIgnoreNullResults()));
 
-        results.forEach(scoreResult -> combinedResults.combine(scoreResult, ElementScore::combineReplace));
+        results.forEach(scoreResult -> combinedResults.combine(scoreResult));
         combinedResults.getResult().forEach((IdentificationData key, ElementScore value) -> {
             final Map<String, Float> aggregateScores = new HashMap<>();
             aggregateScores.put(SCORE_NAME, value.getNamedScores().values().stream().reduce(Math::min).orElse((float) 0.0));

--- a/CoreAnalyticView/src/au/gov/asd/tac/constellation/views/analyticview/aggregators/SumScoreAggregator.java
+++ b/CoreAnalyticView/src/au/gov/asd/tac/constellation/views/analyticview/aggregators/SumScoreAggregator.java
@@ -46,7 +46,7 @@ public class SumScoreAggregator implements AnalyticAggregator<ScoreResult> {
         aggregateResult.setIgnoreNullResults(results.stream()
                 .anyMatch(result -> result.getIgnoreNullResults()));
 
-        results.forEach(scoreResult -> combinedResults.combine(scoreResult, ElementScore::combineReplace));
+        results.forEach(scoreResult -> combinedResults.combine(scoreResult));
         combinedResults.getResult().forEach((IdentificationData key, ElementScore value) -> {
             final Map<String, Float> aggregateScores = new HashMap<>();
             aggregateScores.put(SCORE_NAME, value.getNamedScores().values().stream().reduce((x,y) -> x+y).orElse((float) 0.0));

--- a/CoreAnalyticView/src/au/gov/asd/tac/constellation/views/analyticview/aggregators/SumScoreAggregator.java
+++ b/CoreAnalyticView/src/au/gov/asd/tac/constellation/views/analyticview/aggregators/SumScoreAggregator.java
@@ -16,7 +16,6 @@
 package au.gov.asd.tac.constellation.views.analyticview.aggregators;
 
 import au.gov.asd.tac.constellation.views.analyticview.results.AnalyticResult;
-import au.gov.asd.tac.constellation.views.analyticview.results.IdentificationData;
 import au.gov.asd.tac.constellation.views.analyticview.results.ScoreResult;
 import au.gov.asd.tac.constellation.views.analyticview.results.ScoreResult.ElementScore;
 import java.util.HashMap;
@@ -47,9 +46,9 @@ public class SumScoreAggregator implements AnalyticAggregator<ScoreResult> {
                 .anyMatch(result -> result.getIgnoreNullResults()));
 
         results.forEach(scoreResult -> combinedResults.combine(scoreResult));
-        combinedResults.getResult().forEach((IdentificationData key, ElementScore value) -> {
+        combinedResults.getResult().forEach((key, value) -> {
             final Map<String, Float> aggregateScores = new HashMap<>();
-            aggregateScores.put(SCORE_NAME, value.getNamedScores().values().stream().reduce((x,y) -> x+y).orElse((float) 0.0));
+            aggregateScores.put(SCORE_NAME, value.getNamedScores().values().stream().reduce((x,y) -> x+y).orElse(0.0f));
             aggregateResult.add(new ElementScore(key.getElementType(), key.getElementId(), key.getIdentifier(), false, aggregateScores));
         });
         

--- a/CoreAnalyticView/src/au/gov/asd/tac/constellation/views/analyticview/results/AnalyticData.java
+++ b/CoreAnalyticView/src/au/gov/asd/tac/constellation/views/analyticview/results/AnalyticData.java
@@ -23,16 +23,16 @@ import au.gov.asd.tac.constellation.graph.GraphElementType;
  */
 public abstract class AnalyticData {
 
-    protected final GraphElementType elementType;
-    protected final int elementId;
-    protected final String identifier;
+    protected final IdentificationData id;
     protected final boolean isNull;
 
     public AnalyticData(final GraphElementType elementType, final int elementId, final String identifier, final boolean isNull) {
-        this.elementType = elementType;
-        this.elementId = elementId;
-        this.identifier = identifier;
+        this.id = new IdentificationData(elementType, elementId, identifier);
         this.isNull = isNull;
+    }
+    
+    public IdentificationData getIdentificationData() {
+        return id;
     }
 
     /**
@@ -42,7 +42,7 @@ public abstract class AnalyticData {
      * @return
      */
     public GraphElementType getElementType() {
-        return elementType;
+        return id.getElementType();
     }
 
     /**
@@ -51,7 +51,7 @@ public abstract class AnalyticData {
      * @return
      */
     public int getElementId() {
-        return elementId;
+        return id.getElementId();
     }
 
     /**
@@ -61,7 +61,7 @@ public abstract class AnalyticData {
      * @return
      */
     public String getIdentifier() {
-        return identifier;
+        return id.getIdentifier();
     }
 
     /**
@@ -72,4 +72,5 @@ public abstract class AnalyticData {
     public boolean isNull() {
         return isNull;
     }
+    
 }

--- a/CoreAnalyticView/src/au/gov/asd/tac/constellation/views/analyticview/results/AnalyticResult.java
+++ b/CoreAnalyticView/src/au/gov/asd/tac/constellation/views/analyticview/results/AnalyticResult.java
@@ -80,6 +80,10 @@ public abstract class AnalyticResult<D extends AnalyticData> {
         return Collections.unmodifiableList(result.values().stream().collect(Collectors.toList()));
     }
     
+    public final Map<IdentificationData, D> getResult() {
+        return result;
+    }
+    
     public void add(final D resultData) {
         this.result.put(resultData.getIdentificationData(), resultData);
     }

--- a/CoreAnalyticView/src/au/gov/asd/tac/constellation/views/analyticview/results/AnalyticResult.java
+++ b/CoreAnalyticView/src/au/gov/asd/tac/constellation/views/analyticview/results/AnalyticResult.java
@@ -20,9 +20,9 @@ import au.gov.asd.tac.constellation.views.analyticview.AnalyticViewTopComponent.
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 /**
  * The result of an AnalyticPlugin, which will be supported by one or more
@@ -33,7 +33,8 @@ import java.util.Map;
  */
 public abstract class AnalyticResult<D extends AnalyticData> {
 
-    protected final List<D> result = new LinkedList<>();
+    protected final Map<IdentificationData, D> result = new HashMap<>();
+//    protected final List<D> result = new LinkedList<>();
     protected final Map<String, String> metadata = new HashMap<>();
     protected boolean ignoreNullResults = false;
     protected AnalyticController analyticController = null;
@@ -56,8 +57,8 @@ public abstract class AnalyticResult<D extends AnalyticData> {
     public void setSelectionOnVisualisation(final GraphElementType elementType, final List<Integer> elementIds) {
         final List<D> selectedElementScores = new ArrayList<>();
         final List<D> ignoredElementScores = new ArrayList<>();
-        result.forEach(elementScore -> {
-            if (!elementType.equals(elementScore.elementType)) {
+        result.values().forEach(elementScore -> {
+            if (!elementType.equals(elementScore.getElementType())) {
                 ignoredElementScores.add(elementScore);
             } else if (elementIds.contains(elementScore.getElementId())) {
                 selectedElementScores.add(elementScore);
@@ -73,19 +74,18 @@ public abstract class AnalyticResult<D extends AnalyticData> {
     }
 
     public final void sort() {
-        result.sort(null);
     }
 
     public final List<D> get() {
-        return Collections.unmodifiableList(result);
+        return Collections.unmodifiableList(result.values().stream().collect(Collectors.toList()));
     }
-
-    public void add(final D result) {
-        this.result.add(result);
+    
+    public void add(final D resultData) {
+        this.result.put(resultData.getIdentificationData(), resultData);
     }
 
     public void addAll(final List<D> results) {
-        this.result.addAll(results);
+        results.forEach(result -> this.result.put(result.getIdentificationData(), result));
     }
 
     public final boolean hasMetadata() {

--- a/CoreAnalyticView/src/au/gov/asd/tac/constellation/views/analyticview/results/ClusterResult.java
+++ b/CoreAnalyticView/src/au/gov/asd/tac/constellation/views/analyticview/results/ClusterResult.java
@@ -48,7 +48,7 @@ public class ClusterResult extends AnalyticResult<ClusterData> {
 
         @Override
         public String toString() {
-            return String.format("{%s;%s;%s}", getClass().getSimpleName(), identifier, clusterNumber);
+            return String.format("{%s;%s;%s}", getClass().getSimpleName(), id.identifier, clusterNumber);
         }
 
         @Override

--- a/CoreAnalyticView/src/au/gov/asd/tac/constellation/views/analyticview/results/EmptyResult.java
+++ b/CoreAnalyticView/src/au/gov/asd/tac/constellation/views/analyticview/results/EmptyResult.java
@@ -34,7 +34,7 @@ public class EmptyResult extends AnalyticResult<EmptyData> {
 
         @Override
         public String toString() {
-            return String.format("{%s;%s}", getClass().getSimpleName(), identifier);
+            return String.format("{%s;%s}", getClass().getSimpleName(), id.identifier);
         }
     }
 }

--- a/CoreAnalyticView/src/au/gov/asd/tac/constellation/views/analyticview/results/FactResult.java
+++ b/CoreAnalyticView/src/au/gov/asd/tac/constellation/views/analyticview/results/FactResult.java
@@ -29,7 +29,7 @@ import java.util.stream.Collectors;
 public class FactResult extends AnalyticResult<ElementFact> {
 
     public Set<String> getUniqueFactNames() {
-        return result.stream()
+        return result.values().stream()
                 .map(elementFact -> elementFact.getFactName())
                 .collect(Collectors.toSet());
     }
@@ -67,7 +67,7 @@ public class FactResult extends AnalyticResult<ElementFact> {
 
         @Override
         public String toString() {
-            return String.format("{%s;%s;%s=%s}", getClass().getSimpleName(), identifier, factName, factValue);
+            return String.format("{%s;%s;%s=%s}", getClass().getSimpleName(), id.identifier, factName, factValue);
         }
 
         @Override

--- a/CoreAnalyticView/src/au/gov/asd/tac/constellation/views/analyticview/results/GraphResult.java
+++ b/CoreAnalyticView/src/au/gov/asd/tac/constellation/views/analyticview/results/GraphResult.java
@@ -29,7 +29,7 @@ public class GraphResult extends AnalyticResult<GraphScore> {
 
     @Override
     public void add(final GraphScore result) {
-        this.result.add(result);
+        this.result.put(result.id, result);
         this.metadata.put(result.getType(), String.valueOf(result.getScore()));
     }
 
@@ -69,7 +69,7 @@ public class GraphResult extends AnalyticResult<GraphScore> {
 
         @Override
         public String toString() {
-            return String.format("{%s;%s;%s}", getClass().getSimpleName(), identifier, score);
+            return String.format("{%s;%s;%s}", getClass().getSimpleName(), id.identifier, score);
         }
 
         @Override

--- a/CoreAnalyticView/src/au/gov/asd/tac/constellation/views/analyticview/results/IdentificationData.java
+++ b/CoreAnalyticView/src/au/gov/asd/tac/constellation/views/analyticview/results/IdentificationData.java
@@ -74,7 +74,7 @@ public class IdentificationData {
     }
 
     @Override
-    public boolean equals(Object obj) {
+    public boolean equals(final Object obj) {
         if (this == obj) {
             return true;
         }

--- a/CoreAnalyticView/src/au/gov/asd/tac/constellation/views/analyticview/results/IdentificationData.java
+++ b/CoreAnalyticView/src/au/gov/asd/tac/constellation/views/analyticview/results/IdentificationData.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2010-2020 Australian Signals Directorate
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package au.gov.asd.tac.constellation.views.analyticview.results;
+
+import au.gov.asd.tac.constellation.graph.GraphElementType;
+import java.util.Objects;
+
+/**
+ * A class designed for combining all of the data needed to identify unique graph elements.
+ * 
+ * @author Nova
+ */
+public class IdentificationData {
+   
+    protected final GraphElementType elementType;
+    protected final int elementId;
+    protected final String identifier;
+
+    public IdentificationData(final GraphElementType elementType, final int elementId, final String identifier) {
+        this.elementType = elementType;
+        this.elementId = elementId;
+        this.identifier = identifier;
+    }
+
+    /**
+     * Get the element type of the graph element this AnalyticResult corresponds
+     * to.
+     *
+     * @return
+     */
+    public GraphElementType getElementType() {
+        return elementType;
+    }
+
+    /**
+     * Get the id of the graph element this AnalyticResult corresponds to.
+     *
+     * @return
+     */
+    public int getElementId() {
+        return elementId;
+    }
+
+    /**
+     * Get an identifier value for the graph element this AnalyticResult
+     * corresponds to.
+     *
+     * @return
+     */
+    public String getIdentifier() {
+        return identifier;
+    }
+
+    @Override
+    public int hashCode() {
+        int hash = 3;
+        hash = 71 * hash + Objects.hashCode(this.elementType);
+        hash = 71 * hash + this.elementId;
+        hash = 71 * hash + Objects.hashCode(this.identifier);
+        return hash;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        final IdentificationData other = (IdentificationData) obj;
+        if (this.elementId != other.elementId) {
+            return false;
+        }
+        if (!Objects.equals(this.identifier, other.identifier)) {
+            return false;
+        }
+        if (this.elementType != other.elementType) {
+            return false;
+        }
+        return true;
+    }
+
+
+    
+}

--- a/CoreAnalyticView/src/au/gov/asd/tac/constellation/views/analyticview/results/ScoreResult.java
+++ b/CoreAnalyticView/src/au/gov/asd/tac/constellation/views/analyticview/results/ScoreResult.java
@@ -20,6 +20,7 @@ import au.gov.asd.tac.constellation.views.analyticview.results.ScoreResult.Eleme
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.BiFunction;
 import java.util.stream.Collectors;
 
 /**
@@ -49,9 +50,9 @@ public class ScoreResult extends AnalyticResult<ElementScore> {
         return sb.toString();
     }
     
-    public ScoreResult combine(ScoreResult otherResult) {
+    public ScoreResult combine(ScoreResult otherResult,  BiFunction<ElementScore, ElementScore, ElementScore> remappingFunction) {
         otherResult.result.forEach((key, value) -> 
-        result.merge(key, value, ElementScore::combine)
+        result.merge(key, value, remappingFunction)
         );
         return this;
     }
@@ -66,7 +67,7 @@ public class ScoreResult extends AnalyticResult<ElementScore> {
             this.namedScores = namedScores;
         }
         
-        static public ElementScore combine(ElementScore es1, ElementScore es2) {
+        static public ElementScore combineReplace(ElementScore es1, ElementScore es2) {
             Map<String, Float> combinedNamedScores = new HashMap<>(es1.getNamedScores());
             combinedNamedScores.putAll(es2.getNamedScores());
             

--- a/CoreAnalyticView/src/au/gov/asd/tac/constellation/views/analyticview/results/ScoreResult.java
+++ b/CoreAnalyticView/src/au/gov/asd/tac/constellation/views/analyticview/results/ScoreResult.java
@@ -20,7 +20,6 @@ import au.gov.asd.tac.constellation.views.analyticview.results.ScoreResult.Eleme
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
-import java.util.function.BiFunction;
 import java.util.stream.Collectors;
 
 /**
@@ -50,9 +49,9 @@ public class ScoreResult extends AnalyticResult<ElementScore> {
         return sb.toString();
     }
     
-    public ScoreResult combine(ScoreResult otherResult,  BiFunction<ElementScore, ElementScore, ElementScore> remappingFunction) {
+    public ScoreResult combine(ScoreResult otherResult) {
         otherResult.result.forEach((key, value) -> 
-        result.merge(key, value, remappingFunction)
+        result.merge(key, value, ElementScore::combineReplace)
         );
         return this;
     }
@@ -71,7 +70,7 @@ public class ScoreResult extends AnalyticResult<ElementScore> {
             Map<String, Float> combinedNamedScores = new HashMap<>(es1.getNamedScores());
             combinedNamedScores.putAll(es2.getNamedScores());
             
-            return new ElementScore(es1.getElementType(), es1.getElementId(), es1.getIdentifier(), es1.isNull(), combinedNamedScores);
+            return new ElementScore(es1.getElementType(), es1.getElementId(), es1.getIdentifier(), es1.isNull() && es2.isNull(), combinedNamedScores);
         }
 
         /**

--- a/CoreAnalyticView/src/au/gov/asd/tac/constellation/views/analyticview/results/ScoreResult.java
+++ b/CoreAnalyticView/src/au/gov/asd/tac/constellation/views/analyticview/results/ScoreResult.java
@@ -66,8 +66,8 @@ public class ScoreResult extends AnalyticResult<ElementScore> {
             this.namedScores = namedScores;
         }
         
-        static public ElementScore combineReplace(ElementScore es1, ElementScore es2) {
-            Map<String, Float> combinedNamedScores = new HashMap<>(es1.getNamedScores());
+        public static ElementScore combineReplace(final ElementScore es1, final ElementScore es2) {
+            final Map<String, Float> combinedNamedScores = new HashMap<>(es1.getNamedScores());
             combinedNamedScores.putAll(es2.getNamedScores());
             
             return new ElementScore(es1.getElementType(), es1.getElementId(), es1.getIdentifier(), es1.isNull() && es2.isNull(), combinedNamedScores);

--- a/CoreAnalyticView/src/au/gov/asd/tac/constellation/views/analyticview/results/ScoreResult.java
+++ b/CoreAnalyticView/src/au/gov/asd/tac/constellation/views/analyticview/results/ScoreResult.java
@@ -17,6 +17,7 @@ package au.gov.asd.tac.constellation.views.analyticview.results;
 
 import au.gov.asd.tac.constellation.graph.GraphElementType;
 import au.gov.asd.tac.constellation.views.analyticview.results.ScoreResult.ElementScore;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -30,7 +31,7 @@ import java.util.stream.Collectors;
 public class ScoreResult extends AnalyticResult<ElementScore> {
 
     public Set<String> getUniqueScoreNames() {
-        return result.stream()
+        return result.values().stream()
                 .map(elementScores -> elementScores.getNames())
                 .flatMap(Set::stream).collect(Collectors.toSet());
     }
@@ -38,8 +39,8 @@ public class ScoreResult extends AnalyticResult<ElementScore> {
     @Override
     public String toString() {
         final StringBuilder sb = new StringBuilder();
-        result.forEach(score -> {
-            sb.append(score.elementId).append(": {\n");
+        result.values().forEach(score -> {
+            sb.append(score.getElementId()).append(": {\n");
             score.namedScores.forEach((name, value) -> {
                 sb.append("\tname: ").append(name).append(", value: ").append(value);
             });
@@ -47,7 +48,14 @@ public class ScoreResult extends AnalyticResult<ElementScore> {
         });
         return sb.toString();
     }
-
+    
+    public ScoreResult combine(ScoreResult otherResult) {
+        otherResult.result.forEach((key, value) -> 
+        result.merge(key, value, ElementScore::combine)
+        );
+        return this;
+    }
+    
     public static class ElementScore extends AnalyticData implements Comparable<ElementScore> {
 
         private final Map<String, Float> namedScores;
@@ -56,6 +64,13 @@ public class ScoreResult extends AnalyticResult<ElementScore> {
                 final String identifier, final boolean isNull, final Map<String, Float> namedScores) {
             super(elementType, elementId, identifier, isNull);
             this.namedScores = namedScores;
+        }
+        
+        static public ElementScore combine(ElementScore es1, ElementScore es2) {
+            Map<String, Float> combinedNamedScores = new HashMap<>(es1.getNamedScores());
+            combinedNamedScores.putAll(es2.getNamedScores());
+            
+            return new ElementScore(es1.getElementType(), es1.getElementId(), es1.getIdentifier(), es1.isNull(), combinedNamedScores);
         }
 
         /**
@@ -90,7 +105,7 @@ public class ScoreResult extends AnalyticResult<ElementScore> {
 
         @Override
         public String toString() {
-            return String.format("{%s;%s;%s}", getClass().getSimpleName(), identifier, namedScores);
+            return String.format("{%s;%s;%s}", getClass().getSimpleName(), this.getIdentifier(), namedScores);
         }
 
         @Override


### PR DESCRIPTION
### Description of the Change

<!--
Refactored the way scoreResults are stored to allow for easier combination of results when multiple analytics are run at once. Then made changes to the way the aggregators work to take advantage of this.
This has resulted in improved aggregation speeds.

-->

### Why Should This Be In Core?

<!--

Improvements to the speed of analytic plugins benefit all users.

-->

### Benefits

Speed benefits when using analytic aggregators. Example speed difference:
When running all centrality analytics and using the append aggregator:
1000/1000 Graph: 14,000 ms -> 300 ms
5000/5000 Graph: 525,475ms -> 442 ms

### Possible Drawbacks

Side effect: More results are now shown, previously when aggregating the result would not be shown if any of the analytic produced a null/0 result. Now they show as long as at least one analytic has a non null/0 result.

### Verification Process

<!--

Comparison of results between modified and unmodified version on all aggregators.
Speed tests run using netbeans profiler.

-->

### Applicable Issues

https://github.com/constellation-app/constellation/issues/28
