### PR TITLE
Timeline View summary pane resizing 

### DIFF
--- a/CoreTimelineView/src/au/gov/asd/tac/constellation/views/timeline/TimelinePanel.java
+++ b/CoreTimelineView/src/au/gov/asd/tac/constellation/views/timeline/TimelinePanel.java
@@ -123,7 +123,6 @@ public class TimelinePanel extends Region {
         this.coordinator = coordinator;
 
         // Set the layout constraints:
-        this.setMinHeight(220d);
         this.setMaxHeight(Double.MAX_VALUE);
         this.setMinWidth(440d);
         this.setMaxWidth(Double.MAX_VALUE);

--- a/CoreTimelineView/src/au/gov/asd/tac/constellation/views/timeline/TimelineTopComponent.java
+++ b/CoreTimelineView/src/au/gov/asd/tac/constellation/views/timeline/TimelineTopComponent.java
@@ -98,7 +98,7 @@ import org.openide.windows.TopComponent;
 })
 public final class TimelineTopComponent extends TopComponent implements LookupListener, GraphChangeListener, UndoRedo.Provider {
 
-    private static final double DEFAULT_DIVIDER_LOCATION = 0.9;
+    private static final double DEFAULT_DIVIDER_LOCATION = 0.8;
     private static final String LIGHT_THEME = "resources/Style-Container-Light.css";
     private static final String DARK_THEME = "resources/Style-Container-Dark.css";
     private static final String UPDATE_TIMELINE_THREAD_NAME = "Update Timeline from Graph";
@@ -159,7 +159,7 @@ public final class TimelineTopComponent extends TopComponent implements LookupLi
             timelinePanel = new TimelinePanel(thisComponent);
             overviewPanel = new OverviewPanel(thisComponent);
 
-            SplitPane.setResizableWithParent(overviewPanel, false);
+            SplitPane.setResizableWithParent(overviewPanel, true);
             SplitPane.setResizableWithParent(timelinePanel, true);
             splitPane = new SplitPane();
             splitPane.setId("hiddenSplitter");
@@ -183,9 +183,6 @@ public final class TimelineTopComponent extends TopComponent implements LookupLi
 
             // Set the split pane as the javafx scene:
             container.setScene(scene);
-
-            // Now that the heights are known, set the position of the splitPane divider:
-            splitPane.getDividers().get(0).setPosition(splitPanePosition);
         });
     }
 
