### PR TITLE
Modified menu display to ensure it is visible.

### DIFF
--- a/CoreAnalyticView/src/au/gov/asd/tac/constellation/views/analyticview/AnalyticViewPane.java
+++ b/CoreAnalyticView/src/au/gov/asd/tac/constellation/views/analyticview/AnalyticViewPane.java
@@ -15,6 +15,7 @@
  */
 package au.gov.asd.tac.constellation.views.analyticview;
 
+import au.gov.asd.tac.constellation.utilities.color.ConstellationColor;
 import au.gov.asd.tac.constellation.utilities.icon.UserInterfaceIconProvider;
 import au.gov.asd.tac.constellation.views.analyticview.AnalyticViewTopComponent.AnalyticController;
 import au.gov.asd.tac.constellation.views.analyticview.questions.AnalyticQuestion;
@@ -93,7 +94,7 @@ public class AnalyticViewPane extends BorderPane {
 
         // the pane holding the analytic option buttons
         this.analyticOptionButtons = new HBox();
-        final Button helpButton = new Button("", new ImageView(UserInterfaceIconProvider.HELP.buildImage(16)));
+        final Button helpButton = new Button("", new ImageView(UserInterfaceIconProvider.HELP.buildImage(16, ConstellationColor.BLUEBERRY.getJavaColor())));
         helpButton.setOnAction(event -> {
             new HelpCtx(this.getClass().getName()).display();
         });

--- a/CoreAttributeEditorView/src/au/gov/asd/tac/constellation/views/attributeeditor/resources/Style-AttributeEditor-Dark.css
+++ b/CoreAttributeEditorView/src/au/gov/asd/tac/constellation/views/attributeeditor/resources/Style-AttributeEditor-Dark.css
@@ -6,7 +6,7 @@
 
 .menu-button {
     -fx-background-color: #181818;
-    -fx-border-color: #C4C4C4;
+    -fx-border-color: #444444;
 }
 
 .menu:hover{

--- a/CoreAttributeEditorView/src/au/gov/asd/tac/constellation/views/attributeeditor/resources/Style-AttributeEditor-Dark.css
+++ b/CoreAttributeEditorView/src/au/gov/asd/tac/constellation/views/attributeeditor/resources/Style-AttributeEditor-Dark.css
@@ -4,7 +4,13 @@
  * @author twinkle2_little
  */
 
+.menu-button {
+    -fx-background-color: #181818;
+}
 
+.menu:hover{
+    -fx-background-color: #0093FF;
+}
 
 /* ====== TOOLBAR CLASSES ================================================================= */
 

--- a/CoreAttributeEditorView/src/au/gov/asd/tac/constellation/views/attributeeditor/resources/Style-AttributeEditor-Dark.css
+++ b/CoreAttributeEditorView/src/au/gov/asd/tac/constellation/views/attributeeditor/resources/Style-AttributeEditor-Dark.css
@@ -6,6 +6,7 @@
 
 .menu-button {
     -fx-background-color: #181818;
+    -fx-border-color: #C4C4C4;
 }
 
 .menu:hover{

--- a/CoreConversationView/src/au/gov/asd/tac/constellation/views/conversationview/ConversationBox.java
+++ b/CoreConversationView/src/au/gov/asd/tac/constellation/views/conversationview/ConversationBox.java
@@ -23,6 +23,7 @@ import au.gov.asd.tac.constellation.plugins.PluginExecution;
 import au.gov.asd.tac.constellation.plugins.PluginInteraction;
 import au.gov.asd.tac.constellation.plugins.parameters.PluginParameters;
 import au.gov.asd.tac.constellation.plugins.templates.SimpleEditPlugin;
+import au.gov.asd.tac.constellation.utilities.color.ConstellationColor;
 import au.gov.asd.tac.constellation.utilities.icon.UserInterfaceIconProvider;
 import au.gov.asd.tac.constellation.utilities.javafx.JavafxStyleManager;
 import au.gov.asd.tac.constellation.utilities.tooltip.TooltipPane;
@@ -152,7 +153,7 @@ public final class ConversationBox extends StackPane {
             }
         });
 
-        final ImageView helpImage = new ImageView(UserInterfaceIconProvider.HELP.buildImage(16));
+        final ImageView helpImage = new ImageView(UserInterfaceIconProvider.HELP.buildImage(16, ConstellationColor.BLUEBERRY.getJavaColor()));
         final Button helpButton = new Button("", helpImage);
         helpButton.setOnAction((ActionEvent event) -> {
             final Help help = Lookup.getDefault().lookup(Help.class);

--- a/CoreDataAccessView/src/au/gov/asd/tac/constellation/views/dataaccess/panes/resources/data-access-view.css
+++ b/CoreDataAccessView/src/au/gov/asd/tac/constellation/views/dataaccess/panes/resources/data-access-view.css
@@ -7,7 +7,7 @@
 
 .menu-button {
     -fx-background-color: #181818;
-    -fx-border-color: #C4C4C4;
+    -fx-border-color: #444444;
 }
 
 .menu:hover{

--- a/CoreDataAccessView/src/au/gov/asd/tac/constellation/views/dataaccess/panes/resources/data-access-view.css
+++ b/CoreDataAccessView/src/au/gov/asd/tac/constellation/views/dataaccess/panes/resources/data-access-view.css
@@ -7,6 +7,7 @@
 
 .menu-button {
     -fx-background-color: #181818;
+    -fx-border-color: #C4C4C4;
 }
 
 .menu:hover{

--- a/CoreDataAccessView/src/au/gov/asd/tac/constellation/views/dataaccess/panes/resources/data-access-view.css
+++ b/CoreDataAccessView/src/au/gov/asd/tac/constellation/views/dataaccess/panes/resources/data-access-view.css
@@ -5,6 +5,14 @@
     -fx-cell-hover-color: -fx-shadow-highlight-color;
 }
 
+.menu-button {
+    -fx-background-color: #181818;
+}
+
+.menu:hover{
+    -fx-background-color: #0093FF;
+}
+
 .description-label {
     -fx-text-fill: rgb(200,200,200);
     -fx-font: normal 1.666673em "Arial"; /* 20pt */

--- a/CoreImportExportPlugins/src/au/gov/asd/tac/constellation/plugins/importexport/delimited/DelimitedImportPane.java
+++ b/CoreImportExportPlugins/src/au/gov/asd/tac/constellation/plugins/importexport/delimited/DelimitedImportPane.java
@@ -63,7 +63,7 @@ public class DelimitedImportPane extends BorderPane {
     private final BorderPane root;
 
     private static final String HELP_CTX = DelimitedImportPane.class.getName();
-    private static final Image HELP_IMAGE = UserInterfaceIconProvider.HELP.buildImage(16, ConstellationColor.AZURE.getJavaColor());
+    private static final Image HELP_IMAGE = UserInterfaceIconProvider.HELP.buildImage(16, ConstellationColor.BLUEBERRY.getJavaColor());
     private final Preferences importExportPrefs = NbPreferences.forModule(ImportExportPreferenceKeys.class);
 
     public DelimitedImportPane(final DelimitedImportTopComponent delimitedImportTopComponent) {

--- a/CoreImportExportPlugins/src/au/gov/asd/tac/constellation/plugins/importexport/delimited/DelimitedImportTopComponent.java
+++ b/CoreImportExportPlugins/src/au/gov/asd/tac/constellation/plugins/importexport/delimited/DelimitedImportTopComponent.java
@@ -64,7 +64,8 @@ public final class DelimitedImportTopComponent extends JavaFxTopComponent<Delimi
 
     @Override
     protected String createStyle() {
-        return null;
+        return "resources/delimited-import.css";
+//        return null;
     }
 
     @Override

--- a/CoreImportExportPlugins/src/au/gov/asd/tac/constellation/plugins/importexport/delimited/resources/delimited-import.css
+++ b/CoreImportExportPlugins/src/au/gov/asd/tac/constellation/plugins/importexport/delimited/resources/delimited-import.css
@@ -1,0 +1,7 @@
+.menu-button {
+    -fx-background-color: #181818;
+}
+
+.menu:hover{
+    -fx-background-color: #0093FF;
+}

--- a/CoreImportExportPlugins/src/au/gov/asd/tac/constellation/plugins/importexport/delimited/resources/delimited-import.css
+++ b/CoreImportExportPlugins/src/au/gov/asd/tac/constellation/plugins/importexport/delimited/resources/delimited-import.css
@@ -1,5 +1,6 @@
 .menu-button {
     -fx-background-color: #181818;
+    -fx-border-color: #C4C4C4;
 }
 
 .menu:hover{

--- a/CoreImportExportPlugins/src/au/gov/asd/tac/constellation/plugins/importexport/delimited/resources/delimited-import.css
+++ b/CoreImportExportPlugins/src/au/gov/asd/tac/constellation/plugins/importexport/delimited/resources/delimited-import.css
@@ -1,6 +1,6 @@
 .menu-button {
     -fx-background-color: #181818;
-    -fx-border-color: #C4C4C4;
+    -fx-border-color: #444444;
 }
 
 .menu:hover{

--- a/CorePluginReporterView/src/au/gov/asd/tac/constellation/views/pluginreporter/panes/PluginReporterPane.java
+++ b/CorePluginReporterView/src/au/gov/asd/tac/constellation/views/pluginreporter/panes/PluginReporterPane.java
@@ -19,6 +19,7 @@ import au.gov.asd.tac.constellation.plugins.reporting.GraphReport;
 import au.gov.asd.tac.constellation.plugins.reporting.GraphReportManager;
 import au.gov.asd.tac.constellation.plugins.reporting.PluginReport;
 import au.gov.asd.tac.constellation.plugins.reporting.PluginReportFilter;
+import au.gov.asd.tac.constellation.utilities.color.ConstellationColor;
 import au.gov.asd.tac.constellation.utilities.icon.UserInterfaceIconProvider;
 import au.gov.asd.tac.constellation.utilities.text.SeparatorConstants;
 import au.gov.asd.tac.constellation.views.pluginreporter.PluginReporterTopComponent;
@@ -122,7 +123,7 @@ public class PluginReporterPane extends BorderPane implements ListChangeListener
             setPluginReportFilter(defaultReportFilter);
         });
 
-        final ImageView helpImage = new ImageView(UserInterfaceIconProvider.HELP.buildImage(16));
+        final ImageView helpImage = new ImageView(UserInterfaceIconProvider.HELP.buildImage(16, ConstellationColor.BLUEBERRY.getJavaColor()));
         Button helpButton = new Button("", helpImage);
         helpButton.setOnAction((ActionEvent event) -> {
             final Help help = Lookup.getDefault().lookup(Help.class);


### PR DESCRIPTION
### Description of the Change

Modified menu display settings for several views to give a consistant feel as well as shading any menu options to make the menu identifyable.

### Alternate Designs

nil
### Why Should This Be In Core?

Requested ticket highlighted that in some cases this top menu wasnt easily identifed as cselectable.

### Benefits

Ensure menu is selectable - and identifiable by the user. Note - the issue in this case is that the top bar is a menubar, which normally doesn't have shading for each menu option, this however is having other buttons overlaid so it requires a slightly different look and feel.

### Possible Drawbacks

None identified

### Verification Process

Go through all views and ensure any with menus have the same look and feel - in particualr any menu (ie Options menu for Data
Access View) is shaded differently to identify it as a button.

### Applicable Issues

#866 
