### PR TITLE
Headless Build

### DIFF
--- a/.github/workflows/build-and-scan.yml
+++ b/.github/workflows/build-and-scan.yml
@@ -14,7 +14,7 @@ jobs:
     name: Unit Tests
     runs-on: ubuntu-latest
     env:
-      RUNNER_IMAGE: "constellationapplication/netbeans-runner:12"
+      RUNNER_IMAGE: "constellationapplication/netbeans-runner:12.0.2"
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
       TRAVIS_REPO_SLUG: "${{ github.repository }}"

--- a/.githubutilities/run-tests.sh
+++ b/.githubutilities/run-tests.sh
@@ -18,7 +18,7 @@ ant \
   -Dnbplatform.active.dir="${NETBEANS_HOME}" \
   -Dnbplatform.default.netbeans.dest.dir="${NETBEANS_HOME}" \
   -Dnbplatform.default.harness.dir="${NETBEANS_HOME}"/harness \
-  -Dtest.run.args=-javaagent:"${JACOCO_AGENT}" -Djava.awt.headless=true -Dtestfx.robot=glass -Dtestfx.headless=true -Dprism.order=sw -Dprism.text=t2k test
+  -Dtest.run.args='-javaagent:"${JACOCO_AGENT}" -Djava.awt.headless=true -Dtestfx.robot=glass -Dtestfx.headless=true -Dprism.order=sw -Dprism.text=t2k' test
 
 title "Run Jacoco Processing"
 

--- a/.githubutilities/run-tests.sh
+++ b/.githubutilities/run-tests.sh
@@ -18,7 +18,7 @@ ant \
   -Dnbplatform.active.dir="${NETBEANS_HOME}" \
   -Dnbplatform.default.netbeans.dest.dir="${NETBEANS_HOME}" \
   -Dnbplatform.default.harness.dir="${NETBEANS_HOME}"/harness \
-  -Dtest.run.args='-javaagent:"${JACOCO_AGENT}" -Djava.awt.headless=true -Dtestfx.robot=glass -Dtestfx.headless=true -Dprism.order=sw -Dprism.text=t2k' test
+  -Dtest.run.args="-javaagent:${JACOCO_AGENT} -Djava.awt.headless=true -Dtestfx.robot=glass -Dtestfx.headless=true -Dprism.order=sw -Dprism.text=t2k" test
 
 title "Run Jacoco Processing"
 

--- a/.githubutilities/run-tests.sh
+++ b/.githubutilities/run-tests.sh
@@ -18,7 +18,7 @@ ant \
   -Dnbplatform.active.dir="${NETBEANS_HOME}" \
   -Dnbplatform.default.netbeans.dest.dir="${NETBEANS_HOME}" \
   -Dnbplatform.default.harness.dir="${NETBEANS_HOME}"/harness \
-  -Dtest.run.args=-javaagent:"${JACOCO_AGENT}" test
+  -Dtest.run.args=-javaagent:"${JACOCO_AGENT}" -Djava.awt.headless=true -Dtestfx.robot=glass -Dtestfx.headless=true -Dprism.order=sw -Dprism.text=t2k test
 
 title "Run Jacoco Processing"
 

--- a/CoreDependencies/nbproject/project.xml
+++ b/CoreDependencies/nbproject/project.xml
@@ -226,6 +226,7 @@
                 <package>com.microsoft.schemas.vml.impl</package>
                 <package>com.sun.activation.registries</package>
                 <package>com.sun.activation.viewers</package>
+                <package>com.sun.glass.ui.monocle</package>
                 <package>com.sun.istack</package>
                 <package>com.sun.istack.localization</package>
                 <package>com.sun.istack.logging</package>
@@ -3054,6 +3055,29 @@
                 <package>org.sqlite.jdbc3</package>
                 <package>org.sqlite.jdbc4</package>
                 <package>org.sqlite.util</package>