@@ -463,12 +460,13 @@ public final class TimelineTopComponent extends TopComponent implements LookupLi
                         Platform.runLater(() -> {
                             final ReadableGraph rg1 = graph.getReadableGraph();
                             try {
+                                // Now that the heights are known, set the position of the splitPane divider:
+                                splitPane.setDividerPositions(splitPanePosition);
                                 // Clear anything already on the charts:
                                 timelinePanel.clearTimeline();
                                 overviewPanel.clearHistogram(!isFullRefresh);
                                 // Ensure that everything is visible:
                                 timelinePanel.setDisable(false);
-                                //splitPane.setVisible(true);
                                 //if visibility is set to false at the constructor, the javafx thread gets stuck in an endless loop under
                                 //certain conditions (with timeline open, create graph, close graph) so we set opacity to 0 in the constructor so that it is 'invisible'
 //                                    splitPane.setOpacity(1);

--- a/CoreTimelineView/src/au/gov/asd/tac/constellation/views/timeline/TimelineTopComponent.java
+++ b/CoreTimelineView/src/au/gov/asd/tac/constellation/views/timeline/TimelineTopComponent.java
@@ -98,7 +98,7 @@ import org.openide.windows.TopComponent;
 })
 public final class TimelineTopComponent extends TopComponent implements LookupListener, GraphChangeListener, UndoRedo.Provider {
 
-    private static final double DEFAULT_DIVIDER_LOCATION = 0.6;
+    private static final double DEFAULT_DIVIDER_LOCATION = 0.8;
     private static final String LIGHT_THEME = "resources/Style-Container-Light.css";
     private static final String DARK_THEME = "resources/Style-Container-Dark.css";
     private static final String UPDATE_TIMELINE_THREAD_NAME = "Update Timeline from Graph";

--- a/CoreTimelineView/src/au/gov/asd/tac/constellation/views/timeline/TimelineTopComponent.java
+++ b/CoreTimelineView/src/au/gov/asd/tac/constellation/views/timeline/TimelineTopComponent.java
@@ -98,7 +98,7 @@ import org.openide.windows.TopComponent;
 })
 public final class TimelineTopComponent extends TopComponent implements LookupListener, GraphChangeListener, UndoRedo.Provider {
 
-    private static final double DEFAULT_DIVIDER_LOCATION = 0.8;
+    private static final double DEFAULT_DIVIDER_LOCATION = 0.6;
     private static final String LIGHT_THEME = "resources/Style-Container-Light.css";
     private static final String DARK_THEME = "resources/Style-Container-Dark.css";
     private static final String UPDATE_TIMELINE_THREAD_NAME = "Update Timeline from Graph";
@@ -181,6 +181,9 @@ public final class TimelineTopComponent extends TopComponent implements LookupLi
             splitPane.prefHeightProperty().bind(scene.heightProperty());
             splitPane.prefWidthProperty().bind(scene.widthProperty());
 
+            // Now that the heights are known, set the position of the splitPane divider:
+            splitPane.setDividerPositions(splitPanePosition);
+            
             // Set the split pane as the javafx scene:
             container.setScene(scene);
         });
@@ -460,8 +463,6 @@ public final class TimelineTopComponent extends TopComponent implements LookupLi
                         Platform.runLater(() -> {
                             final ReadableGraph rg1 = graph.getReadableGraph();
                             try {
-                                // Now that the heights are known, set the position of the splitPane divider:
-                                splitPane.setDividerPositions(splitPanePosition);
                                 // Clear anything already on the charts:
                                 timelinePanel.clearTimeline();
                                 overviewPanel.clearHistogram(!isFullRefresh);


### PR DESCRIPTION
<!--

### Requirements

* Filling out the template is required. Any pull request that does not include
enough information to be reviewed in a timely manner may be closed at the
maintainers' discretion.
* Follow the check list items defined by https://github.com/constellation-app/constellation/blob/master/CONTRIBUTING.md#pull-requests
* All new code requires unit tests to ensure they work as expected and will
continue to work as new code is added in the future (regression testing).
* Make sure your branch name is prefixed by `feature`, `bugfix`, `hotfix` or `release`
* Have you read Constellation's Code of Conduct? By filing an issue, you are
expected to comply with it, including treating everyone with respect:
https://github.com/constellation-app/constellation/blob/master/CODE_OF_CONDUCT.md

-->

### Description of the Change
Update to the timeline view to stop the summary pane of the view from resetting to the default size when a selection is made on the graph. The summary pane currently resets to 20% of the view size every time a selection is made on the graph or a change is made to the view. The change stops the summary pane from changing every time.
<!--

We must be able to understand the design of your change from this description.
If we can't get a good idea of what the code will be doing from the description
here, the pull request may be closed at the maintainers' discretion. Keep in
mind that the maintainer reviewing this PR may not be familiar with or have
worked with the code here recently, so please walk us through the concepts.

-->

### Alternate Designs
None realised 
<!--

Explain what other alternates were considered and why the proposed version was
selected.

-->

### Why Should This Be In Core?
Stops the size of the pane from resetting with every change made to the graph, improvement in usability. 
<!--

Explain why this functionality should be in Constellation Core as opposed to a
different module suite. Note that this question is more applicable when adding
new functionality. If this change is a minor update to an exising file then it
is understood that this change has to be to this module suite and a response
and therefore a response to this question is not required.

-->



### Applicable Issues
#910 
<!-- Link any applicable issues here -->
