### PR TITLE
fix refresh of conversation counter

### DIFF
--- a/CoreConversationView/src/au/gov/asd/tac/constellation/views/conversationview/Conversation.java
+++ b/CoreConversationView/src/au/gov/asd/tac/constellation/views/conversationview/Conversation.java
@@ -555,6 +555,7 @@ public class Conversation {
 
         @Override
         protected boolean update(GraphReadMethods graph) {
+            ConversationBox.reset();
             if (resultMessages != null) {
                 resultMessages.setAll(visibleMessages);
             }

--- a/CoreConversationView/src/au/gov/asd/tac/constellation/views/conversationview/ConversationBox.java
+++ b/CoreConversationView/src/au/gov/asd/tac/constellation/views/conversationview/ConversationBox.java
@@ -406,6 +406,8 @@ public final class ConversationBox extends StackPane {
 
             // Handle the case where the cell is empty.
             if (empty || message == null) {
+                searchLabel.setText("Found: " + found);
+                searchLabel.setStyle(found > 0 ? FOUND_COLOUR_TRUE : FOUND_COLOUR_FALSE);
                 setStyle(JavafxStyleManager.CSS_BACKGROUND_COLOR_TRANSPARENT);
                 setGraphic(null);
             } else {

--- a/CoreConversationView/src/au/gov/asd/tac/constellation/views/conversationview/ConversationBox.java
+++ b/CoreConversationView/src/au/gov/asd/tac/constellation/views/conversationview/ConversationBox.java
@@ -118,7 +118,7 @@ public final class ConversationBox extends StackPane {
     private volatile boolean isAdjustingContributionProviders = false;
     private volatile boolean isAdjustingSenderLabels;
 
-    private int found = 0;
+    private static int found = 0;
     private static final String FOUND_COLOUR_TRUE = "-fx-text-fill: yellow;";
     private static final String FOUND_COLOUR_FALSE = "-fx-text-fill: red;";
 
@@ -271,6 +271,13 @@ public final class ConversationBox extends StackPane {
 
         content.getChildren().addAll(optionsPane, searchVBox, contributionsPane, bubbles);
         getChildren().addAll(content, tipsPane);
+    }
+    
+    /**
+     * Reset the ConversationBox prior to updating the contents.
+     */
+    public static void reset(){
+        found = 0;
     }
 
     // A VBox to hold a bubble and a sender.


### PR DESCRIPTION
<!--

### Requirements

* Filling out the template is required. Any pull request that does not include
enough information to be reviewed in a timely manner may be closed at the
maintainers' discretion.
* Follow the check list items defined by https://github.com/constellation-app/constellation/blob/master/CONTRIBUTING.md#pull-requests
* All new code requires unit tests to ensure they work as expected and will
continue to work as new code is added in the future (regression testing).
* Make sure your branch name is prefixed by `feature`, `bugfix`, `hotfix` or `release`
* Have you read Constellation's Code of Conduct? By filing an issue, you are
expected to comply with it, including treating everyone with respect:
https://github.com/constellation-app/constellation/blob/master/CODE_OF_CONDUCT.md

-->

### Description of the Change
This adds a static method to refresh the `ConversationBox` just before an update.
Prior to this, the counter would continue to jump up higher and higher whenever an update would occur.

The `updateComponent` currently triggers on a list change event. Then the view responds by changing only the singular conversations within that list. This is troublesome to reset a count as we don't have access to the iterator which is looping and updating the results. eg. the below is an ideal situation to reset the `foundCount` before the loop
```
foundCount = 0
for conversation in conversations :
    update(conversation)
```

What we have is as below. IE. Some external data structure looping all changes and just providing a means to update.
```
@Override
update(conversation){
    setText(Conversation.getText())
    foundCount+=1
}
```

### Possible Drawbacks
Potential downsides to this is that it couples the classes more. A fix could be to add another listener that would be responsible for only refreshing the view just before the` update(conversation) `call was made. `(Conversation.java -> update() -> Line 558)`

<!--

We must be able to understand the design of your change from this description.
If we can't get a good idea of what the code will be doing from the description
here, the pull request may be closed at the maintainers' discretion. Keep in
mind that the maintainer reviewing this PR may not be familiar with or have
worked with the code here recently, so please walk us through the concepts.

-->





### Applicable Issues
#887 
PR #957 
<!-- Link any applicable issues here -->
