### PR TITLE
Quality Category button bug fix

### DIFF
--- a/CoreDataAccessView/src/au/gov/asd/tac/constellation/views/dataaccess/panes/DataAccessPane.java
+++ b/CoreDataAccessView/src/au/gov/asd/tac/constellation/views/dataaccess/panes/DataAccessPane.java
@@ -44,6 +44,7 @@ import static au.gov.asd.tac.constellation.views.dataaccess.DataAccessPluginType
 import au.gov.asd.tac.constellation.views.dataaccess.io.ParameterIOUtilities;
 import au.gov.asd.tac.constellation.views.dataaccess.state.DataAccessPreferenceKeys;
 import au.gov.asd.tac.constellation.views.dataaccess.templates.DataAccessPreQueryValidation;
+import au.gov.asd.tac.constellation.views.qualitycontrol.QualityControlViewPane;
 import au.gov.asd.tac.constellation.views.qualitycontrol.daemon.QualityControlAutoVetterListener;
 import au.gov.asd.tac.constellation.views.qualitycontrol.widget.QualityControlAutoButton;
 import java.io.File;
@@ -148,6 +149,8 @@ public class DataAccessPane extends AnchorPane implements PluginParametersPaneLi
 
     public DataAccessPane(DataAccessViewTopComponent topComponent) {
         this.topComponent = topComponent;
+        
+        QualityControlViewPane.readSerializedRulePriorities();
 
         dataAccessTabPane = new TabPane();
         dataAccessTabPane.setSide(Side.TOP);

--- a/CoreQualityControlView/src/au/gov/asd/tac/constellation/views/qualitycontrol/QualityControlViewPane.java
+++ b/CoreQualityControlView/src/au/gov/asd/tac/constellation/views/qualitycontrol/QualityControlViewPane.java
@@ -664,7 +664,7 @@ public final class QualityControlViewPane extends BorderPane {
     /**
      * Reads the preferences object to load the rulePriorities.
      */
-    private static void readSerializedRulePriorities() {
+    public static void readSerializedRulePriorities() {
         getPriorities().clear();
         final Map<String, String> priorityStringMap = JsonUtilities.getStringAsMap(FACTORY, PREFERENCES.get(ApplicationPreferenceKeys.RULE_PRIORITIES, ""));
         for (final Entry<String, String> entry : priorityStringMap.entrySet()) {


### PR DESCRIPTION
<!--

### Requirements

* Filling out the template is required. Any pull request that does not include
enough information to be reviewed in a timely manner may be closed at the
maintainers' discretion.
* Follow the check list items defined by https://github.com/constellation-app/constellation/blob/master/CONTRIBUTING.md#pull-requests
* All new code requires unit tests to ensure they work as expected and will
continue to work as new code is added in the future (regression testing).
* Make sure your branch name is prefixed by `feature`, `bugfix`, `hotfix` or `release`
* Have you read Constellation's Code of Conduct? By filing an issue, you are
expected to comply with it, including treating everyone with respect:
https://github.com/constellation-app/constellation/blob/master/CODE_OF_CONDUCT.md

-->

### Description of the Change
Fixed a bug where the quality category button in the DAV didn't have the correct priorities before QCV was open.

### Alternate Designs

<!--

Explain what other alternates were considered and why the proposed version was
selected.

-->

### Why Should This Be In Core?

Fixes a bug in Core

### Benefits

Correct categories displayed in DAV quality category button from the beginning

### Possible Drawbacks

Takes a bit longer to open the DAV since it is now also updating the priorities but I think it is necessary in order to ensure the quality category is correct from the get go

### Verification Process

<!--

What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (e.g., buttons you clicked, text you typed,
commands you ran, etc.), and describe the results you observed.

-->

### Applicable Issues

#1049 
