### PR TITLE
Update Quality Control Category Names and Colours

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Changes in July 2021
 
+-   Update to Quality Control category names and colours in 
+    'QualityControlEvent' to be easier to understand. 
+
 -   Update to `openEdit`, `updateNotesUI`, `createNote` and the constructor in 
     `NotesViewPane` to include variables to hold what graph elements are 
     selected and applied to the note. Also included a right click context menu

--- a/CoreQualityControlView/src/au/gov/asd/tac/constellation/views/qualitycontrol/QualityControlEvent.java
+++ b/CoreQualityControlView/src/au/gov/asd/tac/constellation/views/qualitycontrol/QualityControlEvent.java
@@ -32,17 +32,19 @@ import org.openide.util.Lookup;
 public class QualityControlEvent implements Comparable<QualityControlEvent> {
 
     public enum QualityCategory {
-        DEFAULT,
-        INFO,
-        WARNING,
+        OK,
+        MINOR,
+        MEDIUM,
+        MAJOR,
         SEVERE,
-        FATAL
+        CRITICAL
     }
-    public static final int DEFAULT_VALUE = 1;
-    public static final int INFO_VALUE = 30;
-    public static final int WARNING_VALUE = 60;
+    public static final int OK_VALUE = 0;
+    public static final int MINOR_VALUE = 1;
+    public static final int MEDIUM_VALUE = 30;
+    public static final int MAJOR_VALUE = 60;
     public static final int SEVERE_VALUE = 90;
-    public static final int FATAL_VALUE = 95;
+    public static final int CRITICAL_VALUE = 95;
 
     private int quality = 0;
     private final int vertex;
@@ -50,7 +52,7 @@ public class QualityControlEvent implements Comparable<QualityControlEvent> {
     private final String type;
     private final List<QualityControlRule> rules;
     private final List<String> reasons;
-    private QualityCategory category = QualityCategory.DEFAULT;
+    private QualityCategory category = QualityCategory.OK;
 
     /**
      * Constructor for QualityControlEvent.
@@ -86,22 +88,23 @@ public class QualityControlEvent implements Comparable<QualityControlEvent> {
                     category = QualityControlViewPane.getPriorities().get(rule);
 
                     switch (category) {
-                        case DEFAULT:
-                            quality = DEFAULT_VALUE;
+                        case MINOR:
+                            quality = MINOR_VALUE;
                             break;
-                        case INFO:
-                            quality = INFO_VALUE;
+                        case MEDIUM:
+                            quality = MEDIUM_VALUE;
                             break;
-                        case WARNING:
-                            quality = WARNING_VALUE;
+                        case MAJOR:
+                            quality = MAJOR_VALUE;
                             break;
                         case SEVERE:
                             quality = SEVERE_VALUE;
                             break;
-                        case FATAL:
-                            quality = FATAL_VALUE;
+                        case CRITICAL:
+                            quality = CRITICAL_VALUE;
                             break;
                         default:
+                            quality = OK_VALUE;
                             break;
                     }
                 }
@@ -118,22 +121,22 @@ public class QualityControlEvent implements Comparable<QualityControlEvent> {
     public static QualityCategory getCategoryFromString(final String category) {
         if (StringUtils.isNotEmpty(category)) {
             switch (category.toLowerCase()) {
-                case "default":
-                    return QualityCategory.DEFAULT;
-                case "info":
-                    return QualityCategory.INFO;
-                case "warning":
-                    return QualityCategory.WARNING;
+                case "minor":
+                    return QualityCategory.MINOR;
+                case "medium":
+                    return QualityCategory.MEDIUM;
+                case "major":
+                    return QualityCategory.MAJOR;
                 case "severe":
                     return QualityCategory.SEVERE;
-                case "fatal":
-                    return QualityCategory.FATAL;
+                case "critical":
+                    return QualityCategory.CRITICAL;
                 default:
-                    // default to default case when not readable.
-                    return QualityCategory.DEFAULT;
+                    // default to OK case when not readable.
+                    return QualityCategory.OK;
             }
         }
-        return QualityCategory.DEFAULT;
+        return QualityCategory.OK;
     }
 
     /**

--- a/CoreQualityControlView/src/au/gov/asd/tac/constellation/views/qualitycontrol/QualityControlViewPane.java
+++ b/CoreQualityControlView/src/au/gov/asd/tac/constellation/views/qualitycontrol/QualityControlViewPane.java
@@ -298,7 +298,7 @@ public final class QualityControlViewPane extends BorderPane {
                     public void updateItem(final QualityControlEvent item, final boolean empty) {
                         super.updateItem(item, empty);
                         if (item != null) {
-                            setText(item.getCategory() == QualityCategory.DEFAULT ? Bundle.MSG_NotApplicable() : String.valueOf(item.getCategory().name()));
+                            setText(String.valueOf(item.getCategory().name()));
                             setAlignment(Pos.CENTER);
                             setStyle(qualityStyle(item.getCategory()));
                         }
@@ -370,33 +370,32 @@ public final class QualityControlViewPane extends BorderPane {
      * @return a javafx style based on the given quality and alpha values.
      */
     public static String qualityStyle(final QualityCategory category, final float alpha) {
-        final String whiteText = "-fx-text-fill: rgb(0,0,0);-fx-background-color: rgba(%d,%d,255,%f);";
         final int intensity;
         final String style;
         switch (category) {
-            case INFO:
-                intensity = 255 - (255 * QualityControlEvent.INFO_VALUE) / 100;
-                style = String.format(whiteText, intensity, intensity, alpha);
+            case MINOR:
+                style = String.format("-fx-text-fill: rgb(0,0,0);-fx-background-color: rgba(90,150,255,%f);", alpha);
                 break;
-            case WARNING:
-                intensity = 255 - (255 * QualityControlEvent.WARNING_VALUE) / 100;
-                style = String.format("-fx-text-fill: rgb(255,255,255);-fx-background-color: rgba(%d,%d,255,%f);", intensity, intensity, alpha);
+            case MEDIUM:
+                style = String.format("-fx-text-fill: rgb(0,0,0);-fx-background-color: rgba(255,215,0,%f);", alpha);
+                break;
+            case MAJOR:
+                intensity = 255 - (255 * QualityControlEvent.MAJOR_VALUE) / 100;
+                style = String.format("-fx-text-fill: rgb(255,255,255);-fx-background-color: rgba(255,%d,0,%f);", intensity, alpha);
                 break;
             case SEVERE:
                 intensity = 255 - (255 * QualityControlEvent.SEVERE_VALUE) / 100;
                 style = String.format("-fx-text-fill: rgb(0,0,0);-fx-background-color: rgba(255,%d,%d,%f);", intensity, intensity, alpha);
                 break;
-            case FATAL:
-                intensity = 255 - (255 * QualityControlEvent.FATAL_VALUE) / 100;
-                style = String.format("-fx-text-fill: rgb(255,255,255);-fx-background-color: rgba(0,%d,%d,%f);", intensity, intensity, alpha);
+            case CRITICAL:
+                intensity = 255 - (255 * QualityControlEvent.CRITICAL_VALUE) / 100;
+                style = String.format("-fx-text-fill: rgb(255,255,255);-fx-background-color: rgba(150,%d,%d,%f);", intensity, intensity, alpha);
                 break;
             default:
                 // DEFAULT case
-                intensity = 255 - (255 * QualityControlEvent.DEFAULT_VALUE) / 100;
-                style = String.format(whiteText, intensity, intensity, alpha);
+                style = String.format("-fx-text-fill: rgb(0,0,0);-fx-background-color: rgba(0,200,0,%f);", alpha);
                 break;
         }
-
         return style;
     }
 
@@ -420,53 +419,53 @@ public final class QualityControlViewPane extends BorderPane {
         ruleLabel.setPadding(new Insets(0, 100, 10, 5));
         buttonGrid.add(ruleLabel, 0, rowCount);
 
-        final Label defaultLabel = new Label("DEFAULT");
-        defaultLabel.setPadding(new Insets(0, 10, 10, 10));
-        buttonGrid.add(defaultLabel, 1, rowCount);
+        final Label minorLabel = new Label("MINOR");
+        minorLabel.setPadding(new Insets(0, 10, 10, 10));
+        buttonGrid.add(minorLabel, 1, rowCount);
 
-        final Label infoLabel = new Label("INFO");
-        infoLabel.setPadding(new Insets(0, 10, 10, 10));
-        buttonGrid.add(infoLabel, 2, rowCount);
+        final Label mediumLabel = new Label("MEDIUM");
+        mediumLabel.setPadding(new Insets(0, 10, 10, 10));
+        buttonGrid.add(mediumLabel, 2, rowCount);
 
-        final Label warningLabel = new Label("WARNING");
-        warningLabel.setPadding(new Insets(0, 10, 10, 10));
-        buttonGrid.add(warningLabel, 3, rowCount);
+        final Label majorLabel = new Label("MAJOR");
+        majorLabel.setPadding(new Insets(0, 10, 10, 10));
+        buttonGrid.add(majorLabel, 3, rowCount);
 
         final Label severeLabel = new Label("SEVERE");
         severeLabel.setPadding(new Insets(0, 10, 10, 10));
         buttonGrid.add(severeLabel, 4, rowCount);
 
-        final Label fatalLabel = new Label("FATAL");
-        fatalLabel.setPadding(new Insets(0, 10, 10, 10));
-        buttonGrid.add(fatalLabel, 5, rowCount);
+        final Label criticalLabel = new Label("CRITICAL");
+        criticalLabel.setPadding(new Insets(0, 10, 10, 10));
+        buttonGrid.add(criticalLabel, 5, rowCount);
         rowCount++;
 
         // Setting rule names and buttons
         for (final QualityControlRule rule : Lookup.getDefault().lookupAll(QualityControlRule.class)) {
             final ToggleGroup ruleGroup = new ToggleGroup();
             final Label ruleName = new Label(rule.getName());
-            final RadioButton defaultButton = new RadioButton();
-            final RadioButton infoButton = new RadioButton();
-            final RadioButton warningButton = new RadioButton();
+            final RadioButton minorButton = new RadioButton();
+            final RadioButton mediumButton = new RadioButton();
+            final RadioButton majorButton = new RadioButton();
             final RadioButton severeButton = new RadioButton();
-            final RadioButton fatalButton = new RadioButton();
+            final RadioButton criticalButton = new RadioButton();
             final Button resetButton = new Button("Reset");
             resetButton.setOnAction(event -> {
                 switch (rule.getCategory(0)) {
-                    case DEFAULT:
-                        defaultButton.setSelected(true);
+                    case MINOR:
+                        minorButton.setSelected(true);
                         break;
-                    case INFO:
-                        infoButton.setSelected(true);
+                    case MEDIUM:
+                        mediumButton.setSelected(true);
                         break;
-                    case WARNING:
-                        warningButton.setSelected(true);
+                    case MAJOR:
+                        majorButton.setSelected(true);
                         break;
                     case SEVERE:
                         severeButton.setSelected(true);
                         break;
-                    case FATAL:
-                        fatalButton.setSelected(true);
+                    case CRITICAL:
+                        criticalButton.setSelected(true);
                         break;
                     default:
                         break;
@@ -476,20 +475,20 @@ public final class QualityControlViewPane extends BorderPane {
             getPriorities().putIfAbsent(rule, rule.getCategory(0));
             // setting the selection based on the current priority
             switch (getPriorities().get(rule)) {
-                case DEFAULT:
-                    defaultButton.setSelected(true);
+                case MINOR:
+                    minorButton.setSelected(true);
                     break;
-                case INFO:
-                    infoButton.setSelected(true);
+                case MEDIUM:
+                    mediumButton.setSelected(true);
                     break;
-                case WARNING:
-                    warningButton.setSelected(true);
+                case MAJOR:
+                    majorButton.setSelected(true);
                     break;
                 case SEVERE:
                     severeButton.setSelected(true);
                     break;
-                case FATAL:
-                    fatalButton.setSelected(true);
+                case CRITICAL:
+                    criticalButton.setSelected(true);
                     break;
                 default:
                     break;
@@ -498,41 +497,41 @@ public final class QualityControlViewPane extends BorderPane {
             toggleGroups.add(ruleGroup);
 
             GridPane.setHalignment(ruleName, HPos.LEFT);
-            GridPane.setHalignment(defaultButton, HPos.CENTER);
-            GridPane.setHalignment(infoButton, HPos.CENTER);
-            GridPane.setHalignment(warningButton, HPos.CENTER);
+            GridPane.setHalignment(minorButton, HPos.CENTER);
+            GridPane.setHalignment(mediumButton, HPos.CENTER);
+            GridPane.setHalignment(majorButton, HPos.CENTER);
             GridPane.setHalignment(severeButton, HPos.CENTER);
-            GridPane.setHalignment(fatalButton, HPos.CENTER);
+            GridPane.setHalignment(criticalButton, HPos.CENTER);
             GridPane.setHalignment(resetButton, HPos.CENTER);
 
             ruleName.setPadding(new Insets(0, 0, 5, 5));
-            defaultButton.setPadding(new Insets(0, 10, 5, 10));
-            infoButton.setPadding(new Insets(0, 10, 5, 10));
-            warningButton.setPadding(new Insets(0, 10, 5, 10));
+            minorButton.setPadding(new Insets(0, 10, 5, 10));
+            mediumButton.setPadding(new Insets(0, 10, 5, 10));
+            majorButton.setPadding(new Insets(0, 10, 5, 10));
             severeButton.setPadding(new Insets(0, 10, 5, 10));
-            fatalButton.setPadding(new Insets(0, 10, 5, 10));
+            criticalButton.setPadding(new Insets(0, 10, 5, 10));
             resetButton.setPadding(new Insets(5, 10, 5, 10));
 
-            defaultButton.setUserData(QualityCategory.DEFAULT);
-            infoButton.setUserData(QualityCategory.INFO);
-            warningButton.setUserData(QualityCategory.WARNING);
+            minorButton.setUserData(QualityCategory.MINOR);
+            mediumButton.setUserData(QualityCategory.MEDIUM);
+            majorButton.setUserData(QualityCategory.MAJOR);
             severeButton.setUserData(QualityCategory.SEVERE);
-            fatalButton.setUserData(QualityCategory.FATAL);
+            criticalButton.setUserData(QualityCategory.CRITICAL);
 
-            defaultButton.setToggleGroup(ruleGroup);
-            infoButton.setToggleGroup(ruleGroup);
-            warningButton.setToggleGroup(ruleGroup);
+            minorButton.setToggleGroup(ruleGroup);
+            mediumButton.setToggleGroup(ruleGroup);
+            majorButton.setToggleGroup(ruleGroup);
             severeButton.setToggleGroup(ruleGroup);
-            fatalButton.setToggleGroup(ruleGroup);
+            criticalButton.setToggleGroup(ruleGroup);
 
             ruleGroup.setUserData(rule);
 
             buttonGrid.add(ruleName, 0, rowCount);
-            buttonGrid.add(defaultButton, 1, rowCount);
-            buttonGrid.add(infoButton, 2, rowCount);
-            buttonGrid.add(warningButton, 3, rowCount);
+            buttonGrid.add(minorButton, 1, rowCount);
+            buttonGrid.add(mediumButton, 2, rowCount);
+            buttonGrid.add(majorButton, 3, rowCount);
             buttonGrid.add(severeButton, 4, rowCount);
-            buttonGrid.add(fatalButton, 5, rowCount);
+            buttonGrid.add(criticalButton, 5, rowCount);
             buttonGrid.add(resetButton, 6, rowCount);
 
             rowCount++;
@@ -607,7 +606,7 @@ public final class QualityControlViewPane extends BorderPane {
         for (final Pair<QualityCategory, String> rule : rules) {
             final String[] t = rule.getValue().split("§");
 
-            final String quality = rule.getKey() == QualityCategory.DEFAULT ? Bundle.MSG_NotApplicable() : "" + rule.getKey().name();
+            final String quality = rule.getKey().name();
             final String title = String.format("%s - %s", quality, t[0]);
 
             final Text content = new Text(t[1]);

--- a/CoreQualityControlView/src/au/gov/asd/tac/constellation/views/qualitycontrol/rules/QualityControlRule.java
+++ b/CoreQualityControlView/src/au/gov/asd/tac/constellation/views/qualitycontrol/rules/QualityControlRule.java
@@ -56,46 +56,55 @@ public abstract class QualityControlRule {
             return CATEGORIES_EQUAL;
         }
         // rule1 is never going to be higher than rule 2
-        if (category1 == QualityCategory.DEFAULT) {
+        if (category1 == QualityCategory.OK) {
             return CATEGORY_2_HIGHER;
         }
         // rule2 is never going to be higher than rule 1
-        if (category2 == QualityCategory.DEFAULT) {
+        if (category2 == QualityCategory.OK) {
+            return CATEGORY_1_HIGHER;
+        }
+
+        // rule1 is never going to be higher than rule 2
+        if (category1 == QualityCategory.MINOR) {
+            return CATEGORY_2_HIGHER;
+        }
+        // rule2 is never going to be higher than rule 1
+        if (category2 == QualityCategory.MINOR) {
             return CATEGORY_1_HIGHER;
         }
 
         // rule1 is always going to be higher than rule 2
-        if (category1 == QualityCategory.FATAL) {
+        if (category1 == QualityCategory.CRITICAL) {
             return CATEGORY_1_HIGHER;
         }
         // rule2 is always going to be higher than rule 1
-        if (category2 == QualityCategory.FATAL) {
+        if (category2 == QualityCategory.CRITICAL) {
             return CATEGORY_2_HIGHER;
         }
 
-        // rule1 is info, so rule 2 cannot be default, and is not info because
+        // rule1 is medium, so rule 2 cannot be minor, and is not medium because
         // it is not equal to rule 1.
-        if (category1 == QualityCategory.INFO) {
+        if (category1 == QualityCategory.MEDIUM) {
             return CATEGORY_2_HIGHER;
         }
-        // rule 1 is warning, so rule 2 could be info, severe or fatal
-        if (category1 == QualityCategory.WARNING) {
-            if (category2 == QualityCategory.INFO) {
+        // rule 1 is major, so rule 2 could be medium, severe or critical
+        if (category1 == QualityCategory.MAJOR) {
+            if (category2 == QualityCategory.MEDIUM) {
                 return CATEGORY_1_HIGHER;
             }
-            // if not info, then it is higher than warning
+            // if not info, then it is higher than major
             return CATEGORY_2_HIGHER;
         }
-        // if severe, rule2 could be info, warning, fatal
+        // if severe, rule2 could be medium, major, critical
         if (category1 == QualityCategory.SEVERE) {
-            // if rule2 is fatal, it is higher priority
-            if (category2 == QualityCategory.FATAL) {
+            // if rule2 is critical, it is higher priority
+            if (category2 == QualityCategory.CRITICAL) {
                 return CATEGORY_2_HIGHER;
             }
-            // if not fatal, must be lower.
+            // if not critical, must be lower.
             return CATEGORY_1_HIGHER;
         }
-        // default return false
+        // minor return false
         return CATEGORY_2_HIGHER;
     }
 
@@ -213,16 +222,18 @@ public abstract class QualityControlRule {
      * @return QualityCategory relating to the qualityScore given.
      */
     public static QualityCategory getCategoryByScore(final int qualityScore) {
-        if (qualityScore >= QualityControlEvent.FATAL_VALUE) {
-            return QualityCategory.FATAL;
+        if (qualityScore >= QualityControlEvent.CRITICAL_VALUE) {
+            return QualityCategory.CRITICAL;
         } else if (qualityScore >= QualityControlEvent.SEVERE_VALUE) {
             return QualityCategory.SEVERE;
-        } else if (qualityScore >= QualityControlEvent.WARNING_VALUE) {
-            return QualityCategory.WARNING;
-        } else if (qualityScore >= QualityControlEvent.INFO_VALUE) {
-            return QualityCategory.INFO;
+        } else if (qualityScore >= QualityControlEvent.MAJOR_VALUE) {
+            return QualityCategory.MAJOR;
+        } else if (qualityScore >= QualityControlEvent.MEDIUM_VALUE) {
+            return QualityCategory.MEDIUM;
+        } else if (qualityScore >= QualityControlEvent.MINOR_VALUE) {
+            return QualityCategory.MINOR;
         } else {
-            return QualityCategory.DEFAULT;
+            return QualityCategory.OK;
         }
     }
 

--- a/CoreQualityControlView/src/au/gov/asd/tac/constellation/views/qualitycontrol/widget/DefaultQualityControlAutoButton.java
+++ b/CoreQualityControlView/src/au/gov/asd/tac/constellation/views/qualitycontrol/widget/DefaultQualityControlAutoButton.java
@@ -82,12 +82,12 @@ public final class DefaultQualityControlAutoButton extends QualityControlAutoBut
         final String riskText;
         final String styleText;
         final String tooltipText;
-        if (event != null && event.getCategory() != QualityCategory.DEFAULT) {
+        if (event != null && event.getCategory() != QualityCategory.OK) {
             riskText = String.format(QUALITY_CONTROL_WIDGET_TEXT, String.valueOf(event.getCategory().name()));
             styleText = QualityControlViewPane.qualityStyle(event.getCategory(), 1);
             tooltipText = event.getReasons();
         } else {
-            riskText = String.format(QUALITY_CONTROL_WIDGET_TEXT, Bundle.MSG_NoRisk());
+            riskText = String.format(QUALITY_CONTROL_WIDGET_TEXT, String.valueOf(QualityCategory.OK.name()));
             styleText = DEFAULT_TEXT_STYLE;
             tooltipText = null;
         }

--- a/CoreQualityControlView/src/au/gov/asd/tac/constellation/views/qualitycontrol/widget/DefaultQualityControlAutoButton.java
+++ b/CoreQualityControlView/src/au/gov/asd/tac/constellation/views/qualitycontrol/widget/DefaultQualityControlAutoButton.java
@@ -41,7 +41,7 @@ import org.openide.windows.WindowManager;
 @NbBundle.Messages("MSG_NoRisk=N/A")
 public final class DefaultQualityControlAutoButton extends QualityControlAutoButton implements QualityControlListener {
 
-    protected static final String DEFAULT_TEXT_STYLE = "-fx-text-fill: rgb(0,0,0); -fx-background-color: rgb(255,255,255);";
+    protected static final String DEFAULT_TEXT_STYLE = "-fx-text-fill: rgb(0,0,0); -fx-background-color: rgb(0,200,0,);";
     protected static final String BUTTON_STYLE = "-fx-padding: 2 5 2 5;";
     public static final String QUERY_RISK_DEFAULT_STYLE = "-fx-text-fill: rgb(0,0,0); -fx-padding: 2 5 2 5;";
     public static final String QUALITY_CONTROL_WIDGET_TEXT = "Quality Category: %s";

--- a/CoreQualityControlView/test/unit/src/au/gov/asd/tac/constellation/views/qualitycontrol/QualityControlViewPaneNGTest.java
+++ b/CoreQualityControlView/test/unit/src/au/gov/asd/tac/constellation/views/qualitycontrol/QualityControlViewPaneNGTest.java
@@ -215,15 +215,15 @@ public class QualityControlViewPaneNGTest {
     public void testQualityStyle() {
         System.out.println("qualityStyle");
 
-        final String defaultStyle = QualityControlViewPane.qualityStyle(QualityCategory.DEFAULT);
+        final String defaultStyle = QualityControlViewPane.qualityStyle(QualityCategory.MINOR);
         assertEquals(defaultStyle, String.format("-fx-text-fill: rgb(0,0,0);-fx-background-color: rgba(%d,%d,255,%f);", 253, 253, 0.75f));       
-        final String infoStyle = QualityControlViewPane.qualityStyle(QualityCategory.INFO);
+        final String infoStyle = QualityControlViewPane.qualityStyle(QualityCategory.MEDIUM);
         assertEquals(infoStyle, String.format("-fx-text-fill: rgb(0,0,0);-fx-background-color: rgba(%d,%d,255,%f);", 179, 179, 0.75f));
-        final String warningStyle = QualityControlViewPane.qualityStyle(QualityCategory.WARNING);
+        final String warningStyle = QualityControlViewPane.qualityStyle(QualityCategory.MAJOR);
         assertEquals(warningStyle, String.format("-fx-text-fill: rgb(255,255,255);-fx-background-color: rgba(%d,%d,255,%f);", 102, 102, 0.75f));
         final String severeStyle = QualityControlViewPane.qualityStyle(QualityCategory.SEVERE);
         assertEquals(severeStyle, String.format("-fx-text-fill: rgb(0,0,0);-fx-background-color: rgba(255,%d,%d,%f);", 26, 26, 0.75f));
-        final String fatalStyle = QualityControlViewPane.qualityStyle(QualityCategory.FATAL);
+        final String fatalStyle = QualityControlViewPane.qualityStyle(QualityCategory.CRITICAL);
         assertEquals(fatalStyle, String.format("-fx-text-fill: rgb(255,255,255);-fx-background-color: rgba(0,%d,%d,%f);", 13, 13, 0.75f));
     }
 
@@ -245,9 +245,9 @@ public class QualityControlViewPaneNGTest {
         final MissingTypeRule mRule = new MissingTypeRule();
         final UnknownTypeRule uRule = new UnknownTypeRule();
         
-        assertEquals(result.get(iiRule), QualityCategory.INFO);
+        assertEquals(result.get(iiRule), QualityCategory.MEDIUM);
         assertEquals(result.get(mRule), QualityCategory.SEVERE);
-        assertEquals(result.get(uRule), QualityCategory.DEFAULT);
+        assertEquals(result.get(uRule), QualityCategory.MINOR);
     }
     
     /**

--- a/CoreQualityControlView/test/unit/src/au/gov/asd/tac/constellation/views/qualitycontrol/QualityControlViewPaneNGTest.java
+++ b/CoreQualityControlView/test/unit/src/au/gov/asd/tac/constellation/views/qualitycontrol/QualityControlViewPaneNGTest.java
@@ -215,16 +215,18 @@ public class QualityControlViewPaneNGTest {
     public void testQualityStyle() {
         System.out.println("qualityStyle");
 
-        final String defaultStyle = QualityControlViewPane.qualityStyle(QualityCategory.MINOR);
-        assertEquals(defaultStyle, String.format("-fx-text-fill: rgb(0,0,0);-fx-background-color: rgba(%d,%d,255,%f);", 253, 253, 0.75f));       
-        final String infoStyle = QualityControlViewPane.qualityStyle(QualityCategory.MEDIUM);
-        assertEquals(infoStyle, String.format("-fx-text-fill: rgb(0,0,0);-fx-background-color: rgba(%d,%d,255,%f);", 179, 179, 0.75f));
-        final String warningStyle = QualityControlViewPane.qualityStyle(QualityCategory.MAJOR);
-        assertEquals(warningStyle, String.format("-fx-text-fill: rgb(255,255,255);-fx-background-color: rgba(%d,%d,255,%f);", 102, 102, 0.75f));
+        final String okStyle = QualityControlViewPane.qualityStyle(QualityCategory.OK);
+        assertEquals(okStyle, String.format("-fx-text-fill: rgb(0,0,0);-fx-background-color: rgba(0,200,0,%f);", 0.75f));
+        final String minorStyle = QualityControlViewPane.qualityStyle(QualityCategory.MINOR);
+        assertEquals(minorStyle, String.format("-fx-text-fill: rgb(0,0,0);-fx-background-color: rgba(90,150,255,%f);", 0.75f));
+        final String mediumStyle = QualityControlViewPane.qualityStyle(QualityCategory.MEDIUM);
+        assertEquals(mediumStyle, String.format("-fx-text-fill: rgb(0,0,0);-fx-background-color: rgba(255,215,0,%f);", 0.75f));
+        final String majorStyle = QualityControlViewPane.qualityStyle(QualityCategory.MAJOR);
+        assertEquals(majorStyle, String.format("-fx-text-fill: rgb(255,255,255);-fx-background-color: rgba(255,%d,0,%f);", 102, 0.75f));
         final String severeStyle = QualityControlViewPane.qualityStyle(QualityCategory.SEVERE);
         assertEquals(severeStyle, String.format("-fx-text-fill: rgb(0,0,0);-fx-background-color: rgba(255,%d,%d,%f);", 26, 26, 0.75f));
-        final String fatalStyle = QualityControlViewPane.qualityStyle(QualityCategory.CRITICAL);
-        assertEquals(fatalStyle, String.format("-fx-text-fill: rgb(255,255,255);-fx-background-color: rgba(0,%d,%d,%f);", 13, 13, 0.75f));
+        final String criticalStyle = QualityControlViewPane.qualityStyle(QualityCategory.CRITICAL);
+        assertEquals(criticalStyle, String.format("-fx-text-fill: rgb(255,255,255);-fx-background-color: rgba(150,%d,%d,%f);", 13, 13, 0.75f));
     }
 
     /**

--- a/CoreQualityControlView/test/unit/src/au/gov/asd/tac/constellation/views/qualitycontrol/event/QualityControlEventNGTest.java
+++ b/CoreQualityControlView/test/unit/src/au/gov/asd/tac/constellation/views/qualitycontrol/event/QualityControlEventNGTest.java
@@ -32,11 +32,12 @@ import org.testng.annotations.Test;
  */
 public class QualityControlEventNGTest {
 
-    private final static QualityControlEvent.QualityCategory DEFAULT = QualityControlEvent.QualityCategory.MINOR;
-    private final static QualityControlEvent.QualityCategory INFO = QualityControlEvent.QualityCategory.MEDIUM;
-    private final static QualityControlEvent.QualityCategory WARNING = QualityControlEvent.QualityCategory.MAJOR;
+    private final static QualityControlEvent.QualityCategory OK = QualityControlEvent.QualityCategory.OK;
+    private final static QualityControlEvent.QualityCategory MINOR = QualityControlEvent.QualityCategory.MINOR;
+    private final static QualityControlEvent.QualityCategory MEDIUM = QualityControlEvent.QualityCategory.MEDIUM;
+    private final static QualityControlEvent.QualityCategory MAJOR = QualityControlEvent.QualityCategory.MAJOR;
     private final static QualityControlEvent.QualityCategory SEVERE = QualityControlEvent.QualityCategory.SEVERE;
-    private final static QualityControlEvent.QualityCategory FATAL = QualityControlEvent.QualityCategory.CRITICAL;
+    private final static QualityControlEvent.QualityCategory CRITICAL = QualityControlEvent.QualityCategory.CRITICAL;
 
     public QualityControlEventNGTest() {
     }
@@ -62,36 +63,46 @@ public class QualityControlEventNGTest {
      */
     @Test
     public void testGetCategoryFromString() {
-        String categoryString = "default";
+        String categoryString = "ok";
 
-        // DEFAULT test
-        assertEquals(QualityControlEvent.getCategoryFromString(categoryString), DEFAULT);
-        categoryString = "DEFAULT";
-        assertEquals(QualityControlEvent.getCategoryFromString(categoryString), DEFAULT);
-        categoryString = "DEFAULTA";
-        assertEquals(QualityControlEvent.getCategoryFromString(categoryString), DEFAULT);
-        categoryString = "ADEFAULT";
-        assertEquals(QualityControlEvent.getCategoryFromString(categoryString), DEFAULT);
+        // OK test
+        assertEquals(QualityControlEvent.getCategoryFromString(categoryString), OK);
+        categoryString = "OK";
+        assertEquals(QualityControlEvent.getCategoryFromString(categoryString), OK);
+        categoryString = "OKA";
+        assertEquals(QualityControlEvent.getCategoryFromString(categoryString), OK);
+        categoryString = "AOK";
+        assertEquals(QualityControlEvent.getCategoryFromString(categoryString), OK);
 
-        // INFO test
-        categoryString = "info";
-        assertEquals(QualityControlEvent.getCategoryFromString(categoryString), INFO);
-        categoryString = "INFO";
-        assertEquals(QualityControlEvent.getCategoryFromString(categoryString), INFO);
-        categoryString = "INFOA";
-        assertEquals(QualityControlEvent.getCategoryFromString(categoryString), DEFAULT);
-        categoryString = "AINFO";
-        assertEquals(QualityControlEvent.getCategoryFromString(categoryString), DEFAULT);
+        // MINOR test
+        categoryString = "minor";
+        assertEquals(QualityControlEvent.getCategoryFromString(categoryString), MINOR);
+        categoryString = "MINOR";
+        assertEquals(QualityControlEvent.getCategoryFromString(categoryString), MINOR);
+        categoryString = "MINORA";
+        assertEquals(QualityControlEvent.getCategoryFromString(categoryString), OK);
+        categoryString = "AMINOR";
+        assertEquals(QualityControlEvent.getCategoryFromString(categoryString), OK);
 
-        // WARNING test
-        categoryString = "warning";
-        assertEquals(QualityControlEvent.getCategoryFromString(categoryString), WARNING);
-        categoryString = "WARNING";
-        assertEquals(QualityControlEvent.getCategoryFromString(categoryString), WARNING);
-        categoryString = "WARNINGA";
-        assertEquals(QualityControlEvent.getCategoryFromString(categoryString), DEFAULT);
-        categoryString = "AWARNING";
-        assertEquals(QualityControlEvent.getCategoryFromString(categoryString), DEFAULT);
+        // MEDIUM test
+        categoryString = "medium";
+        assertEquals(QualityControlEvent.getCategoryFromString(categoryString), MEDIUM);
+        categoryString = "MEDIUM";
+        assertEquals(QualityControlEvent.getCategoryFromString(categoryString), MEDIUM);
+        categoryString = "MEDIUMA";
+        assertEquals(QualityControlEvent.getCategoryFromString(categoryString), OK);
+        categoryString = "AMEDIUM";
+        assertEquals(QualityControlEvent.getCategoryFromString(categoryString), OK);
+
+        // MAJOR test
+        categoryString = "major";
+        assertEquals(QualityControlEvent.getCategoryFromString(categoryString), MAJOR);
+        categoryString = "MAJOR";
+        assertEquals(QualityControlEvent.getCategoryFromString(categoryString), MAJOR);
+        categoryString = "MAJORA";
+        assertEquals(QualityControlEvent.getCategoryFromString(categoryString), OK);
+        categoryString = "AMAJOR";
+        assertEquals(QualityControlEvent.getCategoryFromString(categoryString), OK);
 
         // SEVERE test
         categoryString = "severe";
@@ -99,19 +110,19 @@ public class QualityControlEventNGTest {
         categoryString = "SEVERE";
         assertEquals(QualityControlEvent.getCategoryFromString(categoryString), SEVERE);
         categoryString = "SEVEREA";
-        assertEquals(QualityControlEvent.getCategoryFromString(categoryString), DEFAULT);
+        assertEquals(QualityControlEvent.getCategoryFromString(categoryString), OK);
         categoryString = "ASEVERE";
-        assertEquals(QualityControlEvent.getCategoryFromString(categoryString), DEFAULT);
+        assertEquals(QualityControlEvent.getCategoryFromString(categoryString), OK);
 
-        // FATAL test
-        categoryString = "fatal";
-        assertEquals(QualityControlEvent.getCategoryFromString(categoryString), FATAL);
-        categoryString = "FATAL";
-        assertEquals(QualityControlEvent.getCategoryFromString(categoryString), FATAL);
-        categoryString = "FATALA";
-        assertEquals(QualityControlEvent.getCategoryFromString(categoryString), DEFAULT);
-        categoryString = "AFATAL";
-        assertEquals(QualityControlEvent.getCategoryFromString(categoryString), DEFAULT);
+        // CRITICAL test
+        categoryString = "critical";
+        assertEquals(QualityControlEvent.getCategoryFromString(categoryString), CRITICAL);
+        categoryString = "CRITICAL";
+        assertEquals(QualityControlEvent.getCategoryFromString(categoryString), CRITICAL);
+        categoryString = "CRITICALA";
+        assertEquals(QualityControlEvent.getCategoryFromString(categoryString), OK);
+        categoryString = "ACRITICAL";
+        assertEquals(QualityControlEvent.getCategoryFromString(categoryString), OK);
     }
 
     /**

--- a/CoreQualityControlView/test/unit/src/au/gov/asd/tac/constellation/views/qualitycontrol/event/QualityControlEventNGTest.java
+++ b/CoreQualityControlView/test/unit/src/au/gov/asd/tac/constellation/views/qualitycontrol/event/QualityControlEventNGTest.java
@@ -32,11 +32,11 @@ import org.testng.annotations.Test;
  */
 public class QualityControlEventNGTest {
 
-    private final static QualityControlEvent.QualityCategory DEFAULT = QualityControlEvent.QualityCategory.DEFAULT;
-    private final static QualityControlEvent.QualityCategory INFO = QualityControlEvent.QualityCategory.INFO;
-    private final static QualityControlEvent.QualityCategory WARNING = QualityControlEvent.QualityCategory.WARNING;
+    private final static QualityControlEvent.QualityCategory DEFAULT = QualityControlEvent.QualityCategory.MINOR;
+    private final static QualityControlEvent.QualityCategory INFO = QualityControlEvent.QualityCategory.MEDIUM;
+    private final static QualityControlEvent.QualityCategory WARNING = QualityControlEvent.QualityCategory.MAJOR;
     private final static QualityControlEvent.QualityCategory SEVERE = QualityControlEvent.QualityCategory.SEVERE;
-    private final static QualityControlEvent.QualityCategory FATAL = QualityControlEvent.QualityCategory.FATAL;
+    private final static QualityControlEvent.QualityCategory FATAL = QualityControlEvent.QualityCategory.CRITICAL;
 
     public QualityControlEventNGTest() {
     }

--- a/CoreQualityControlView/test/unit/src/au/gov/asd/tac/constellation/views/qualitycontrol/rules/QualityControlRuleNGTest.java
+++ b/CoreQualityControlView/test/unit/src/au/gov/asd/tac/constellation/views/qualitycontrol/rules/QualityControlRuleNGTest.java
@@ -122,7 +122,7 @@ public class QualityControlRuleNGTest {
     @Test
     public void testGetCategoryByScore() {
         assertEquals(QualityControlRule.getCategoryByScore(QualityControlEvent.MINOR_VALUE - 1),
-                QualityControlEvent.QualityCategory.MINOR); // ONE BELOW
+                QualityControlEvent.QualityCategory.OK); // ONE BELOW
         assertEquals(QualityControlRule.getCategoryByScore(QualityControlEvent.MINOR_VALUE),
                 QualityControlEvent.QualityCategory.MINOR); // ON VALUE
         assertEquals(QualityControlRule.getCategoryByScore(QualityControlEvent.MINOR_VALUE + 1),

--- a/CoreQualityControlView/test/unit/src/au/gov/asd/tac/constellation/views/qualitycontrol/rules/QualityControlRuleNGTest.java
+++ b/CoreQualityControlView/test/unit/src/au/gov/asd/tac/constellation/views/qualitycontrol/rules/QualityControlRuleNGTest.java
@@ -59,60 +59,60 @@ public class QualityControlRuleNGTest {
         final int cat2Higher = 1;
 
         // Test categories are equal
-        assertEquals(QualityControlRule.testPriority(QualityControlEvent.QualityCategory.FATAL,
-                QualityControlEvent.QualityCategory.FATAL), catEqual);
+        assertEquals(QualityControlRule.testPriority(QualityControlEvent.QualityCategory.CRITICAL,
+                QualityControlEvent.QualityCategory.CRITICAL), catEqual);
         assertEquals(QualityControlRule.testPriority(QualityControlEvent.QualityCategory.SEVERE,
                 QualityControlEvent.QualityCategory.SEVERE), catEqual);
-        assertEquals(QualityControlRule.testPriority(QualityControlEvent.QualityCategory.WARNING,
-                QualityControlEvent.QualityCategory.WARNING), catEqual);
-        assertEquals(QualityControlRule.testPriority(QualityControlEvent.QualityCategory.INFO,
-                QualityControlEvent.QualityCategory.INFO), catEqual);
-        assertEquals(QualityControlRule.testPriority(QualityControlEvent.QualityCategory.DEFAULT,
-                QualityControlEvent.QualityCategory.DEFAULT), catEqual);
+        assertEquals(QualityControlRule.testPriority(QualityControlEvent.QualityCategory.MAJOR,
+                QualityControlEvent.QualityCategory.MAJOR), catEqual);
+        assertEquals(QualityControlRule.testPriority(QualityControlEvent.QualityCategory.MEDIUM,
+                QualityControlEvent.QualityCategory.MEDIUM), catEqual);
+        assertEquals(QualityControlRule.testPriority(QualityControlEvent.QualityCategory.MINOR,
+                QualityControlEvent.QualityCategory.MINOR), catEqual);
 
         // Test category 1 is higher
-        assertEquals(QualityControlRule.testPriority(QualityControlEvent.QualityCategory.FATAL,
+        assertEquals(QualityControlRule.testPriority(QualityControlEvent.QualityCategory.CRITICAL,
                 QualityControlEvent.QualityCategory.SEVERE), cat1Higher);
         assertEquals(QualityControlRule.testPriority(QualityControlEvent.QualityCategory.SEVERE,
-                QualityControlEvent.QualityCategory.WARNING), cat1Higher);
-        assertEquals(QualityControlRule.testPriority(QualityControlEvent.QualityCategory.WARNING,
-                QualityControlEvent.QualityCategory.INFO), cat1Higher);
-        assertEquals(QualityControlRule.testPriority(QualityControlEvent.QualityCategory.INFO,
-                QualityControlEvent.QualityCategory.DEFAULT), cat1Higher);
-        assertEquals(QualityControlRule.testPriority(QualityControlEvent.QualityCategory.FATAL,
-                QualityControlEvent.QualityCategory.WARNING), cat1Higher);
+                QualityControlEvent.QualityCategory.MAJOR), cat1Higher);
+        assertEquals(QualityControlRule.testPriority(QualityControlEvent.QualityCategory.MAJOR,
+                QualityControlEvent.QualityCategory.MEDIUM), cat1Higher);
+        assertEquals(QualityControlRule.testPriority(QualityControlEvent.QualityCategory.MEDIUM,
+                QualityControlEvent.QualityCategory.MINOR), cat1Higher);
+        assertEquals(QualityControlRule.testPriority(QualityControlEvent.QualityCategory.CRITICAL,
+                QualityControlEvent.QualityCategory.MAJOR), cat1Higher);
         assertEquals(QualityControlRule.testPriority(QualityControlEvent.QualityCategory.SEVERE,
-                QualityControlEvent.QualityCategory.INFO), cat1Higher);
-        assertEquals(QualityControlRule.testPriority(QualityControlEvent.QualityCategory.WARNING,
-                QualityControlEvent.QualityCategory.DEFAULT), cat1Higher);
-        assertEquals(QualityControlRule.testPriority(QualityControlEvent.QualityCategory.FATAL,
-                QualityControlEvent.QualityCategory.INFO), cat1Higher);
+                QualityControlEvent.QualityCategory.MEDIUM), cat1Higher);
+        assertEquals(QualityControlRule.testPriority(QualityControlEvent.QualityCategory.MAJOR,
+                QualityControlEvent.QualityCategory.MINOR), cat1Higher);
+        assertEquals(QualityControlRule.testPriority(QualityControlEvent.QualityCategory.CRITICAL,
+                QualityControlEvent.QualityCategory.MEDIUM), cat1Higher);
         assertEquals(QualityControlRule.testPriority(QualityControlEvent.QualityCategory.SEVERE,
-                QualityControlEvent.QualityCategory.DEFAULT), cat1Higher);
-        assertEquals(QualityControlRule.testPriority(QualityControlEvent.QualityCategory.FATAL,
-                QualityControlEvent.QualityCategory.DEFAULT), cat1Higher);
+                QualityControlEvent.QualityCategory.MINOR), cat1Higher);
+        assertEquals(QualityControlRule.testPriority(QualityControlEvent.QualityCategory.CRITICAL,
+                QualityControlEvent.QualityCategory.MINOR), cat1Higher);
 
         // Test category 2 is higher
         assertEquals(QualityControlRule.testPriority(QualityControlEvent.QualityCategory.SEVERE,
-                QualityControlEvent.QualityCategory.FATAL), cat2Higher);
-        assertEquals(QualityControlRule.testPriority(QualityControlEvent.QualityCategory.WARNING,
+                QualityControlEvent.QualityCategory.CRITICAL), cat2Higher);
+        assertEquals(QualityControlRule.testPriority(QualityControlEvent.QualityCategory.MAJOR,
                 QualityControlEvent.QualityCategory.SEVERE), cat2Higher);
-        assertEquals(QualityControlRule.testPriority(QualityControlEvent.QualityCategory.INFO,
-                QualityControlEvent.QualityCategory.WARNING), cat2Higher);
-        assertEquals(QualityControlRule.testPriority(QualityControlEvent.QualityCategory.DEFAULT,
-                QualityControlEvent.QualityCategory.INFO), cat2Higher);
-        assertEquals(QualityControlRule.testPriority(QualityControlEvent.QualityCategory.WARNING,
-                QualityControlEvent.QualityCategory.FATAL), cat2Higher);
-        assertEquals(QualityControlRule.testPriority(QualityControlEvent.QualityCategory.INFO,
+        assertEquals(QualityControlRule.testPriority(QualityControlEvent.QualityCategory.MEDIUM,
+                QualityControlEvent.QualityCategory.MAJOR), cat2Higher);
+        assertEquals(QualityControlRule.testPriority(QualityControlEvent.QualityCategory.MINOR,
+                QualityControlEvent.QualityCategory.MEDIUM), cat2Higher);
+        assertEquals(QualityControlRule.testPriority(QualityControlEvent.QualityCategory.MAJOR,
+                QualityControlEvent.QualityCategory.CRITICAL), cat2Higher);
+        assertEquals(QualityControlRule.testPriority(QualityControlEvent.QualityCategory.MEDIUM,
                 QualityControlEvent.QualityCategory.SEVERE), cat2Higher);
-        assertEquals(QualityControlRule.testPriority(QualityControlEvent.QualityCategory.DEFAULT,
-                QualityControlEvent.QualityCategory.WARNING), cat2Higher);
-        assertEquals(QualityControlRule.testPriority(QualityControlEvent.QualityCategory.INFO,
-                QualityControlEvent.QualityCategory.FATAL), cat2Higher);
-        assertEquals(QualityControlRule.testPriority(QualityControlEvent.QualityCategory.DEFAULT,
+        assertEquals(QualityControlRule.testPriority(QualityControlEvent.QualityCategory.MINOR,
+                QualityControlEvent.QualityCategory.MAJOR), cat2Higher);
+        assertEquals(QualityControlRule.testPriority(QualityControlEvent.QualityCategory.MEDIUM,
+                QualityControlEvent.QualityCategory.CRITICAL), cat2Higher);
+        assertEquals(QualityControlRule.testPriority(QualityControlEvent.QualityCategory.MINOR,
                 QualityControlEvent.QualityCategory.SEVERE), cat2Higher);
-        assertEquals(QualityControlRule.testPriority(QualityControlEvent.QualityCategory.DEFAULT,
-                QualityControlEvent.QualityCategory.FATAL), cat2Higher);
+        assertEquals(QualityControlRule.testPriority(QualityControlEvent.QualityCategory.MINOR,
+                QualityControlEvent.QualityCategory.CRITICAL), cat2Higher);
     }
 
     /**
@@ -121,39 +121,39 @@ public class QualityControlRuleNGTest {
      */
     @Test
     public void testGetCategoryByScore() {
-        assertEquals(QualityControlRule.getCategoryByScore(QualityControlEvent.DEFAULT_VALUE - 1),
-                QualityControlEvent.QualityCategory.DEFAULT); // ONE BELOW
-        assertEquals(QualityControlRule.getCategoryByScore(QualityControlEvent.DEFAULT_VALUE),
-                QualityControlEvent.QualityCategory.DEFAULT); // ON VALUE
-        assertEquals(QualityControlRule.getCategoryByScore(QualityControlEvent.DEFAULT_VALUE + 1),
-                QualityControlEvent.QualityCategory.DEFAULT); // ONE ABOVE
+        assertEquals(QualityControlRule.getCategoryByScore(QualityControlEvent.MINOR_VALUE - 1),
+                QualityControlEvent.QualityCategory.MINOR); // ONE BELOW
+        assertEquals(QualityControlRule.getCategoryByScore(QualityControlEvent.MINOR_VALUE),
+                QualityControlEvent.QualityCategory.MINOR); // ON VALUE
+        assertEquals(QualityControlRule.getCategoryByScore(QualityControlEvent.MINOR_VALUE + 1),
+                QualityControlEvent.QualityCategory.MINOR); // ONE ABOVE
 
-        assertEquals(QualityControlRule.getCategoryByScore(QualityControlEvent.INFO_VALUE - 1),
-                QualityControlEvent.QualityCategory.DEFAULT); // ONE BELOW
-        assertEquals(QualityControlRule.getCategoryByScore(QualityControlEvent.INFO_VALUE),
-                QualityControlEvent.QualityCategory.INFO); // ON VALUE
-        assertEquals(QualityControlRule.getCategoryByScore(QualityControlEvent.INFO_VALUE + 1),
-                QualityControlEvent.QualityCategory.INFO); // ONE ABOVE
+        assertEquals(QualityControlRule.getCategoryByScore(QualityControlEvent.MEDIUM_VALUE - 1),
+                QualityControlEvent.QualityCategory.MINOR); // ONE BELOW
+        assertEquals(QualityControlRule.getCategoryByScore(QualityControlEvent.MEDIUM_VALUE),
+                QualityControlEvent.QualityCategory.MEDIUM); // ON VALUE
+        assertEquals(QualityControlRule.getCategoryByScore(QualityControlEvent.MEDIUM_VALUE + 1),
+                QualityControlEvent.QualityCategory.MEDIUM); // ONE ABOVE
 
-        assertEquals(QualityControlRule.getCategoryByScore(QualityControlEvent.WARNING_VALUE - 1),
-                QualityControlEvent.QualityCategory.INFO); // ONE BELOW
-        assertEquals(QualityControlRule.getCategoryByScore(QualityControlEvent.WARNING_VALUE),
-                QualityControlEvent.QualityCategory.WARNING); // ON VALUE
-        assertEquals(QualityControlRule.getCategoryByScore(QualityControlEvent.WARNING_VALUE + 1),
-                QualityControlEvent.QualityCategory.WARNING); // ONE ABOVE
+        assertEquals(QualityControlRule.getCategoryByScore(QualityControlEvent.MAJOR_VALUE - 1),
+                QualityControlEvent.QualityCategory.MEDIUM); // ONE BELOW
+        assertEquals(QualityControlRule.getCategoryByScore(QualityControlEvent.MAJOR_VALUE),
+                QualityControlEvent.QualityCategory.MAJOR); // ON VALUE
+        assertEquals(QualityControlRule.getCategoryByScore(QualityControlEvent.MAJOR_VALUE + 1),
+                QualityControlEvent.QualityCategory.MAJOR); // ONE ABOVE
 
         assertEquals(QualityControlRule.getCategoryByScore(QualityControlEvent.SEVERE_VALUE - 1),
-                QualityControlEvent.QualityCategory.WARNING); // ONE BELOW
+                QualityControlEvent.QualityCategory.MAJOR); // ONE BELOW
         assertEquals(QualityControlRule.getCategoryByScore(QualityControlEvent.SEVERE_VALUE),
                 QualityControlEvent.QualityCategory.SEVERE); // ON VALUE
         assertEquals(QualityControlRule.getCategoryByScore(QualityControlEvent.SEVERE_VALUE + 1),
                 QualityControlEvent.QualityCategory.SEVERE); // ONE ABOVE
 
-        assertEquals(QualityControlRule.getCategoryByScore(QualityControlEvent.FATAL_VALUE - 1),
+        assertEquals(QualityControlRule.getCategoryByScore(QualityControlEvent.CRITICAL_VALUE - 1),
                 QualityControlEvent.QualityCategory.SEVERE); // ONE BELOW
-        assertEquals(QualityControlRule.getCategoryByScore(QualityControlEvent.FATAL_VALUE),
-                QualityControlEvent.QualityCategory.FATAL); // ON VALUE
-        assertEquals(QualityControlRule.getCategoryByScore(QualityControlEvent.FATAL_VALUE + 1),
-                QualityControlEvent.QualityCategory.FATAL); // ONE ABOVE
+        assertEquals(QualityControlRule.getCategoryByScore(QualityControlEvent.CRITICAL_VALUE),
+                QualityControlEvent.QualityCategory.CRITICAL); // ON VALUE
+        assertEquals(QualityControlRule.getCategoryByScore(QualityControlEvent.CRITICAL_VALUE + 1),
+                QualityControlEvent.QualityCategory.CRITICAL); // ONE ABOVE
     }
 }

--- a/CoreQualityControlView/test/unit/src/au/gov/asd/tac/constellation/views/qualitycontrol/widget/DefaultQualityControlAutoButtonNGTest.java
+++ b/CoreQualityControlView/test/unit/src/au/gov/asd/tac/constellation/views/qualitycontrol/widget/DefaultQualityControlAutoButtonNGTest.java
@@ -88,10 +88,9 @@ public class DefaultQualityControlAutoButtonNGTest {
             new JFXPanel();
             DefaultQualityControlAutoButton instance = new DefaultQualityControlAutoButton();
 
-            String expRiskText = String.format(instance.QUALITY_CONTROL_WIDGET_TEXT, Bundle.MSG_NoRisk());
+            String expRiskText = "Quality Category: " + QualityCategory.OK.name();
             String expStyleText = instance.DEFAULT_TEXT_STYLE + instance.BUTTON_STYLE;
             String expTooltipText = null;
-
             instance.qualityControlChanged(null);
 
             String resultRiskText = instance.getText();
@@ -118,7 +117,7 @@ public class DefaultQualityControlAutoButtonNGTest {
             DefaultQualityControlAutoButton instance = new DefaultQualityControlAutoButton();
 
             final String expRiskText = "Quality Category: CRITICAL";
-            final String expStyleText = "-fx-text-fill: rgb(255,255,255);-fx-background-color: rgba(0,13,13,1.000000);" + instance.BUTTON_STYLE;
+            final String expStyleText = "-fx-text-fill: rgb(255,255,255);-fx-background-color: rgba(150,13,13,1.000000);" + instance.BUTTON_STYLE;
             final String expTooltipText = "Reason 1, Reason2";
 
             instance.qualityControlChanged(state);

--- a/CoreQualityControlView/test/unit/src/au/gov/asd/tac/constellation/views/qualitycontrol/widget/DefaultQualityControlAutoButtonNGTest.java
+++ b/CoreQualityControlView/test/unit/src/au/gov/asd/tac/constellation/views/qualitycontrol/widget/DefaultQualityControlAutoButtonNGTest.java
@@ -66,7 +66,7 @@ public class DefaultQualityControlAutoButtonNGTest {
 
         //mock QualityControlEvent
         qualityControlEvent = mock(QualityControlEvent.class);
-        when(qualityControlEvent.getCategory()).thenReturn(QualityCategory.FATAL);
+        when(qualityControlEvent.getCategory()).thenReturn(QualityCategory.CRITICAL);
         when(qualityControlEvent.getReasons()).thenReturn("Reason 1, Reason2");
 
         events.add(qualityControlEvent);
@@ -117,7 +117,7 @@ public class DefaultQualityControlAutoButtonNGTest {
             new JFXPanel();
             DefaultQualityControlAutoButton instance = new DefaultQualityControlAutoButton();
 
-            final String expRiskText = "Quality Category: FATAL";
+            final String expRiskText = "Quality Category: CRITICAL";
             final String expStyleText = "-fx-text-fill: rgb(255,255,255);-fx-background-color: rgba(0,13,13,1.000000);" + instance.BUTTON_STYLE;
             final String expTooltipText = "Reason 1, Reason2";
 

--- a/CoreWhatsNewView/src/au/gov/asd/tac/constellation/views/whatsnew/whatsnew.txt
+++ b/CoreWhatsNewView/src/au/gov/asd/tac/constellation/views/whatsnew/whatsnew.txt
@@ -1,6 +1,10 @@
 == 3030-12-31 Getting Started
 <p>If you're new to Constellation, read the <a href="" helpId="au.gov.asd.tac.constellation.functionality.introduction">introduction</a>.</p>
 
+== 2021-07-26 Quality Control Category Changes
+<p>Quality Control category names and colours have been updated to match commonly seen category names and colours. The category names are now Minor, Medium, Major, Severe and Critical.</p>
+<p>A new category OK has been added for when a Quality Control rule has not been flagged.<p> 
+
 == 2021-07-15 Notes View Selection
 <p>User Notes now have the option to include nodes and transactions on the graph that are selected when the note is created. If no elements are selected, the note will be applied to the whole graph.</p>
 <p>To view what graph elements are applied to the note, a right click context menu has been added to user notes with the option to select on graph which will highlight the relevant nodes and transactions, or the whole graph.</p>


### PR DESCRIPTION
<!--

### Requirements

* Filling out the template is required. Any pull request that does not include
enough information to be reviewed in a timely manner may be closed at the
maintainers' discretion.
* Follow the check list items defined by https://github.com/constellation-app/constellation/blob/master/CONTRIBUTING.md#pull-requests
* All new code requires unit tests to ensure they work as expected and will
continue to work as new code is added in the future (regression testing).
* Make sure your branch name is prefixed by `feature`, `bugfix`, `hotfix` or `release`
* Have you read Constellation's Code of Conduct? By filing an issue, you are
expected to comply with it, including treating everyone with respect:
https://github.com/constellation-app/constellation/blob/master/CODE_OF_CONDUCT.md

-->

### Description of the Change
Updated the names of most of the Quality Control Categories and some of the colours to be more visible and less confusing. 
The category names have been changed from Default, Info, Warning, Severe and Fatal, which could be confusing, to Minor, Medium, Major, Severe and Critical. A category called OK has been added for when no Quality Control rules have been flagged. 
<!--

We must be able to understand the design of your change from this description.
If we can't get a good idea of what the code will be doing from the description
here, the pull request may be closed at the maintainers' discretion. Keep in
mind that the maintainer reviewing this PR may not be familiar with or have
worked with the code here recently, so please walk us through the concepts.

-->

### Alternate Designs
None realised.
<!--

Explain what other alternates were considered and why the proposed version was
selected.

-->

### Why Should This Be In Core?
Updates the Quality Control categories to be less confusing for users by providing more meaningful category names. The colours are now also more meaningful by being colours that are more representative of the category names (e.g. OK is Green, Minor is Blue, Medium is Yellow, Major is Orange, Severe is Red and Critical is Dark Red).
<!--

Explain why this functionality should be in Constellation Core as opposed to a
different module suite. Note that this question is more applicable when adding
new functionality. If this change is a minor update to an existing file then it
is understood that this change has to be to this module suite and a response
and therefore a response to this question is not required.

-->

### Benefits
Makes the Quality Control view less confusing for users. 
<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks
None realised.
<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process
Tested that all of the new category names and colours appear correctly, see images below.
<!--

What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (e.g. buttons you clicked, text you typed,
commands you ran, etc.), and describe the results you observed.

-->

### Applicable Issues
#1136 
<!-- Link any applicable issues here -->

![OK](https://user-images.githubusercontent.com/73083035/126738060-52d91a68-bd31-4cd6-85be-65453ff4ecca.PNG)
![Minor](https://user-images.githubusercontent.com/73083035/126738068-df0bee0f-419b-4331-a786-b4418ffb2fdd.PNG)
![Medium](https://user-images.githubusercontent.com/73083035/126738070-c0a1aeac-837d-4c15-af54-7cadaf9180bc.PNG)
![Major](https://user-images.githubusercontent.com/73083035/126738072-99995e72-7f31-47ed-b337-a1fd8bb8565a.PNG)
![Severe](https://user-images.githubusercontent.com/73083035/126738075-f9de79c8-857a-408c-b486-af7d22026e84.PNG)
![Critical](https://user-images.githubusercontent.com/73083035/126738078-e3081e19-c608-49db-bf23-e605058e8502.PNG)
