### PR TITLE
:fire: Remove unused code from ImmutableObjectCache

### DIFF
--- a/CoreUtilities/src/au/gov/asd/tac/constellation/utilities/datastructure/ImmutableObjectCache.java
+++ b/CoreUtilities/src/au/gov/asd/tac/constellation/utilities/datastructure/ImmutableObjectCache.java
@@ -15,10 +15,8 @@
  */
 package au.gov.asd.tac.constellation.utilities.datastructure;
 
-import au.gov.asd.tac.constellation.utilities.text.SeparatorConstants;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Map.Entry;
 
 /**
  * The ImmutableObjectCache de-duplicates instances of the same immutable object
@@ -30,20 +28,7 @@ import java.util.Map.Entry;
  */
 public class ImmutableObjectCache {
 
-    private static final boolean VERBOSE = false;
-
-    private final Map<Class<?>, int[]> results;
-    private long savedStringBytes = 0;
-
     private final Map<Object, Object> cache = new HashMap<>();
-
-    public ImmutableObjectCache() {
-        if (VERBOSE) {
-            results = new HashMap<>();
-        } else {
-            results = null;
-        }
-    }
 
     /**
      * Returns the caches instance of the specified immutable object.
@@ -65,57 +50,17 @@ public class ImmutableObjectCache {
             return null;
         }
 
-        if (VERBOSE) {
-            int[] classResult = results.get(immutableObject.getClass());
-            if (classResult == null) {
-                classResult = new int[3];
-                results.put(immutableObject.getClass(), classResult);
-            }
-
-            final Object cachedInstance = cache.get(immutableObject);
-            if (cachedInstance == null) {
-                cache.put(immutableObject, immutableObject);
-                classResult[0]++;
-                return immutableObject;
-            } else {
-                if (cachedInstance == immutableObject) {
-                    classResult[1]++;
-                } else {
-                    classResult[2]++;
-                    if (immutableObject instanceof String) {
-                        savedStringBytes += 8 + 2 + ((String) immutableObject).length() * 2;
-                    }
-                }
-                return (T) cachedInstance;
-            }
-
+        final Object cachedInstance = cache.get(immutableObject);
+        if (cachedInstance == null) {
+            cache.put(immutableObject, immutableObject);
+            return immutableObject;
         } else {
-            final Object cachedInstance = cache.get(immutableObject);
-            if (cachedInstance == null) {
-                cache.put(immutableObject, immutableObject);
-                return immutableObject;
-            } else {
-                return (T) cachedInstance;
-            }
+            return (T) cachedInstance;
         }
     }
 
     @Override
     public String toString() {
-        if (VERBOSE) {
-            final StringBuilder out = new StringBuilder();
-            out.append("ImmutableObjectCache[entries = ").append(cache.size()).append("]\n");
-            for (Entry<Class<?>, int[]> e : results.entrySet()) {
-                out.append("    ").append(e.getKey().getCanonicalName()).append(SeparatorConstants.COLON);
-                out.append(" new = ").append(e.getValue()[0]);
-                out.append(", old = ").append(e.getValue()[1]);
-                out.append(", dedupe = ").append(e.getValue()[2]);
-                out.append(SeparatorConstants.NEWLINE);
-            }
-            out.append("    saved String bytes = ").append(savedStringBytes).append(SeparatorConstants.NEWLINE);
-            return out.toString();
-        } else {
-            return "ImmutableObjectCache[entries = " + cache.size() + "]";
-        }
+        return "ImmutableObjectCache[entries = " + cache.size() + "]";
     }
 }

--- a/CoreUtilities/test/unit/src/au/gov/asd/tac/constellation/utilities/datastructure/ImmutableObjectCacheNGTest.java
+++ b/CoreUtilities/test/unit/src/au/gov/asd/tac/constellation/utilities/datastructure/ImmutableObjectCacheNGTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2010-2021 Australian Signals Directorate
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package au.gov.asd.tac.constellation.utilities.datastructure;
+
+import org.testng.annotations.Test;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertSame;
+
+/**
+ * @author groombridge34a
+ */
+public class ImmutableObjectCacheNGTest {
+    
+    private final class ClassX {
+        private int i = 0;
+        public ClassX(int i) {
+            this.i = i;
+        }
+        @Override
+        public boolean equals(Object o) {
+            if (o == this)
+                return true;
+            if (!(o instanceof ClassX))
+                return false;
+            ClassX other = (ClassX) o;
+            return this.i == other.i;
+        }
+        @Override
+        public int hashCode() {
+            return (int) (i ^ (i >>> 32));
+        }
+    };
+    
+    private final class ClassY {};
+    
+    private static final String TO_STRING = "ImmutableObjectCache[entries = %d]";
+    
+    /**
+     * toString() and deduplicating null on an empty cache.
+     */
+    @Test
+    public void testEmptyAndNull() {
+        ImmutableObjectCache cache = new ImmutableObjectCache();
+        
+        // empty cache
+        assertEquals(cache.toString(), String.format(TO_STRING, 0));
+        
+        // adding null simply returns null, no other actions are performed
+        assertNull(cache.deduplicate(null));
+        assertEquals(cache.toString(), String.format(TO_STRING, 0));
+    }
+    
+    /**
+     * Adding the same, equivalent and different objects to the cache.
+     */
+    @Test
+    public void testDeduplicateAndToString() {
+        ImmutableObjectCache cache = new ImmutableObjectCache();
+        
+        // add the same object twice
+        ClassX cx1 = new ClassX(0);
+        assertSame(cache.deduplicate(cx1), cx1);
+        assertSame(cache.deduplicate(cx1), cx1);
+        assertEquals(cache.toString(), String.format(TO_STRING, 1));
+
+        // add an equivalent object to an object already present
+        ClassX cx2 = new ClassX(0);
+        ClassX cx2ret = cache.deduplicate(cx2);
+        assertSame(cx2ret, cx1);
+        assertEquals(cx2ret, cx2);
+        assertEquals(cache.toString(), String.format(TO_STRING, 1));
+        
+        // add an object of a different class
+        ClassY cy = new ClassY();
+        assertSame(cache.deduplicate(cy), cy);
+        assertEquals(cache.toString(), String.format(TO_STRING, 2));
+    }
+
+}


### PR DESCRIPTION
### Description of the Change

ImmutableObjectCache included a second, more complex version of the code which is unreachable.

### Alternate Designs

Whether the simple or complex code is enabled could be controlled by changing the VERBOSE field to a flag controlled by configuration.

### Why Should This Be In Core?

This code has never been reachable during the commit history of this project. Keeping dead code "just because" increases the complexity of the code.

### Benefits

Reduced code complexity and technical debt.

### Possible Drawbacks

This code was not covered by unit tests, it's possible that regression errors could be introduced.

### Verification Process

Created regression tests

### Applicable Issues

#413