### PR TITLE
Issue#19 corrup star file handling

### DIFF
--- a/CoreGraphFile/src/au/gov/asd/tac/constellation/graph/file/io/GraphJsonReader.java
+++ b/CoreGraphFile/src/au/gov/asd/tac/constellation/graph/file/io/GraphJsonReader.java
@@ -100,7 +100,6 @@ public final class GraphJsonReader {
     public Graph readGraphZip(final File graphFile, final IoProgress progress) throws IOException, GraphParseException {
         try (final InputStream in = new BufferedInputStream(new FileInputStream(graphFile))) {
             return readGraphZip(graphFile.getPath(), in, progress);
-            
         }
     }
 
@@ -109,7 +108,7 @@ public final class GraphJsonReader {
             progress.start(100);
             byteReader = new GraphByteReader(bin);
         } 
-        catch (IOException ex) {
+        catch (final IOException ex) {
             // An exception occured attempting to read a zip (star) file, mark progress as complete to allow status 
             // to be updated with either loading of backup file if it exists
             progress.finish();
@@ -127,9 +126,9 @@ public final class GraphJsonReader {
 
             try {
                 graph = readGraph(name, in.getInputStream(), in.getAvailableSize(), progress);
-            } catch (IllegalStateException ex) {
+            } catch (final IllegalStateException ex) {
                 throw new GraphParseException(ex.getMessage(), ex);
-            } catch (InterruptedException ex) {
+            } catch (final InterruptedException ex) {
                 Thread.currentThread().interrupt();
                 throw new GraphParseException(ex.getMessage(), ex);
             } finally {
@@ -428,7 +427,7 @@ public final class GraphJsonReader {
                 throw new GraphParseException(String.format("Expected END_ARRAY, found '%s'.", current));
             }
 
-        } catch (Exception ex) {
+        } catch (final Exception ex) {
             Exceptions.printStackTrace(ex);
         } finally {
             jp.close();
@@ -454,7 +453,7 @@ public final class GraphJsonReader {
                     }
                 }
             });
-        } catch (Exception ex) {
+        } catch (final Exception ex) {
             final String msg = "There was an error loading some parts of the graph. The error was " + ex.getLocalizedMessage();
             // TODO: throw a plugin exception
 //            throw new PluginException(PluginNotificationLevel.ERROR, msg); 
@@ -556,7 +555,7 @@ public final class GraphJsonReader {
                     final Long modCount = node.get("mod_count").longValue();
                     attrValCount.put(attrId, modCount);
                 }
-            } catch (IllegalArgumentException ex) {
+            } catch (final IllegalArgumentException ex) {
                 // It's possible that we're reading a graph that contains an attribute type that we don't know about.
                 // This can happen when a module adds a new META type to a saved graph, and someone attempts to open
                 // that graph without that module (or an older version of that module).

--- a/CoreGraphFile/src/au/gov/asd/tac/constellation/graph/file/io/GraphJsonReader.java
+++ b/CoreGraphFile/src/au/gov/asd/tac/constellation/graph/file/io/GraphJsonReader.java
@@ -100,15 +100,20 @@ public final class GraphJsonReader {
     public Graph readGraphZip(final File graphFile, final IoProgress progress) throws IOException, GraphParseException {
         try (final InputStream in = new BufferedInputStream(new FileInputStream(graphFile))) {
             return readGraphZip(graphFile.getPath(), in, progress);
+            
         }
     }
 
     public Graph readGraphZip(final String name, InputStream bin, final IoProgress progress) throws IOException, GraphParseException {
         try (bin) {
             progress.start(100);
-            progress.progress("Reading file: " + name);
-            
             byteReader = new GraphByteReader(bin);
+        } 
+        catch (IOException ex) {
+            // An exception occured attempting to read a zip (star) file, mark progress as complete to allow status 
+            // to be updated with either loading of backup file if it exists
+            progress.finish();
+            throw ex;
         }
 
         try {

--- a/CoreGraphFile/src/au/gov/asd/tac/constellation/graph/file/save/AutosaveUtilities.java
+++ b/CoreGraphFile/src/au/gov/asd/tac/constellation/graph/file/save/AutosaveUtilities.java
@@ -198,13 +198,6 @@ public final class AutosaveUtilities {
                 }
             }
         }
-
-        if (toBak.exists()) {
-            final boolean toBakIsDeleted = toBak.delete();
-            if (!toBakIsDeleted) {
-                //TODO: Handle case where file not successfully deleted
-            }
-        }
     }
 
     /**

--- a/CoreInteractiveGraph/src/au/gov/asd/tac/constellation/graph/interaction/gui/VisualGraphOpener.java
+++ b/CoreInteractiveGraph/src/au/gov/asd/tac/constellation/graph/interaction/gui/VisualGraphOpener.java
@@ -117,7 +117,7 @@ public final class VisualGraphOpener extends GraphOpener {
                         final File autosaved = new File(AutosaveUtilities.getAutosaveDir(), props.getProperty(AutosaveUtilities.ID) + GraphDataObject.FILE_EXTENSION);
                         try {
                             AutosaveUtilities.copyFile(autosaved, f);
-                        } catch (IOException ex) {
+                        } catch (final IOException ex) {
                             LOGGER.log(Level.WARNING, "Copying autosaved file", ex);
                         }
                     }
@@ -178,10 +178,10 @@ public final class VisualGraphOpener extends GraphOpener {
             if (graph == null) {
                 try {
                     final long t0 = System.currentTimeMillis();
-                    LOGGER.log(Level.INFO, String.format("MMDEBUG Attempting to open %s", graphFile.toString()));
+                    LOGGER.log(Level.INFO, String.format("Attempting to open %s", graphFile.toString()));
                     graph = new GraphJsonReader().readGraphZip(graphFile, new HandleIoProgress(String.format("Reading %s...", graphFile.getName())));
                     time = System.currentTimeMillis() - t0;
-                } catch (GraphParseException | IOException | RuntimeException ex) {  
+                } catch (final GraphParseException | IOException | RuntimeException ex) {  
                     gex = ex;
                 }
 
@@ -190,15 +190,14 @@ public final class VisualGraphOpener extends GraphOpener {
                         // An exception was thrown trying to read specified star file. The most likely reason for this is
                         // a corrupt star file. Check to see if there was a 'backup' star file generated before the star file
                         // was writtien - if so, attmept to load this.
-                        String backupFilename = graphFile.toString().concat(BACKUP_EXTENSION);
-                        File backupFile = new File(backupFilename);
+                        final File backupFile = new File(graphFile.toString().concat(BACKUP_EXTENSION));
                         
                         if (backupFile.exists()) {
                             
                             // Try to load backup file that was located, if it loads then clear previous exception, if not the 
                             // original exception is kept to be handled in the done method
                             final long t0 = System.currentTimeMillis();
-                            LOGGER.log(Level.WARNING, String.format("MMDEBUG Unable to open requested file, attempting to open backup %s", backupFile.toString()));
+                            LOGGER.log(Level.WARNING, String.format("Unable to open requested file, attempting to open backup %s", backupFile.toString()));
                             graph = new GraphJsonReader().readGraphZip(backupFile, new HandleIoProgress(String.format("%s could not be opened, attempting to open backup file", 
                                     graphFile.getName(), backupFile.getName())));
                             time = System.currentTimeMillis() - t0;
@@ -212,8 +211,8 @@ public final class VisualGraphOpener extends GraphOpener {
                         }
                     }
                 }
-                catch (GraphParseException | IOException | RuntimeException ex) {  
-                    LOGGER.log(Level.WARNING, String.format("MMDEBUG Unable to open requested file or any associated backup", graphFile.toString()));
+                catch (final GraphParseException | IOException | RuntimeException ex) {  
+                    LOGGER.log(Level.WARNING, String.format("Unable to open requested file or any associated backup", graphFile.toString()));
                     gex = ex;
                 }
  

--- a/CoreInteractiveGraph/src/au/gov/asd/tac/constellation/graph/interaction/gui/VisualGraphTopComponent.java
+++ b/CoreInteractiveGraph/src/au/gov/asd/tac/constellation/graph/interaction/gui/VisualGraphTopComponent.java
@@ -1061,6 +1061,7 @@ public final class VisualGraphTopComponent extends CloneableTopComponent impleme
      */
     private class BackgroundWriter extends SwingWorker<Void, Object> {
 
+        private static final String BACKUP_EXTENSION = ".bak";
         private final String name;
         private final GraphDataObject freshGdo;
         private final boolean deleteOldGdo;
@@ -1112,10 +1113,10 @@ public final class VisualGraphTopComponent extends CloneableTopComponent impleme
                 File srcFile = new File(fileobj.getPath());
                 String srcfilePath = srcFile.getParent().concat("\\").concat(this.name).concat(".").concat(fileobj.getExt());
                 
-                // TODO: at the moment to prove concept just appending _bak to source file name, but should these be saved
-                // elsewhere, ie .CONSTELLATION/backups or something (note if it was done that way would need logic to handle
-                // duplicate filenames etc) ?
-                FileUtils.copyFile(new File(srcfilePath), new File(srcfilePath.concat("_bak")));
+                // Create a backup copy of the file before overwriting it. If the backup copy fails, then code will never
+                // get to execute the save, so the actual file should remain intact. If the save fails, the backup file will
+                // already have been written.
+                FileUtils.copyFile(new File(srcfilePath), new File(srcfilePath.concat(BACKUP_EXTENSION)));
                 
                 try (OutputStream out = new BufferedOutputStream(freshGdo.getPrimaryFile().getOutputStream())) {
                     // Write the graph.

--- a/CoreInteractiveGraph/src/au/gov/asd/tac/constellation/graph/interaction/gui/VisualGraphTopComponent.java
+++ b/CoreInteractiveGraph/src/au/gov/asd/tac/constellation/graph/interaction/gui/VisualGraphTopComponent.java
@@ -956,9 +956,9 @@ public final class VisualGraphTopComponent extends CloneableTopComponent impleme
          * @throws IOException When I/O errors happen.
          */
         @Override
-        protected void handleSave() throws IOException {          
+        protected void handleSave() throws IOException {
             final GraphDataObject gdo = graphNode.getDataObject();
-       
+
             if (gdo.isInMemory()) {
                 // We don't want to do a save if this is an in-memory DataObject.
                 // Instead, we'll do the "Save As..." action and let it naturally do the right thing.
@@ -1109,9 +1109,9 @@ public final class VisualGraphTopComponent extends CloneableTopComponent impleme
                 //     - if the star file fails to load, check to see if a 'backup' exists
                 //        - if backup was found attempt to load it
                 //        - if backup was not found throw load error
-                FileObject fileobj = freshGdo.getPrimaryFile();
-                File srcFile = new File(fileobj.getPath());
-                String srcfilePath = srcFile.getParent().concat("\\").concat(this.name).concat(".").concat(fileobj.getExt());
+                final FileObject fileobj = freshGdo.getPrimaryFile();
+                final File srcFile = new File(fileobj.getPath());
+                final String srcfilePath = srcFile.getParent().concat(File.pathSeparator).concat(this.name).concat(".").concat(fileobj.getExt());
                 
                 // Create a backup copy of the file before overwriting it. If the backup copy fails, then code will never
                 // get to execute the save, so the actual file should remain intact. If the save fails, the backup file will
@@ -1123,7 +1123,7 @@ public final class VisualGraphTopComponent extends CloneableTopComponent impleme
                     cancelled = new GraphJsonWriter().writeGraphToZip(copy, out, new HandleIoProgress("Writing..."));
                 }
                 SaveNotification.saved(freshGdo.getPrimaryFile().getPath());
-            } catch (Exception ex) {
+            } catch (final Exception ex) {
                 Exceptions.printStackTrace(ex);
             }
 


### PR DESCRIPTION
### Description of the Change

Added an additional level of redundacy to star file loads, such that backup files (.bak) are created on save, prior to saving of new file verison. These backup files capture the star file before updates, (because these files were able to be loaded). Additionally, no longer delete backup file when loading an autosave file .

Upon load, andattmept is made to open the selected star file, if this fails, a check is made to see if an associated backup is found and if sao, attempts are made to load this. 

### Alternate Designs

I considered options to try and capture all ways a file could be corrupted, but there are too many to consider, hence is is considered easier to be more robust in loading.

### Why Should This Be In Core?

Bug fix.

### Benefits

Add an extra level of redundancy to file loading.

### Possible Drawbacks

There is one case still not covered, if an autosave file exists and actual file is corrupted.

### Verification Process

Us the following table: 
![image](https://user-images.githubusercontent.com/58677108/109226669-13628b80-780f-11eb-977b-b9dd3875c065.png)

Create a set of valid and invalid files. Itertate through the scenarios identified in the above table and confirm that the file loaded (or error) is in line with table.


### Applicable Issues

#19 
