### PR TITLE
Conversation view lock up fix

### DIFF
--- a/CoreConversationView/src/au/gov/asd/tac/constellation/views/conversationview/ConversationViewTopComponent.java
+++ b/CoreConversationView/src/au/gov/asd/tac/constellation/views/conversationview/ConversationViewTopComponent.java
@@ -72,11 +72,8 @@ public final class ConversationViewTopComponent extends JavaFxTopComponent<Conve
         setName(Bundle.CTL_ConversationViewTopComponent());
         setToolTipText(Bundle.HINT_ConversationViewTopComponent());
         Platform.setImplicitExit(false);
-
-        Platform.runLater(() -> {
-            conversationBox = new ConversationBox(conversation);
-            conversation.getGraphUpdateManager().setManaged(true);
-        });
+        conversationBox = new ConversationBox(conversation);
+        conversation.getGraphUpdateManager().setManaged(true);
         initContent();
     }
 


### PR DESCRIPTION
<!--

### Requirements

* Filling out the template is required. Any pull request that does not include
enough information to be reviewed in a timely manner may be closed at the
maintainers' discretion.
* Follow the check list items defined by https://github.com/constellation-app/constellation/blob/master/CONTRIBUTING.md#pull-requests
* All new code requires unit tests to ensure they work as expected and will
continue to work as new code is added in the future (regression testing).
* Make sure your branch name is prefixed by `feature`, `bugfix`, `hotfix` or `release`
* Have you read Constellation's Code of Conduct? By filing an issue, you are
expected to comply with it, including treating everyone with respect:
https://github.com/constellation-app/constellation/blob/master/CODE_OF_CONDUCT.md

-->

### Description of the Change

Fixed the issue where Conversation View sometimes locks up when you open it. The source of the problem was an unnecessary call of `Platform.runLater` in the constructor.

### Alternate Designs

<!--

Explain what other alternates were considered and why the proposed version was
selected.

-->

### Why Should This Be In Core?

Fixes bug in Core

### Benefits

Conversation view should hopefully not lock up anymore

### Possible Drawbacks

Nil

### Verification Process

Ran the reproducer as described in #978, also did some general playing around in the Conversation view to ensure nothing else broke in the process.

### Applicable Issues

#978
