### PR TITLE
Added EDGE and LINK element types to saupport filterinf by them.

### DIFF
--- a/CoreHistogramView/src/au/gov/asd/tac/constellation/views/histogram/HistogramClearFilterPlugin.java
+++ b/CoreHistogramView/src/au/gov/asd/tac/constellation/views/histogram/HistogramClearFilterPlugin.java
@@ -53,6 +53,8 @@ public class HistogramClearFilterPlugin extends SimpleEditPlugin {
         final List<ElementTypeParameterValue> elementTypes = new ArrayList<>();
         elementTypes.add(new ElementTypeParameterValue(GraphElementType.TRANSACTION));
         elementTypes.add(new ElementTypeParameterValue(GraphElementType.VERTEX));
+        elementTypes.add(new ElementTypeParameterValue(GraphElementType.EDGE));
+        elementTypes.add(new ElementTypeParameterValue(GraphElementType.LINK));
         SingleChoiceParameterType.setOptionsData(elementTypeParameter, elementTypes);
         parameters.addParameter(elementTypeParameter);
 

--- a/CoreHistogramView/src/au/gov/asd/tac/constellation/views/histogram/HistogramFilterOnSelectionPlugin.java
+++ b/CoreHistogramView/src/au/gov/asd/tac/constellation/views/histogram/HistogramFilterOnSelectionPlugin.java
@@ -56,6 +56,8 @@ public class HistogramFilterOnSelectionPlugin extends SimpleEditPlugin {
         final List<ElementTypeParameterValue> elementTypes = new ArrayList<>();
         elementTypes.add(new ElementTypeParameterValue(GraphElementType.TRANSACTION));
         elementTypes.add(new ElementTypeParameterValue(GraphElementType.VERTEX));
+        elementTypes.add(new ElementTypeParameterValue(GraphElementType.EDGE));
+        elementTypes.add(new ElementTypeParameterValue(GraphElementType.LINK));
         SingleChoiceParameterType.setOptionsData(elementTypeParameter, elementTypes);
         parameters.addParameter(elementTypeParameter);
 


### PR DESCRIPTION
Modified Historgram filter setup to include EDGE and LINK as potential element types in line with GUI.
This is done to ensure code is able to successfully filter by element type  rather than retuning null and triggering exceptions.


### Alternate Designs

Nil - this is a bug fix due to missing element types

### Why Should This Be In Core?

Bug fix

### Benefits

Can now filter by Edge/Link Grapg Elements rather than seeing an exception

### Possible Drawbacks

none known

### Verification Process

Repeated steps shown in issue description. 
Performed filtered-by and clear opeorations for all graph element types.

### Applicable Issues

#952
