### PR TITLE
🐛 Layers view null pointer fix

### DIFF
--- a/CoreLayersView/src/au/gov/asd/tac/constellation/views/layers/LayersViewController.java
+++ b/CoreLayersView/src/au/gov/asd/tac/constellation/views/layers/LayersViewController.java
@@ -188,7 +188,7 @@ public class LayersViewController {
     }
 
     public boolean getParentVisibility() {
-        return parent != null ? parent.getVisibility() : false;
+        return parent != null && parent.getVisibility();
     }
 
     public void readStateFuture() {

--- a/CoreLayersView/src/au/gov/asd/tac/constellation/views/layers/LayersViewController.java
+++ b/CoreLayersView/src/au/gov/asd/tac/constellation/views/layers/LayersViewController.java
@@ -91,6 +91,9 @@ public class LayersViewController {
     }
 
     public void setListenedAttributes() {
+        if(parent == null){
+            return;
+        }
         parent.removeValueHandlers(valueMonitors);
         valueMonitors.addAll(parent.setChangeListeners(List.copyOf(changeListeners)));
     }
@@ -172,6 +175,9 @@ public class LayersViewController {
      * View pane.
      */
     public void readState() {
+        if(parent == null){
+            return;
+        }
         final LayersViewPane pane = parent.getContent();
         final Graph graph = GraphManager.getDefault().getActiveGraph();
         if (pane == null || graph == null) {
@@ -182,10 +188,13 @@ public class LayersViewController {
     }
 
     public boolean getParentVisibility() {
-        return parent != null ? parent.getVisibility() : null;
+        return parent != null ? parent.getVisibility() : false;
     }
 
     public void readStateFuture() {
+        if(parent == null){
+            return;
+        }
         final LayersViewPane pane = parent.getContent();
         final Graph graph = GraphManager.getDefault().getActiveGraph();
         if (pane == null || graph == null) {

--- a/CoreLayersView/src/au/gov/asd/tac/constellation/views/layers/shortcut/LayersViewShortcuts.java
+++ b/CoreLayersView/src/au/gov/asd/tac/constellation/views/layers/shortcut/LayersViewShortcuts.java
@@ -74,7 +74,9 @@ public class LayersViewShortcuts extends AbstractAction {
         final Future<?> future = LayersViewController.getDefault().writeState();
 
         try {
-            future.get();
+            if(future != null){
+                future.get();
+            }
         } catch (final InterruptedException ex) {
             Exceptions.printStackTrace(ex);
             Thread.currentThread().interrupt();


### PR DESCRIPTION
<!--

### Requirements

* Filling out the template is required. Any pull request that does not include
enough information to be reviewed in a timely manner may be closed at the
maintainers' discretion.
* Follow the check list items defined by https://github.com/constellation-app/constellation/blob/master/CONTRIBUTING.md#pull-requests
* All new code requires unit tests to ensure they work as expected and will
continue to work as new code is added in the future (regression testing).
* Make sure your branch name is prefixed by `feature`, `bugfix`, `hotfix` or `release`
* Have you read Constellation's Code of Conduct? By filing an issue, you are
expected to comply with it, including treating everyone with respect:
https://github.com/constellation-app/constellation/blob/master/CODE_OF_CONDUCT.md

-->

### Description of the Change
A few noted null pointers to finish off #1002 
Returning a boolean as false instead of null made sense.
<!--

We must be able to understand the design of your change from this description.
If we can't get a good idea of what the code will be doing from the description
here, the pull request may be closed at the maintainers' discretion. Keep in
mind that the maintainer reviewing this PR may not be familiar with or have
worked with the code here recently, so please walk us through the concepts.

-->

Tested by having no graph open.
Use the hotkeys ctrl + alt + L
ctrl + alt +1

The error should occur at that point.

With the fix, there is no null pointer and no drawbacks because nothing should  be occurring without a graph or the Layers View opened.