### PR TITLE
:racecar: Converted displayPos's to int

### DIFF
--- a/CoreTimelineView/src/au/gov/asd/tac/constellation/views/timeline/clustering/TreeElement.java
+++ b/CoreTimelineView/src/au/gov/asd/tac/constellation/views/timeline/clustering/TreeElement.java
@@ -31,9 +31,9 @@ public abstract class TreeElement {
 
     public abstract long getUpperTimeExtent();
 
-    public abstract long getLowerDisplayPos();
+    public abstract int getLowerDisplayPos();
 
-    public abstract long getUpperDisplayPos();
+    public abstract int getUpperDisplayPos();
 
     public abstract int getCount();
 

--- a/CoreTimelineView/src/au/gov/asd/tac/constellation/views/timeline/clustering/TreeLeaf.java
+++ b/CoreTimelineView/src/au/gov/asd/tac/constellation/views/timeline/clustering/TreeLeaf.java
@@ -24,8 +24,8 @@ public class TreeLeaf extends TreeElement implements Comparable<TreeLeaf> {
     private final int id;
     private final long datetime;
 
-    private final long lowerDisplayPos;
-    private final long upperDisplayPos;
+    private final int lowerDisplayPos;
+    private final int upperDisplayPos;
 
     int vertexIdA;
     int vertexIdB;
@@ -33,8 +33,8 @@ public class TreeLeaf extends TreeElement implements Comparable<TreeLeaf> {
     private int selectionCount = 0;
     private final boolean nodesSelected;
 
-    TreeLeaf(final int transactionID, final long transactionValue, final boolean isSelected, final boolean nodesSelected, final long lowerDisplayPos,
-            final long upperDisplayPos, final int vertexIdA, final int vertexIdB) {
+    TreeLeaf(final int transactionID, final long transactionValue, final boolean isSelected, final boolean nodesSelected, final int lowerDisplayPos,
+            final int upperDisplayPos, final int vertexIdA, final int vertexIdB) {
         this.id = transactionID;
         this.datetime = transactionValue;
         this.lowerDisplayPos = lowerDisplayPos;
@@ -67,12 +67,12 @@ public class TreeLeaf extends TreeElement implements Comparable<TreeLeaf> {
     }
 
     @Override
-    public long getLowerDisplayPos() {
+    public int getLowerDisplayPos() {
         return lowerDisplayPos;
     }
 
     @Override
-    public long getUpperDisplayPos() {
+    public int getUpperDisplayPos() {
         return upperDisplayPos;
     }
 

--- a/CoreTimelineView/src/au/gov/asd/tac/constellation/views/timeline/clustering/TreeNode.java
+++ b/CoreTimelineView/src/au/gov/asd/tac/constellation/views/timeline/clustering/TreeNode.java
@@ -31,8 +31,8 @@ public class TreeNode extends TreeElement implements Comparable<TreeNode> {
     private int selectedLeafCount;
     private long lowerTimeExtent;
     private long upperTimeExtent;
-    private long lowerDisplayPos;
-    private long upperDisplayPos;
+    private int lowerDisplayPos;
+    private int upperDisplayPos;
     private boolean nodesSelectedInLeaves;
 
     public TreeNode(final TreeElement firstChild, final TreeElement lastChild) {
@@ -104,12 +104,12 @@ public class TreeNode extends TreeElement implements Comparable<TreeNode> {
     }
 
     @Override
-    public long getLowerDisplayPos() {
+    public int getLowerDisplayPos() {
         return lowerDisplayPos;
     }
 
     @Override
-    public long getUpperDisplayPos() {
+    public int getUpperDisplayPos() {
         return upperDisplayPos;
     }
 


### PR DESCRIPTION
### Description of the Change

<!--

Converted the upperDisplayPos and lowerDisplayPos variables from longs 
to ints to slightly reduce memory usage. We know we can do this safely
because the variables used to instantiate them originally were ints.

-->

### Alternate Designs

<!--

NA

-->

### Why Should This Be In Core?

<!--

Module is in core.

-->

### Benefits

<!-- Small reduction in the amount of memory used when keeping the timeline view open-->

### Possible Drawbacks

<!-- NA -->

### Verification Process

<!--
tested timeline view functionality and memory usage on multiple graphs.

-->

### Applicable Issues

#407 
