### PR TITLE
Split Nodes Reset Attributes

### DIFF
--- a/CoreDataAccessView/src/au/gov/asd/tac/constellation/views/dataaccess/plugins/clean/SplitNodesPlugin.java
+++ b/CoreDataAccessView/src/au/gov/asd/tac/constellation/views/dataaccess/plugins/clean/SplitNodesPlugin.java
@@ -121,7 +121,7 @@ public class SplitNodesPlugin extends SimpleEditPlugin implements DataAccessPlug
         
         final PluginParameter<BooleanParameterValue> completeSchema = BooleanParameterType.build(COMPLETE_WITH_SCHEMA_OPTION_ID);
         completeSchema.setName("Complete with Schema");
-        completeSchema.setDescription("Choose to apply the type schema to the graph");
+        completeSchema.setDescription("Choose to apply the type schema to the selection");
         completeSchema.setBooleanValue(true);
         params.addParameter(completeSchema);
 

--- a/CoreDataAccessView/src/au/gov/asd/tac/constellation/views/dataaccess/plugins/clean/SplitNodesPlugin.java
+++ b/CoreDataAccessView/src/au/gov/asd/tac/constellation/views/dataaccess/plugins/clean/SplitNodesPlugin.java
@@ -163,7 +163,7 @@ public class SplitNodesPlugin extends SimpleEditPlugin implements DataAccessPlug
         }
     }
 
-    private int createNewNode(final GraphWriteMethods graph, final int selectedNode, final String newNodeIdentifier, final String linkType, final boolean splitIntoSameLevel) {
+    private int createNewNode(final GraphWriteMethods graph, final int selectedNode, final String newNodeIdentifier, final String linkType, final boolean splitIntoSameLevel) {        
         final int vertexIdentifierAttributeId = VisualConcept.VertexAttribute.IDENTIFIER.ensure(graph);
         final int transactionTypeAttributeId = AnalyticConcept.TransactionAttribute.TYPE.ensure(graph);
         final int transactionDirectedAttribute = VisualConcept.TransactionAttribute.DIRECTED.ensure(graph);
@@ -222,9 +222,8 @@ public class SplitNodesPlugin extends SimpleEditPlugin implements DataAccessPlug
     }
 
     @Override
-    public void edit(final GraphWriteMethods graph, final PluginInteraction interaction, final PluginParameters parameters) throws InterruptedException, PluginException {
-       final StoreGraph subgraph = SubgraphUtilities.copyGraph(graph);
-        
+    public void edit(final GraphWriteMethods graph, final PluginInteraction interaction, final PluginParameters parameters) throws InterruptedException, PluginException {        
+        final StoreGraph subgraph = SubgraphUtilities.copyGraph(graph);
         
         final Map<String, PluginParameter<?>> splitParameters = parameters.getParameters();
         final String character = splitParameters.get(SPLIT_PARAMETER_ID) != null && splitParameters.get(SPLIT_PARAMETER_ID).getStringValue() != null ? splitParameters.get(SPLIT_PARAMETER_ID).getStringValue() : "";
@@ -291,14 +290,13 @@ public class SplitNodesPlugin extends SimpleEditPlugin implements DataAccessPlug
                 vlGraph.retrieveCoords();
             }
 
-           // if (splitParameters.get(COMPLETE_WITH_SCHEMA_OPTION_ID).getBooleanValue()){
-           //     PluginExecution.withPlugin(VisualSchemaPluginRegistry.COMPLETE_SCHEMA).executeNow(graph);
-           // }  
+            if (splitParameters.get(COMPLETE_WITH_SCHEMA_OPTION_ID).getBooleanValue()){
+                PluginExecution.withPlugin(VisualSchemaPluginRegistry.COMPLETE_SCHEMA).executeNow(graph);
+            }  
             
-           // PluginExecution.withPlugin(VisualSchemaPluginRegistry.COMPLETE_SCHEMA).executeNow(subgraph);
             PluginExecutor.startWith(InteractiveGraphPluginRegistry.RESET_VIEW).executeNow(subgraph);
             PluginExecutor.startWith(InteractiveGraphPluginRegistry.RESET_VIEW).executeNow(graph);
-            final RecordStore subgraphScore = GraphRecordStoreUtilities.getAll(subgraph, allOccurrences, allOccurrences);
+            final RecordStore subgraphScore = GraphRecordStoreUtilities.getAll(subgraph, false, false);
             GraphRecordStoreUtilities.addRecordStoreToGraph(graph, subgraphScore, false, false, null);
         }
     }

