### PR TITLE
Five sec write lock action fix

### DIFF
--- a/CoreTesting/src/au/gov/asd/tac/constellation/testing/CoreTestingPluginRegistry.java
+++ b/CoreTesting/src/au/gov/asd/tac/constellation/testing/CoreTestingPluginRegistry.java
@@ -35,6 +35,7 @@ import au.gov.asd.tac.constellation.testing.construction.SudokuGraphBuilderPlugi
 public class CoreTestingPluginRegistry {
 
     public static final String FIVE_SECOND_READ_LOCK = FiveSecondReadLockPlugin.class.getName();
+    public static final String FIVE_SECOND_WRITE_LOCK = FiveSecondWriteLockPlugin.class.getName();
     public static final String PLUGIN_EXCEPTION = PluginExceptionPlugin.class.getName();
 
     public static final String COMPLETE_GRAPH_BUILDER = CompleteGraphBuilderPlugin.class.getName();

--- a/CoreTesting/src/au/gov/asd/tac/constellation/testing/FiveSecondWriteLockAction.java
+++ b/CoreTesting/src/au/gov/asd/tac/constellation/testing/FiveSecondWriteLockAction.java
@@ -49,6 +49,6 @@ public final class FiveSecondWriteLockAction implements ActionListener {
 
     @Override
     public void actionPerformed(final ActionEvent e) {
-        PluginExecution.withPlugin(PluginRegistry.get(CoreTestingPluginRegistry.FIVE_SECOND_READ_LOCK)).executeLater(context.getGraph());
+        PluginExecution.withPlugin(PluginRegistry.get(CoreTestingPluginRegistry.FIVE_SECOND_WRITE_LOCK)).executeLater(context.getGraph());
     }
 }


### PR DESCRIPTION
<!--

### Requirements

* Filling out the template is required. Any pull request that does not include
enough information to be reviewed in a timely manner may be closed at the
maintainers' discretion.
* Follow the check list items defined by https://github.com/constellation-app/constellation/blob/master/CONTRIBUTING.md#pull-requests
* All new code requires unit tests to ensure they work as expected and will
continue to work as new code is added in the future (regression testing).
* Make sure your branch name is prefixed by `feature`, `bugfix`, `hotfix` or `release`
* Have you read Constellation's Code of Conduct? By filing an issue, you are
expected to comply with it, including treating everyone with respect:
https://github.com/constellation-app/constellation/blob/master/CODE_OF_CONDUCT.md

-->

### Description of the Change

The Five second write lock action was calling the five second read lock plugin instead of its namesake. Have fixed this.

### Alternate Designs

<!--

Explain what other alternates were considered and why the proposed version was
selected.

-->

### Why Should This Be In Core?

Fix bug in core

### Benefits

Fix bug in core

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process

<!--

What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (e.g. buttons you clicked, text you typed,
commands you ran, etc.), and describe the results you observed.

-->

### Applicable Issues

<!-- Link any applicable issues here -->