+                <package>org.testfx.api</package>
+                <package>org.testfx.assertions.api</package>
+                <package>org.testfx.assertions.impl</package>
+                <package>org.testfx.internal</package>
+                <package>org.testfx.matcher.base</package>
+                <package>org.testfx.matcher.control</package>
+                <package>org.testfx.osgi</package>
+                <package>org.testfx.osgi.service</package>
+                <package>org.testfx.robot</package>
+                <package>org.testfx.robot.impl</package>
+                <package>org.testfx.service.adapter</package>
+                <package>org.testfx.service.adapter.impl</package>
+                <package>org.testfx.service.finder</package>
+                <package>org.testfx.service.finder.impl</package>
+                <package>org.testfx.service.locator</package>
+                <package>org.testfx.service.locator.impl</package>
+                <package>org.testfx.service.query</package>
+                <package>org.testfx.service.query.impl</package>
+                <package>org.testfx.service.support</package>
+                <package>org.testfx.service.support.impl</package>
+                <package>org.testfx.toolkit</package>
+                <package>org.testfx.toolkit.impl</package>
+                <package>org.testfx.util</package>
                 <package>org.w3.x2000.x09.xmldsig</package>
                 <package>org.w3.x2000.x09.xmldsig.impl</package>
                 <package>org.w3.xlink</package>
@@ -3892,6 +3916,10 @@
                 <binary-origin>release/modules/ext/objenesis-3.2.jar</binary-origin>
             </class-path-extension>
             <class-path-extension>
+                <runtime-relative-path>ext/openjfx-monocle-jdk-11+26.jar</runtime-relative-path>
+                <binary-origin>release/modules/ext/openjfx-monocle-jdk-11+26.jar</binary-origin>
+            </class-path-extension>
+            <class-path-extension>
                 <runtime-relative-path>ext/org.eclipse.emf.common-2.15.0.jar</runtime-relative-path>
                 <binary-origin>release/modules/ext/org.eclipse.emf.common-2.15.0.jar</binary-origin>
             </class-path-extension>
@@ -3982,6 +4010,10 @@
             <class-path-extension>
                 <runtime-relative-path>ext/systems-common-2.0.1.jar</runtime-relative-path>
                 <binary-origin>release/modules/ext/systems-common-2.0.1.jar</binary-origin>
+            </class-path-extension>
+            <class-path-extension>
+                <runtime-relative-path>ext/testfx-core-4.0.16-alpha.jar</runtime-relative-path>
+                <binary-origin>release/modules/ext/testfx-core-4.0.16-alpha.jar</binary-origin>
             </class-path-extension>
             <class-path-extension>
                 <runtime-relative-path>ext/txw2-2.4.0-b180830.0438.jar</runtime-relative-path>

--- a/CoreDependencies/src/ivy.xml
+++ b/CoreDependencies/src/ivy.xml
@@ -81,7 +81,11 @@
         <dependency org="org.python" name="jython-standalone" rev="2.7.2"/>
         <dependency org="org.swinglabs" name="swingx" rev="1.6.1"/>
         <dependency org="org.fxmisc.richtext" name="richtextfx" rev="0.10.6"/>
+        
+        <!-- Testing -->
         <dependency org="nl.jqno.equalsverifier" name="equalsverifier" rev="3.7"/>
+        <dependency org="org.testfx" name="openjfx-monocle" rev="jdk-11+26" transitive="false" />
+        <dependency org="org.testfx" name="testfx-core" rev="4.0.16-alpha" />
         
         <!-- Downloaded Manually -->
         <!--<dependency org="unfolding" name="unfolding" rev="0.9.6"/>-->

