### PR TITLE
:bug: Potential fix to bug causing glyphs to replace others.

### DIFF
--- a/CoreOpenGLDisplay/src/au/gov/asd/tac/constellation/visual/opengl/utilities/glyphs/GlyphRectangleBuffer.java
+++ b/CoreOpenGLDisplay/src/au/gov/asd/tac/constellation/visual/opengl/utilities/glyphs/GlyphRectangleBuffer.java
@@ -256,11 +256,12 @@ final class GlyphRectangleBuffer {
         //
         final int hashCode = Arrays.hashCode(img.getRGB(0, 0, w, h, null, 0, w));
 
-        Integer rectIndex = memory.putIfAbsent(hashCode, memory.size());
+        
+        Integer rectIndex = memory.get(hashCode);
         if (rectIndex == null) {
-            rectIndex = memory.get(hashCode);
-            addImageToBuffer(img, rectIndex, extra, w, h);
+            rectIndex = synchronizedAddHashcode(hashCode, img, extra, w, h);
         }
+        
         return rectIndex;
     }
     
@@ -355,5 +356,15 @@ final class GlyphRectangleBuffer {
             return false;
         }
         return true;
+    }
+
+    private synchronized Integer synchronizedAddHashcode(int hashCode, BufferedImage img, int extra, int w, int h) {
+        int value = memory.size();
+        Integer rectIndex = memory.putIfAbsent(hashCode, value);
+        if (rectIndex == null) {
+            rectIndex = value;
+            addImageToBuffer(img, rectIndex, extra, w, h);
+        }
+        return rectIndex;
     }
 }

--- a/CoreOpenGLDisplay/src/au/gov/asd/tac/constellation/visual/opengl/utilities/glyphs/GlyphRectangleBuffer.java
+++ b/CoreOpenGLDisplay/src/au/gov/asd/tac/constellation/visual/opengl/utilities/glyphs/GlyphRectangleBuffer.java
@@ -358,7 +358,7 @@ final class GlyphRectangleBuffer {
         return true;
     }
 
-    private synchronized Integer synchronizedAddHashcode(int hashCode, BufferedImage img, int extra, int w, int h) {
+    private synchronized int synchronizedAddHashcode(final int hashCode, final BufferedImage img, final int extra, final int w, final int h) {
         int value = memory.size();
         Integer rectIndex = memory.putIfAbsent(hashCode, value);
         if (rectIndex == null) {


### PR DESCRIPTION
### Description of the Change

<!--

A bug has been reported that the wrong letter may appear in the place
of another. As it happens for all occurances of that letter and the glyph
is pefectly formed it appears to be an issue with the logical connection
of a glyph to its position.
On inspections I dont believe this part of code was threadsafe, in
particular memory.size() may be 1 less than it should be if the previous
glyph is still being added to the map. This would cause the second glyph
to overwrite the first, subsequent occurrences of the first glyph would then
retrieve the second glyph, which would explain the behaviour detailed
above.
This should fix that by ensuring that a new glyph is not added until the
previous has been added.

-->

### Alternate Designs

<!--

Instead of using an explicit synchronize I consider changing memory to be either a ConcurrentHashMap or SynchronizedHashMap. However a concurrentHashMap would not fix the problem as it does not guarantee that a put will conclude prior to a size being returned. The Synchornized map goes too far the other way, creating a lock each time a get is performed. This would massively reduce the methods speed as much of the time we are just retriving glyphs rather than storing them and we want this to occur synchronously.

-->

### Why Should This Be In Core?

<!--

Fixes core presentation issue.

-->

### Benefits

Hopefully this will stop a bug causing labels to be rendered incorrectly.

### Possible Drawbacks

May not actually fix the issue as I can-not reliably test it as it is an infrequent multi-threading issue for an individual that common enough that a group using constellation frequently will notice it.

### Verification Process

<!--

Unable to verify. Checked that labels appear to get rendered correctly (but they did before and I can't garuntee it occurs correctly everytime).

-->

### Applicable Issues

#962 
