### PR TITLE
Bugfix/945 broken interaction

### DIFF
--- a/CoreInteractiveGraph/src/au/gov/asd/tac/constellation/graph/interaction/visual/DefaultInteractionEventHandler.java
+++ b/CoreInteractiveGraph/src/au/gov/asd/tac/constellation/graph/interaction/visual/DefaultInteractionEventHandler.java
@@ -998,7 +998,7 @@ public class DefaultInteractionEventHandler implements InteractionEventHandler {
 
     private void performDrag(GraphWriteMethods wg, final Camera camera, final Point from, final Point to) {
         // Get the ids of the selected nodes (and those of the associated transaction as well)
-        final List<Integer> draggedNodeIds = gatherSelectedNodes(wg);
+        final List<Integer> draggedNodes = gatherSelectedNodes(wg);
         int nodeBeingDraggedId = eventState.getCurrentHitType().equals(HitType.TRANSACTION) ? wg.getTransactionSourceVertex(eventState.getCurrentHitId()) : eventState.getCurrentHitId();
 
         // Get the position of the node being dragged.
@@ -1014,13 +1014,14 @@ public class DefaultInteractionEventHandler implements InteractionEventHandler {
         final int z2Attribute = VisualConcept.VertexAttribute.Z2.get(wg);
         final int cameraAttribute = VisualConcept.GraphAttribute.CAMERA.get(wg);
         
-        draggedNodeIds.forEach(vertexId -> {
+        draggedNodes.forEach(vertexId -> {
             final Vector3f currentPos = VisualGraphUtilities.getMixedVertexCoordinates(wg, vertexId, xAttribute, x2Attribute, yAttribute, y2Attribute, zAttribute, z2Attribute, cameraAttribute);
             currentPos.add(delta);
             VisualGraphUtilities.setVertexCoordinates(wg, currentPos, vertexId, xAttribute, yAttribute, zAttribute);
         });
-
-        scheduleXYZChangeOperation(Ints.toArray(draggedNodeIds));
+        
+        draggedNodes.replaceAll(id -> wg.getVertexPosition(id)); // Replade the Id's with positions.
+        scheduleXYZChangeOperation(Ints.toArray(draggedNodes));
     }
 
     private void performPointSelection(final boolean toggleSelection, final boolean clearSelection, final GraphElementType elementType, final int elementId) {

--- a/CoreInteractiveGraph/src/au/gov/asd/tac/constellation/graph/interaction/visual/DefaultInteractionEventHandler.java
+++ b/CoreInteractiveGraph/src/au/gov/asd/tac/constellation/graph/interaction/visual/DefaultInteractionEventHandler.java
@@ -320,6 +320,7 @@ public class DefaultInteractionEventHandler implements InteractionEventHandler {
     }
 
     private void scheduleXYZChangeOperation(final int[] verticiesMoved) {
+        // VerticiesMoved should be a list of vertexPositions for the verticies moved.
         operationQueue.add(manager.constructMultiChangeOperation(Arrays.asList(
                 new VisualChangeBuilder(VisualProperty.VERTEX_X).forItems(verticiesMoved).withId(currentXYZChangeIds[0]).build(),
                 new VisualChangeBuilder(VisualProperty.VERTEX_Y).forItems(verticiesMoved).withId(currentXYZChangeIds[1]).build(),
@@ -1020,7 +1021,7 @@ public class DefaultInteractionEventHandler implements InteractionEventHandler {
             VisualGraphUtilities.setVertexCoordinates(wg, currentPos, vertexId, xAttribute, yAttribute, zAttribute);
         });
         
-        draggedNodes.replaceAll(id -> wg.getVertexPosition(id)); // Replade the Id's with positions.
+        draggedNodes.replaceAll(id -> wg.getVertexPosition(id)); // Replade the Id's with positions, as required by scheduleXYZCHangeOperation.
         scheduleXYZChangeOperation(Ints.toArray(draggedNodes));
     }
 


### PR DESCRIPTION
-->

### Description of the Change

<!--
ScheduleXYZChangeOperation now receives vertexPositions instead of vertexIDs.  

-->


### Why Should This Be In Core?

<!--

Previous version causes crashes.
-->

### Benefits
Should stop crashes whilst maintaining recent performance improvements.

### Possible Drawbacks

Drawbacks may be discovered on future testing.

### Verification Process

<!--

Tested on a couple of different graphs.
Also tested by @arcturus2 .

-->

### Applicable Issues

#946