--- a/CoreDataAccessView/src/au/gov/asd/tac/constellation/views/dataaccess/plugins/clean/SplitNodesPlugin.java
+++ b/CoreDataAccessView/src/au/gov/asd/tac/constellation/views/dataaccess/plugins/clean/SplitNodesPlugin.java
@@ -70,6 +70,8 @@ public class SplitNodesPlugin extends SimpleEditPlugin implements DataAccessPlug
     public static final String DUPLICATE_TRANSACTIONS_PARAMETER_ID = PluginParameter.buildId(SplitNodesPlugin.class, "split_level");
     public static final String TRANSACTION_TYPE_PARAMETER_ID = PluginParameter.buildId(SplitNodesPlugin.class, "transaction_type");
     public static final String ALL_OCCURRENCES_PARAMETER_ID = PluginParameter.buildId(SplitNodesPlugin.class, "all_occurances");
+    
+    public static final String COMPLETE_WITH_SCHEMA_OPTION_ID = PluginParameter.buildId(SplitNodesPlugin.class, "complete_schema");
 
     @Override
     public String getType() {
@@ -112,6 +114,12 @@ public class SplitNodesPlugin extends SimpleEditPlugin implements DataAccessPlug
         allOccurrences.setDescription("Choose to split on all instances of the character(s) rather than just the first instance");
         allOccurrences.setBooleanValue(false);
         params.addParameter(allOccurrences);
+        
+        final PluginParameter<BooleanParameterValue> completeSchema = BooleanParameterType.build(COMPLETE_WITH_SCHEMA_OPTION_ID);
+        completeSchema.setName("Complete with Schema");
+        completeSchema.setDescription("Choose to apply the type schema to the graph");
+        completeSchema.setBooleanValue(true);
+        params.addParameter(completeSchema);
 
         params.addController(DUPLICATE_TRANSACTIONS_PARAMETER_ID, (master, parameters, change) -> {
             if (change == ParameterChange.VALUE) {
@@ -276,7 +284,9 @@ public class SplitNodesPlugin extends SimpleEditPlugin implements DataAccessPlug
                 vlGraph.retrieveCoords();
             }
 
-            PluginExecution.withPlugin(VisualSchemaPluginRegistry.COMPLETE_SCHEMA).executeNow(graph);
+            if (splitParameters.get(COMPLETE_WITH_SCHEMA_OPTION_ID).getBooleanValue()){
+                PluginExecution.withPlugin(VisualSchemaPluginRegistry.COMPLETE_SCHEMA).executeNow(graph);
+            }
             PluginExecutor.startWith(InteractiveGraphPluginRegistry.RESET_VIEW).executeNow(graph);
         }
     }


### PR DESCRIPTION
<!--

### Requirements

* Filling out the template is required. Any pull request that does not include
enough information to be reviewed in a timely manner may be closed at the
maintainers' discretion.
* Follow the check list items defined by https://github.com/constellation-app/constellation/blob/master/CONTRIBUTING.md#pull-requests
* All new code requires unit tests to ensure they work as expected and will
continue to work as new code is added in the future (regression testing).
* Make sure your branch name is prefixed by `feature`, `bugfix`, `hotfix` or `release`
* Have you read Constellation's Code of Conduct? By filing an issue, you are
expected to comply with it, including treating everyone with respect:
https://github.com/constellation-app/constellation/blob/master/CODE_OF_CONDUCT.md

-->

### Description of the Change
The split nodes plugin when run would change the icons and colours of nodes due to the complete with schema plugin being run by default. A checkbox has been added to the split nodes plugin to allow for the user to decide whether they wish for complete with schema to be run on the selected nodes. The selected nodes which the split nodes plugin runs on are placed into a subgraph so that if the user chooses to use the complete with schema plugin it only affects the nodes in that subgraph instead of altering the entire graph. 
<!--

We must be able to understand the design of your change from this description.
If we can't get a good idea of what the code will be doing from the description
here, the pull request may be closed at the maintainers' discretion. Keep in
mind that the maintainer reviewing this PR may not be familiar with or have
worked with the code here recently, so please walk us through the concepts.

-->

### Alternate Designs
None realised
<!--

Explain what other alternates were considered and why the proposed version was
selected.

-->

### Why Should This Be In Core?
Allows for the user to make more decisions about how the graph is affected when the split nodes plugin is run. 
<!--

Explain why this functionality should be in Constellation Core as opposed to a
different module suite. Note that this question is more applicable when adding
new functionality. If this change is a minor update to an exising file then it
is understood that this change has to be to this module suite and a response
and therefore a response to this question is not required.

-->

### Benefits
Allows for users to choose whether they want to keep the changes they have made to nodes (colours and icons) when running the plugin.
<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks
None realised
<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process
Tested by running the split nodes plugin alongside the other plugins in data access view. Also ran the split nodes plugin with and without the complete with schema checkbox ticked and on both selections on a graph and the full graph.
<!--

What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (e.g., buttons you clicked, text you typed,
commands you ran, etc.), and describe the results you observed.

-->

### Applicable Issues
#896 
<!-- Link any applicable issues here -->