--- a/CoreTableView/test/unit/src/au/gov/asd/tac/constellation/views/tableview2/ShowInTableViewContextMenuProviderNGTest.java
+++ b/CoreTableView/test/unit/src/au/gov/asd/tac/constellation/views/tableview2/ShowInTableViewContextMenuProviderNGTest.java
@@ -45,8 +45,8 @@ public class ShowInTableViewContextMenuProviderNGTest {
     @Test
     public void getItems() {
         final ShowInTableViewContextMenuProvider provider = new ShowInTableViewContextMenuProvider();
-        assertEquals(provider.getItems(null, GraphElementType.VERTEX, -1), List.of("Show in New Table View"));
-        assertEquals(provider.getItems(null, GraphElementType.TRANSACTION, -1), List.of("Show in New Table View"));
+        assertEquals(provider.getItems(null, GraphElementType.VERTEX, -1), List.of("Show in Table View"));
+        assertEquals(provider.getItems(null, GraphElementType.TRANSACTION, -1), List.of("Show in Table View"));
         assertTrue(provider.getItems(null, GraphElementType.META, -1).isEmpty());
     }
 

--- a/CoreTableView/test/unit/src/au/gov/asd/tac/constellation/views/tableview2/io/TableViewPreferencesIOUtilitiesNGTest.java
+++ b/CoreTableView/test/unit/src/au/gov/asd/tac/constellation/views/tableview2/io/TableViewPreferencesIOUtilitiesNGTest.java
@@ -41,6 +41,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import org.openide.util.NbPreferences;
 import static org.testng.AssertJUnit.assertEquals;
+import org.testfx.api.FxToolkit;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeClass;
@@ -62,6 +63,9 @@ public class TableViewPreferencesIOUtilitiesNGTest {
 
     @BeforeClass
     public static void setUpClass() throws Exception {
+        FxToolkit.registerPrimaryStage();
+        FxToolkit.showStage();
+
         jsonIOStaticMock = Mockito.mockStatic(JsonIO.class);
         nbPreferencesStaticMock = Mockito.mockStatic(NbPreferences.class);
         applicationPrefKeysStaticMock = Mockito.mockStatic(ApplicationPreferenceKeys.class);
@@ -69,6 +73,7 @@ public class TableViewPreferencesIOUtilitiesNGTest {
 
     @AfterClass
     public static void tearDownClass() throws Exception {
+        FxToolkit.hideStage();
         jsonIOStaticMock.close();
         nbPreferencesStaticMock.close();
         applicationPrefKeysStaticMock.close();
@@ -148,67 +153,58 @@ public class TableViewPreferencesIOUtilitiesNGTest {
 
     @Test
     public void savePreferences() throws IOException {
-        // TODO Find a better solution for this. Because of this limitation these tests
-        //      will not be run on the CI server.
-        if (!GraphicsEnvironment.isHeadless()) {
-            // Interestingly once you throw the skip exception it doesn't call the tear down class
-            // so we need to instantiate the static mocks only once we know we will be running the
-            // tests.
-            new JFXPanel();
+        nbPreferencesStaticMock.when(() -> NbPreferences.forModule(ApplicationPreferenceKeys.class))
+                .thenReturn(null);
+        applicationPrefKeysStaticMock.when(() -> ApplicationPreferenceKeys.getUserDir(null))
+                .thenReturn(System.getProperty("java.io.tmpdir"));
 
-            nbPreferencesStaticMock.when(() -> NbPreferences.forModule(ApplicationPreferenceKeys.class))
-                    .thenReturn(null);
-            applicationPrefKeysStaticMock.when(() -> ApplicationPreferenceKeys.getUserDir(null))
-                    .thenReturn(System.getProperty("java.io.tmpdir"));
+        final ObservableList<TableColumn<ObservableList<String>, ? extends Object>> columns = mock(ObservableList.class);
+        when(columns.size()).thenReturn(4);
 
-            final ObservableList<TableColumn<ObservableList<String>, ? extends Object>> columns = mock(ObservableList.class);
-            when(columns.size()).thenReturn(4);
+        final ObservableList<TableColumn<ObservableList<String>, ? extends Object>> sortOrder = mock(ObservableList.class);
+        when(sortOrder.isEmpty()).thenReturn(Boolean.FALSE);
 
-            final ObservableList<TableColumn<ObservableList<String>, ? extends Object>> sortOrder = mock(ObservableList.class);
-            when(sortOrder.isEmpty()).thenReturn(Boolean.FALSE);
+        final TableColumn<ObservableList<String>, ? extends Object> column1 = mock(TableColumn.class);
+        final TableColumn<ObservableList<String>, ? extends Object> column2 = mock(TableColumn.class);
+        final TableColumn<ObservableList<String>, ? extends Object> column3 = mock(TableColumn.class);
+        final TableColumn<ObservableList<String>, ? extends Object> column4 = mock(TableColumn.class);
 
-            final TableColumn<ObservableList<String>, ? extends Object> column1 = mock(TableColumn.class);
-            final TableColumn<ObservableList<String>, ? extends Object> column2 = mock(TableColumn.class);
-            final TableColumn<ObservableList<String>, ? extends Object> column3 = mock(TableColumn.class);
-            final TableColumn<ObservableList<String>, ? extends Object> column4 = mock(TableColumn.class);
+        when(column1.isVisible()).thenReturn(true);
+        when(column1.getText()).thenReturn("ABC");
 
-            when(column1.isVisible()).thenReturn(true);
-            when(column1.getText()).thenReturn("ABC");
+        when(column2.isVisible()).thenReturn(true);
+        when(column2.getText()).thenReturn("DEF");
+        when(column2.getSortType()).thenReturn(TableColumn.SortType.ASCENDING);
 
-            when(column2.isVisible()).thenReturn(true);
-            when(column2.getText()).thenReturn("DEF");
-            when(column2.getSortType()).thenReturn(TableColumn.SortType.ASCENDING);
+        when(column3.isVisible()).thenReturn(false);
+        when(column3.getText()).thenReturn("GHI");
 
-            when(column3.isVisible()).thenReturn(false);
-            when(column3.getText()).thenReturn("GHI");
+        when(column4.isVisible()).thenReturn(true); // <- This seem wrong. Its dropped.
+        when(column4.getText()).thenReturn("JKL");
 
-            when(column4.isVisible()).thenReturn(true); // <- This seem wrong. Its dropped.
-            when(column4.getText()).thenReturn("JKL");
+        doReturn(column1).when(columns).get(0);
+        doReturn(column2).when(columns).get(1);
+        doReturn(column3).when(columns).get(2);
+        doReturn(column4).when(columns).get(3);
 
-            doReturn(column1).when(columns).get(0);
-            doReturn(column2).when(columns).get(1);
-            doReturn(column3).when(columns).get(2);
-            doReturn(column4).when(columns).get(3);
+        doReturn(column2).when(sortOrder).get(0);
 
-            doReturn(column2).when(sortOrder).get(0);
+        final TableView<ObservableList<String>> tableView = mock(TableView.class);
+        when(tableView.getColumns()).thenReturn(columns);
+        when(tableView.getSortOrder()).thenReturn(sortOrder);
 
-            final TableView<ObservableList<String>> tableView = mock(TableView.class);
-            when(tableView.getColumns()).thenReturn(columns);
-            when(tableView.getSortOrder()).thenReturn(sortOrder);
+        TableViewPreferencesIOUtilities.savePreferences(GraphElementType.TRANSACTION, tableView, 5);
 
-            TableViewPreferencesIOUtilities.savePreferences(GraphElementType.TRANSACTION, tableView, 5);
+        final ObjectMapper objectMapper = new ObjectMapper();
+        final ArrayNode expectedJsonTree = (ArrayNode) objectMapper.readTree(
+                new FileInputStream(getClass().getResource("resources/transaction-preferences.json").getPath())
+        );
 
-            final ObjectMapper objectMapper = new ObjectMapper();
-            final ArrayNode expectedJsonTree = (ArrayNode) objectMapper.readTree(
-                    new FileInputStream(getClass().getResource("resources/transaction-preferences.json").getPath())
-            );
-
-            jsonIOStaticMock.verify(() -> JsonIO.saveJsonPreferences(
-                    eq("TableViewPreferences"),
-                    any(ObjectMapper.class),
-                    eq(expectedJsonTree),
-                    eq("transaction-")
-            ));
-        }
+        jsonIOStaticMock.verify(() -> JsonIO.saveJsonPreferences(
+                eq("TableViewPreferences"),
+                any(ObjectMapper.class),
+                eq(expectedJsonTree),
+                eq("transaction-")
+        ));
     }
 }

--- a/docker/netbeans-runner/Dockerfile
+++ b/docker/netbeans-runner/Dockerfile
@@ -13,6 +13,7 @@ RUN apt-get -y update \
     wget \
     python3 \
     git \
+    libx11-dev \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
### Description of the Change

Added TestFX and Monocle to the deps. This should hopefully allow for a headless build to run over JavaFX code.  Added required system props to the run test script so that the build runs in headless mode.

The PR contains one example of how to write the tests as a proof of concept.

### Alternate Designs



### Why Should This Be In Core?

This will mean that all the tests we have written that involve JavaFX code can now be run on the CI and included in coverage stats.

### Benefits

All tests run as a part of the CI build.

### Possible Drawbacks

The Monocle dep is based on the JDK version. This could cause some issues when we look at upgrading to the next LTS. No one seems to have touched the GitHub repo for a while but I am not sure what is involved in making a new release. It is part of the TestFX package so hopefully it will be kept up to date as needed.

### Verification Process

### Applicable Issues
