### PR TITLE
QC View Graph load bug fix

### DIFF
--- a/CoreQualityControlView/src/au/gov/asd/tac/constellation/views/qualitycontrol/daemon/QualityControlAutoVetter.java
+++ b/CoreQualityControlView/src/au/gov/asd/tac/constellation/views/qualitycontrol/daemon/QualityControlAutoVetter.java
@@ -159,7 +159,7 @@ public final class QualityControlAutoVetter implements GraphManagerListener, Gra
                 final long thisCameraModificationCounter = readableGraph.getValueModificationCounter(cameraAttribute);
 
                 if (thisGlobalModificationCounter != lastGlobalModificationCounter) {
-                    if (lastCameraModificationCounter == thisCameraModificationCounter) {
+                    if (lastGlobalModificationCounter == -1 || lastCameraModificationCounter == thisCameraModificationCounter) {
                         updateQualityControlState(graph);
                     }
                     lastGlobalModificationCounter = thisGlobalModificationCounter;


### PR DESCRIPTION
<!--

### Requirements

* Filling out the template is required. Any pull request that does not include
enough information to be reviewed in a timely manner may be closed at the
maintainers' discretion.
* Follow the check list items defined by https://github.com/constellation-app/constellation/blob/master/CONTRIBUTING.md#pull-requests
* All new code requires unit tests to ensure they work as expected and will
continue to work as new code is added in the future (regression testing).
* Make sure your branch name is prefixed by `feature`, `bugfix`, `hotfix` or `release`
* Have you read Constellation's Code of Conduct? By filing an issue, you are
expected to comply with it, including treating everyone with respect:
https://github.com/constellation-app/constellation/blob/master/CODE_OF_CONDUCT.md

-->

### Description of the Change

Fixed a bug where the quality control view sometimes wouldn't update when you loaded a graph.

The issue ended up pointing to a change made to not update the quality control state when the camera was modified (e.g. camera zoom). What it resulted in though was that when you loaded or switched to a graph where the camera was different to what was currently set, the quality control state wouldn't update (even if there were other changes besides the camera).

Since the global mod counter resets to -1 every time you load or switch graphs, extending the camera mod check to include a check for the global mod count being -1 resolves the issue.

### Alternate Designs

<!--

Explain what other alternates were considered and why the proposed version was
selected.

-->

### Why Should This Be In Core?

Fixes a bug in Core

### Benefits

Quality control view now updates as expected when you load a graph or switch graphs.

### Possible Drawbacks

Nil

### Verification Process

<!--

What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (e.g., buttons you clicked, text you typed,
commands you ran, etc.), and describe the results you observed.

-->

### Applicable Issues

#1054
