### PR TITLE
Improve the performance of File -> Open

### DIFF
--- a/CoreUtilities/src/au/gov/asd/tac/constellation/utilities/icon/ConstellationIcon.java
+++ b/CoreUtilities/src/au/gov/asd/tac/constellation/utilities/icon/ConstellationIcon.java
@@ -22,6 +22,7 @@ import java.awt.image.BufferedImage;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -65,9 +66,9 @@ public class ConstellationIcon {
     /**
      * A cache to store icons
      */
-    private static final Map<ThreeTuple<IconData, Integer, Color>, Object> ICON_CACHE = new HashMap<>();
-    private static final Map<ThreeTuple<IconData, Integer, Color>, Object> IMAGE_CACHE = new HashMap<>();
-    private static final Map<ThreeTuple<IconData, Integer, Color>, Object> BUFFERED_IMAGE_CACHE = new HashMap<>();
+    private static final Map<ThreeTuple<Integer, Integer, Color>, Object> ICON_CACHE = new HashMap<>();
+    private static final Map<ThreeTuple<Integer, Integer, Color>, Object> IMAGE_CACHE = new HashMap<>();
+    private static final Map<ThreeTuple<Integer, Integer, Color>, Object> BUFFERED_IMAGE_CACHE = new HashMap<>();
 
     private final String name;
     private final IconData iconData;
@@ -233,7 +234,7 @@ public class ConstellationIcon {
      */
     public BufferedImage buildBufferedImage(final int size, final Color color) {
         // build the cache key
-        final ThreeTuple<IconData, Integer, Color> key = buildCacheKey(iconData, size, color);
+        final ThreeTuple<Integer, Integer, Color> key = buildCacheKey(size, color);
 
         BufferedImage icon;
         if (BUFFERED_IMAGE_CACHE.containsKey(key)) {
@@ -300,7 +301,7 @@ public class ConstellationIcon {
      */
     public Icon buildIcon(final int size, final Color color) {
         // build the cache key
-        final ThreeTuple<IconData, Integer, Color> key = buildCacheKey(iconData, size, color);
+        final ThreeTuple<Integer, Integer, Color> key = buildCacheKey(size, color);
 
         final ImageIcon icon;
         if (ICON_CACHE.containsKey(key)) {
@@ -362,7 +363,7 @@ public class ConstellationIcon {
      */
     public Image buildImage(final int size, final Color color) {
         // build the cache key
-        final ThreeTuple<IconData, Integer, Color> key = buildCacheKey(iconData, size, color);
+        final ThreeTuple<Integer, Integer, Color> key = buildCacheKey(size, color);
 
         final Image image;
         if (IMAGE_CACHE.containsKey(key)) {
@@ -379,7 +380,7 @@ public class ConstellationIcon {
 
         return image;
     }
-    
+
     /**
      * Used to clear cache images in the ConstellationIcon cache. This should be
      * called when closing the last open graph to release consumed resources.
@@ -396,13 +397,13 @@ public class ConstellationIcon {
      * Build a key that can be used to index the icon byte array in the icon
      * cache.
      *
-     * @param iconData The icon data object
      * @param size The size of the icon
      * @param color The colour of the icon
-     * @return The byte array of the icon ready for conversion
+     *
+     * @return A unique key represented as a ThreeTuple
      */
-    private ThreeTuple<IconData, Integer, Color> buildCacheKey(final IconData iconData, final int size, final Color color) {
-        return ThreeTuple.create(iconData, size, color);
+    private ThreeTuple<Integer, Integer, Color> buildCacheKey(final int size, final Color color) {
+        return ThreeTuple.create(name.hashCode() + iconData.hashCode(), size, color);
     }
 
     /**

--- a/CoreUtilities/src/au/gov/asd/tac/constellation/utilities/icon/IconData.java
+++ b/CoreUtilities/src/au/gov/asd/tac/constellation/utilities/icon/IconData.java
@@ -174,27 +174,20 @@ public abstract class IconData {
 
     @Override
     public int hashCode() {
-        int hash = 7;
-        hash = 79 * hash + Arrays.hashCode(this.data);
-        return hash;
+        return 79 * 7 + Arrays.hashCode(this.data);
     }
 
     @Override
-    public boolean equals(Object obj) {
+    public boolean equals(final Object obj) {
         if (this == obj) {
             return true;
-        }
-        if (obj == null) {
+        } else if (obj == null) {
             return false;
-        }
-        if (getClass() != obj.getClass()) {
+        } else if (getClass() != obj.getClass()) {
             return false;
         }
         final IconData other = (IconData) obj;
-        if (!Arrays.equals(this.data, other.data)) {
-            return false;
-        }
-        return true;
+        return Arrays.equals(this.data, other.data);
     }
 
     @Override

--- a/CoreUtilities/src/au/gov/asd/tac/constellation/utilities/icon/IconData.java
+++ b/CoreUtilities/src/au/gov/asd/tac/constellation/utilities/icon/IconData.java
@@ -21,6 +21,7 @@ import java.awt.image.BufferedImage;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Arrays;
 import java.util.logging.Logger;
 import javax.imageio.ImageIO;
 import org.openide.util.Exceptions;
@@ -169,6 +170,31 @@ public abstract class IconData {
 
             return scaledImage;
         }
+    }
+
+    @Override
+    public int hashCode() {
+        int hash = 7;
+        hash = 79 * hash + Arrays.hashCode(this.data);
+        return hash;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        final IconData other = (IconData) obj;
+        if (!Arrays.equals(this.data, other.data)) {
+            return false;
+        }
+        return true;
     }
 
     @Override


### PR DESCRIPTION
<!--

### Requirements

* Filling out the template is required. Any pull request that does not include
enough information to be reviewed in a timely manner may be closed at the
maintainers' discretion.
* Follow the check list items defined by https://github.com/constellation-app/constellation/blob/master/CONTRIBUTING.md#pull-requests
* All new code requires unit tests to ensure they work as expected and will
continue to work as new code is added in the future (regression testing).
* Make sure your branch name is prefixed by `feature`, `bugfix`, `hotfix` or `release`
* Have you read Constellation's Code of Conduct? By filing an issue, you are
expected to comply with it, including treating everyone with respect:
https://github.com/constellation-app/constellation/blob/master/CODE_OF_CONDUCT.md

-->

### Description of the Change

* The Constellation icon (and others) were not being cached properly so File -> Open on a folder containing star graphs would waste CPU time building the icon again for each filename.
* Fixed a memory leak where built icons was cached but never retrieved.
* In the cache, the `IconData` is no longer stored which has greatly reduced the memory footprint.

Opening a folder containing 10,000 star files :smile:

![image](https://user-images.githubusercontent.com/39325530/111922923-cc577580-8af0-11eb-9e43-f708a8f2542e.png)

The following profiles Constellation from launch so it includes calls to create icons throughout the application. This includes the 4 icons in the bottom right corner (nodes, transactions, edges, links) etc. You will notice that `IconData.createData()` was called 35k times and is now just 15 times!

Performance of `master` taking around 5.5 seconds:
![master loading graphs](https://user-images.githubusercontent.com/39325530/111922945-e2fdcc80-8af0-11eb-900c-e63547e08e3a.png)

Performance of this branch taking under 0.2 seconds:
![latest file opening graphs](https://user-images.githubusercontent.com/39325530/111922984-0b85c680-8af1-11eb-8222-f780514cf491.png)

### Alternate Designs

<!--

Explain what other alternates were considered and why the proposed version was
selected.

-->

### Why Should This Be In Core?

<!--

Explain why this functionality should be in Constellation Core as opposed to a
different module suite. Note that this question is more applicable when adding
new functionality. If this change is a minor update to an exising file then it
is understood that this change has to be to this module suite and a response
and therefore a response to this question is not required.

-->

### Benefits

* Performance improvement opening folders containing lots of star files. This reduced CPU and memory use.
* Fix a memory leak whereby dynamically built icons in  `ICONS_CACHE` was being populated but never retrieved.
* In the cache, the `IconData` is no longer stored which has greatly reduced the memory footprint.

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process

Tested using a folder containing 10,000 star files.

### Applicable Issues

<!-- Link any applicable issues here -->
