### PR TITLE
Added bin count to Histogram

### DIFF
--- a/CoreHistogramView/src/au/gov/asd/tac/constellation/views/histogram/HistogramDisplay.java
+++ b/CoreHistogramView/src/au/gov/asd/tac/constellation/views/histogram/HistogramDisplay.java
@@ -66,7 +66,7 @@ public class HistogramDisplay extends JPanel implements MouseInputListener, Mous
     static final String NO_VALUE = "<No Value>";
     private static final String PROPERTY_VALUE = "Property Value";
     private static final String COUNT = "Count";
-    private final String totalBinsCount = "Total Bin Count: ";
+    private static final String totalBinsCount = "Total Bin Count: ";
 
     // The color that shows where a bar would be if it was bigger.
     // This provides a guide to the user so they can click anywhere level with a bar,
@@ -108,6 +108,7 @@ public class HistogramDisplay extends JPanel implements MouseInputListener, Mous
     private boolean controlDown;
     private boolean binCollectionOutOfDate = true;
     private final JPopupMenu copyMenu = new JPopupMenu();
+    private static final int HALF = 2;
 
     public HistogramDisplay(HistogramTopComponent topComponent) {
         this.topComponent = topComponent;
@@ -344,9 +345,10 @@ public class HistogramDisplay extends JPanel implements MouseInputListener, Mous
                 
                 int countTextWidth = g2.getFontMetrics().stringWidth(headerStringTotalBins);
                 
-                g2.drawString(headerStringValue, LEFT_MARGIN + iconPadding, TOP_MARGIN + (barHeight / 2) + correction);
-                g2.drawString(headerStringCount, barLeft, TOP_MARGIN + (barHeight / 2) + correction);
-                g2.drawString(headerStringTotalBins, getParent().getWidth() - countTextWidth, TOP_MARGIN + (barHeight /2) + correction);
+                g2.drawString(headerStringValue, LEFT_MARGIN + iconPadding, TOP_MARGIN + (barHeight / HALF) + correction);
+                g2.drawString(headerStringCount, barLeft, TOP_MARGIN + (barHeight / HALF) + correction);
+                g2.drawString(headerStringTotalBins, getParent().getWidth() - countTextWidth, 
+                        TOP_MARGIN + (barHeight /HALF) + correction);
                 
                 // Draw the visible bars.
                 for (int bar = firstBar; bar <= lastBar; bar++) {

--- a/CoreHistogramView/src/au/gov/asd/tac/constellation/views/histogram/HistogramDisplay.java
+++ b/CoreHistogramView/src/au/gov/asd/tac/constellation/views/histogram/HistogramDisplay.java
@@ -67,7 +67,6 @@ public class HistogramDisplay extends JPanel implements MouseInputListener, Mous
     private static final String PROPERTY_VALUE = "Property Value";
     private static final String COUNT = "Count";
     private static final String TOTAL_BINS_COUNT = "Total Bin Count: ";
-    private static final int HALF = 2;
 
     // The color that shows where a bar would be if it was bigger.
     // This provides a guide to the user so they can click anywhere level with a bar,
@@ -343,13 +342,12 @@ public class HistogramDisplay extends JPanel implements MouseInputListener, Mous
                 final String headerStringCount = getStringToFit(COUNT, barsWidth, g2);
                 final String headerStringTotalBins = getStringToFit(TOTAL_BINS_COUNT + bins.length, barsWidth, g2);
                 
-                int countTextWidth = g2.getFontMetrics().stringWidth(headerStringTotalBins);
+                final int countTextWidth = g2.getFontMetrics().stringWidth(headerStringTotalBins);
                 
-                g2.drawString(headerStringValue, LEFT_MARGIN + iconPadding, 
-                        TOP_MARGIN + (barHeight / HALF) + correction);
-                g2.drawString(headerStringCount, barLeft, TOP_MARGIN + (barHeight / HALF) + correction);
+                g2.drawString(headerStringValue, LEFT_MARGIN + iconPadding, TOP_MARGIN + (barHeight / 2) + correction);
+                g2.drawString(headerStringCount, barLeft, TOP_MARGIN + (barHeight / 2) + correction);
                 g2.drawString(headerStringTotalBins, getParent().getWidth() - countTextWidth, 
-                        TOP_MARGIN + (barHeight /HALF) + correction);
+                        TOP_MARGIN + (barHeight / 2) + correction);
                 
                 // Draw the visible bars.
                 for (int bar = firstBar; bar <= lastBar; bar++) {

--- a/CoreHistogramView/src/au/gov/asd/tac/constellation/views/histogram/HistogramDisplay.java
+++ b/CoreHistogramView/src/au/gov/asd/tac/constellation/views/histogram/HistogramDisplay.java
@@ -66,6 +66,7 @@ public class HistogramDisplay extends JPanel implements MouseInputListener, Mous
     static final String NO_VALUE = "<No Value>";
     private static final String PROPERTY_VALUE = "Property Value";
     private static final String COUNT = "Count";
+    private final String totalBinsCount = "Total Bin Count: ";
 
     // The color that shows where a bar would be if it was bigger.
     // This provides a guide to the user so they can click anywhere level with a bar,
@@ -339,9 +340,14 @@ public class HistogramDisplay extends JPanel implements MouseInputListener, Mous
 
                 final String headerStringValue = getStringToFit(PROPERTY_VALUE, textWidth, g2);
                 final String headerStringCount = getStringToFit(COUNT, barsWidth, g2);
+                final String headerStringTotalBins = getStringToFit(totalBinsCount + bins.length, barsWidth, g2);
+                
+                int countTextWidth = g2.getFontMetrics().stringWidth(headerStringTotalBins);
+                
                 g2.drawString(headerStringValue, LEFT_MARGIN + iconPadding, TOP_MARGIN + (barHeight / 2) + correction);
                 g2.drawString(headerStringCount, barLeft, TOP_MARGIN + (barHeight / 2) + correction);
-
+                g2.drawString(headerStringTotalBins, getParent().getWidth() - countTextWidth, TOP_MARGIN + (barHeight /2) + correction);
+                
                 // Draw the visible bars.
                 for (int bar = firstBar; bar <= lastBar; bar++) {
                     Bin bin = bins[bar];

--- a/CoreHistogramView/src/au/gov/asd/tac/constellation/views/histogram/HistogramDisplay.java
+++ b/CoreHistogramView/src/au/gov/asd/tac/constellation/views/histogram/HistogramDisplay.java
@@ -66,7 +66,8 @@ public class HistogramDisplay extends JPanel implements MouseInputListener, Mous
     static final String NO_VALUE = "<No Value>";
     private static final String PROPERTY_VALUE = "Property Value";
     private static final String COUNT = "Count";
-    private static final String totalBinsCount = "Total Bin Count: ";
+    private static final String TOTAL_BINS_COUNT = "Total Bin Count: ";
+    private static final int HALF = 2;
 
     // The color that shows where a bar would be if it was bigger.
     // This provides a guide to the user so they can click anywhere level with a bar,
@@ -108,7 +109,6 @@ public class HistogramDisplay extends JPanel implements MouseInputListener, Mous
     private boolean controlDown;
     private boolean binCollectionOutOfDate = true;
     private final JPopupMenu copyMenu = new JPopupMenu();
-    private static final int HALF = 2;
 
     public HistogramDisplay(HistogramTopComponent topComponent) {
         this.topComponent = topComponent;
@@ -341,11 +341,12 @@ public class HistogramDisplay extends JPanel implements MouseInputListener, Mous
 
                 final String headerStringValue = getStringToFit(PROPERTY_VALUE, textWidth, g2);
                 final String headerStringCount = getStringToFit(COUNT, barsWidth, g2);
-                final String headerStringTotalBins = getStringToFit(totalBinsCount + bins.length, barsWidth, g2);
+                final String headerStringTotalBins = getStringToFit(TOTAL_BINS_COUNT + bins.length, barsWidth, g2);
                 
                 int countTextWidth = g2.getFontMetrics().stringWidth(headerStringTotalBins);
                 
-                g2.drawString(headerStringValue, LEFT_MARGIN + iconPadding, TOP_MARGIN + (barHeight / HALF) + correction);
+                g2.drawString(headerStringValue, LEFT_MARGIN + iconPadding, 
+                        TOP_MARGIN + (barHeight / HALF) + correction);
                 g2.drawString(headerStringCount, barLeft, TOP_MARGIN + (barHeight / HALF) + correction);
                 g2.drawString(headerStringTotalBins, getParent().getWidth() - countTextWidth, 
                         TOP_MARGIN + (barHeight /HALF) + correction);

--- a/CoreHistogramView/src/au/gov/asd/tac/constellation/views/histogram/HistogramTopComponent.java
+++ b/CoreHistogramView/src/au/gov/asd/tac/constellation/views/histogram/HistogramTopComponent.java
@@ -87,6 +87,8 @@ import org.openide.windows.TopComponent;
 })
 public final class HistogramTopComponent extends TopComponent implements GraphManagerListener, GraphChangeListener, UndoRedo.Provider {
 
+    private static final int MIN_WIDTH = 425;
+    private static final int MIN_HEIGHT = 400;
     Graph currentGraph = null;
     private final HistogramControls controls;
     private final HistogramDisplay display;
@@ -105,9 +107,6 @@ public final class HistogramTopComponent extends TopComponent implements GraphMa
     private int selectedAttribute = Graph.NOT_FOUND;
     private long latestGraphChangeID = 0;
     private ElementSet currentFilter;
-    
-    private static final int MIN_WIDTH = 425;
-    private static final int MIN_HEIGHT = 400;
 
     public HistogramTopComponent() {
         initComponents();

--- a/CoreHistogramView/src/au/gov/asd/tac/constellation/views/histogram/HistogramTopComponent.java
+++ b/CoreHistogramView/src/au/gov/asd/tac/constellation/views/histogram/HistogramTopComponent.java
@@ -109,7 +109,8 @@ public final class HistogramTopComponent extends TopComponent implements GraphMa
     public HistogramTopComponent() {
         initComponents();
         setName(Bundle.CTL_HistogramTopComponent());
-        setToolTipText(Bundle.HINT_HistogramTopComponent());
+        setToolTipText(Bundle.HINT_HistogramTopComponent()); 
+        this.setMinimumSize(new java.awt.Dimension(425, 400));
 
         controls = new HistogramControls(this);
         add(controls, BorderLayout.SOUTH);

--- a/CoreHistogramView/src/au/gov/asd/tac/constellation/views/histogram/HistogramTopComponent.java
+++ b/CoreHistogramView/src/au/gov/asd/tac/constellation/views/histogram/HistogramTopComponent.java
@@ -105,12 +105,15 @@ public final class HistogramTopComponent extends TopComponent implements GraphMa
     private int selectedAttribute = Graph.NOT_FOUND;
     private long latestGraphChangeID = 0;
     private ElementSet currentFilter;
+    
+    private static final int MIN_WIDTH = 425;
+    private static final int MIN_HEIGHT = 400;
 
     public HistogramTopComponent() {
         initComponents();
         setName(Bundle.CTL_HistogramTopComponent());
         setToolTipText(Bundle.HINT_HistogramTopComponent()); 
-        this.setMinimumSize(new java.awt.Dimension(425, 400));
+        this.setMinimumSize(new java.awt.Dimension(MIN_WIDTH, MIN_HEIGHT));
 
         controls = new HistogramControls(this);
         add(controls, BorderLayout.SOUTH);

--- a/CoreWhatsNewView/src/au/gov/asd/tac/constellation/views/whatsnew/whatsnew.txt
+++ b/CoreWhatsNewView/src/au/gov/asd/tac/constellation/views/whatsnew/whatsnew.txt
@@ -1,6 +1,9 @@
 == 3030-12-31 Getting Started
 <p>If you're new to CONSTELLATION, read the <a href="" helpId="au.gov.asd.tac.constellation.functionality.introduction">introduction</a>.</p>
 
+== 2021-04-01 Histogram Bin Counter
+<p>A count for the total number of bins currently shown in the Histogram has been added to the top right of the view.</p>
+
 == 2021-03-22 Scatter Plot
 <p>Ctrl-Shift-O has been added as a keyboard shortcut to open up the Scatter Plot View.</p>
 


### PR DESCRIPTION
<!--

### Requirements

* Filling out the template is required. Any pull request that does not include
enough information to be reviewed in a timely manner may be closed at the
maintainers' discretion.
* Follow the check list items defined by https://github.com/constellation-app/constellation/blob/master/CONTRIBUTING.md#pull-requests
* All new code requires unit tests to ensure they work as expected and will
continue to work as new code is added in the future (regression testing).
* Make sure your branch name is prefixed by `feature`, `bugfix`, `hotfix` or `release`
* Have you read Constellation's Code of Conduct? By filing an issue, you are
expected to comply with it, including treating everyone with respect:
https://github.com/constellation-app/constellation/blob/master/CODE_OF_CONDUCT.md

-->

### Description of the Change
Added a total bin count to the top of the Histogram view. 
Also set the minimum width of the Histogram view so that all elements are always able to be viewed.
<!--

We must be able to understand the design of your change from this description.
If we can't get a good idea of what the code will be doing from the description
here, the pull request may be closed at the maintainers' discretion. Keep in
mind that the maintainer reviewing this PR may not be familiar with or have
worked with the code here recently, so please walk us through the concepts.

-->

### Why Should This Be In Core?
Allows for the user to easily tell how many bins are currently in the Histogram.
<!--

Explain why this functionality should be in Constellation Core as opposed to a
different module suite. Note that this question is more applicable when adding
new functionality. If this change is a minor update to an exising file then it
is understood that this change has to be to this module suite and a response
and therefore a response to this question is not required.

-->


### Applicable Issues
#996 
<!-- Link any applicable issues here -->
