### PR TITLE
:bug: Stop error triggered when switching graphs with find open

### DIFF
--- a/CoreFindView/src/au/gov/asd/tac/constellation/views/find/gui/FindCriteriaPanel.java
+++ b/CoreFindView/src/au/gov/asd/tac/constellation/views/find/gui/FindCriteriaPanel.java
@@ -112,6 +112,7 @@ public class FindCriteriaPanel extends JPanel implements DateTimeListenerInterfa
         createCriteriaPanels();
 
         this.localState = localState;
+        this.localState = this.getState();
 
         panelCriteriaHolder.removeAll();
 


### PR DESCRIPTION
Previously an error could occur when switching between graphs because
a FindRules attribute and type would be modified without its attributes
being updated to reflect the new type.
The line added causes the attributes value to be corrected prior to
accessing the attributes in the method that the error occurs in.

### Description of the Change

<!--
Added a getState line to the creator for FIndCriteriaPanel to ensure that the entires in the localStates argu variable are consistent with its type and attribute.

-->

### Alternate Designs

<!--

Considered forcing attribute, type and argu variables to all be updated together at all times so that discrepancies cannot occur. However I'm not convinced this wouldn't have unintended knock on effects.
I think ideally the find view needs re-writing, however this would be a significant time investment.
-->

### Why Should This Be In Core?

<!--

Fixes a bug in the core version of constellation.

-->

### Benefits

Stops the occurrence  of an error when switching graphs with the find view open.

### Possible Drawbacks

I was unable to reproduce the slowness described in the ticket so this may actually address a different issue. However this error occurs when performing the steps described in the reproducer and I have seen errors remain hidden and cause application slowdown before.

### Verification Process

<!--

Repeated reproducer steps without the issue.

-->

### Applicable Issues

#852 
