### PR TITLE
:bug: Fix incorrect initial population of analytic aggregators.

### DIFF
--- a/CoreAnalyticView/src/au/gov/asd/tac/constellation/views/analyticview/AnalyticConfigurationPane.java
+++ b/CoreAnalyticView/src/au/gov/asd/tac/constellation/views/analyticview/AnalyticConfigurationPane.java
@@ -159,6 +159,7 @@ public class AnalyticConfigurationPane extends VBox {
 
         // build the pane holding the list of analytic categories
         this.categoryListPane = new TitledPane("Categories", categoryList);
+        categoryListPane.setExpanded(false);
 
         // set up the list of analytic questions
         this.questionToPluginsMap = new HashMap<>();


### PR DESCRIPTION
Incorrect initial display of analytic aggregators was due to the 
categoryListPane.expanded value being initially set to true when it 
actually starts hidden, with the questionListPane expanded. Added a line
after initialisation to set categoryListPane.expanded to false.

### Description of the Change

<!--

CategoryListPane.expanded is now initalised to false immediately after object creation.

-->

### Alternate Designs

<!--

NA

-->

### Why Should This Be In Core?

<!--

Analytic view is a core feature.

-->

### Benefits

Analytic views aggregators panel now initialises with the correct choices.

### Possible Drawbacks

NA

### Verification Process

<!--

Tested initial status of aggregation pane.

-->

### Applicable Issues

#926 
