### PR TITLE
:fire: Remove unused "localized" parameter from locate method signature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Constellation Changes
 
+## Changes in September 2021
+
+-   Removed unused `localized` parameter from the signature of the `locate()`
+    method in `ConstellationInstalledFileLocator`.
+
 ## Changes in August 2021
 
 -   Added 'updateTagsFiltersAvailable', 'updateSelectedTagsCombo', 

--- a/CoreMapView/src/au/gov/asd/tac/constellation/views/mapview/MapViewTileRenderer.java
+++ b/CoreMapView/src/au/gov/asd/tac/constellation/views/mapview/MapViewTileRenderer.java
@@ -653,7 +653,7 @@ public class MapViewTileRenderer extends PApplet {
         if (!locatedFile.isAbsolute()) {
             final String codeNameBase = "au.gov.asd.tac.constellation.views.mapview";
             final String relativePath = resourcePath + where;
-            locatedFile = ConstellationInstalledFileLocator.locate(relativePath, codeNameBase, false, MapViewTileRenderer.class.getProtectionDomain());
+            locatedFile = ConstellationInstalledFileLocator.locate(relativePath, codeNameBase, MapViewTileRenderer.class.getProtectionDomain());
             if (locatedFile == null) {
                 final URL url = getClass().getProtectionDomain().getCodeSource().getLocation();
                 locatedFile = new File(url.toString());

--- a/CoreMapView/src/au/gov/asd/tac/constellation/views/mapview/markers/ConstellationPointMarker.java
+++ b/CoreMapView/src/au/gov/asd/tac/constellation/views/mapview/markers/ConstellationPointMarker.java
@@ -72,7 +72,7 @@ public class ConstellationPointMarker extends ConstellationAbstractMarker {
             final File templateImageFile = ConstellationInstalledFileLocator.locate(
                     "modules/ext/data/" + TEMPLATE_IMAGE_PATH,
                     "au.gov.asd.tac.constellation.views.mapview",
-                    false, ConstellationPointMarker.class.getProtectionDomain());
+                    ConstellationPointMarker.class.getProtectionDomain());
             final BufferedImage templateImage = ImageIO.read(templateImageFile);
             TEMPLATE_IMAGE = new PImage(templateImage.getWidth(), templateImage.getHeight(), PConstants.ARGB);
             TEMPLATE_IMAGE.loadPixels();

--- a/CoreMapView/src/au/gov/asd/tac/constellation/views/mapview/providers/DefaultMapProvider.java
+++ b/CoreMapView/src/au/gov/asd/tac/constellation/views/mapview/providers/DefaultMapProvider.java
@@ -53,7 +53,7 @@ public class DefaultMapProvider extends MapProvider {
         final File defaultMap = ConstellationInstalledFileLocator.locate(
                 "modules/ext/defaultMap.mbtiles",
                 "au.gov.asd.tac.constellation.views.mapview",
-                false, DefaultMapProvider.class.getProtectionDomain());
+                DefaultMapProvider.class.getProtectionDomain());
         final String connection = String.format("jdbc:sqlite:%s", defaultMap.getAbsolutePath());
         final int zoom = (int) coordinate.zoom;
         final float gridSize = PApplet.pow(2, coordinate.zoom);

--- a/CoreScriptingView/src/au/gov/asd/tac/constellation/views/scripting/ScriptingViewPane.java
+++ b/CoreScriptingView/src/au/gov/asd/tac/constellation/views/scripting/ScriptingViewPane.java
@@ -88,7 +88,10 @@ import org.python.core.PyTraceback;
 public class ScriptingViewPane extends JPanel {
 
     private static final Logger LOGGER = Logger.getLogger(ScriptingViewPane.class.getName());
-    private static final File GET_STARTED_FILE = ConstellationInstalledFileLocator.locate("modules/ext/scripting_getting_started.txt", "au.gov.asd.tac.constellation.views.scripting", false, ScriptingViewPane.class.getProtectionDomain());
+    private static final File GET_STARTED_FILE = ConstellationInstalledFileLocator.locate(
+            "modules/ext/scripting_getting_started.txt", 
+            "au.gov.asd.tac.constellation.views.scripting", 
+            ScriptingViewPane.class.getProtectionDomain());
     private static final String SCRIPTING_VIEW_THREAD_NAME = "Scripting View";
 
     private static final String LANGUAGE = "Python";

--- a/CoreUtilities/src/au/gov/asd/tac/constellation/utilities/file/ConstellationInstalledFileLocator.java
+++ b/CoreUtilities/src/au/gov/asd/tac/constellation/utilities/file/ConstellationInstalledFileLocator.java
@@ -41,13 +41,11 @@ public class ConstellationInstalledFileLocator {
      * using {@code / } as a separator, regardless of platform)
      * @param codeNameBase name of the supplying module, e.g.
      * {@code org.netbeans.modules.foo}; may be {@code null} if unknown
-     * @param localized true to perform a localized and branded lookup (useful
-     * for documentation etc.)
      * @param protectedDomain the {@code ProtectionDomain} of the class used to
      * find the location of the JAR.
      * @return the requested {@code File}, if it can be found, else {@code null}
      */
-    public static File locate(String relativePath, String codeNameBase, boolean localized, ProtectionDomain protectedDomain) {
+    public static File locate(String relativePath, String codeNameBase, ProtectionDomain protectedDomain) {
         File locatedFile = InstalledFileLocator.getDefault().locate(relativePath, codeNameBase, false);
         if (locatedFile == null) {
             // InstalledFileLocator only works in the NetBeans environment.

--- a/CoreUtilities/src/au/gov/asd/tac/constellation/utilities/icon/FileIconData.java
+++ b/CoreUtilities/src/au/gov/asd/tac/constellation/utilities/icon/FileIconData.java
@@ -31,7 +31,7 @@ public class FileIconData extends IconData {
     private final File file;
 
     public FileIconData(final String relativePath, final String codeNameBase) {
-        final File locatedFile = ConstellationInstalledFileLocator.locate(relativePath, codeNameBase, false, FileIconData.class.getProtectionDomain());
+        final File locatedFile = ConstellationInstalledFileLocator.locate(relativePath, codeNameBase, FileIconData.class.getProtectionDomain());
         this.file = locatedFile;
     }
 


### PR DESCRIPTION
### Description of the Change

The `ConstellationInstalledFileLocator` class in `CoreUtilities` includes a `locate()` method intended to find files in NetBeans modules. One of the method parameters is `boolean localized`, which was intended to narrow the search to a localized and branded lookup. But the method never uses this parameter, it's hard coded to `false`.

### Alternate Designs

None.

### Why Should This Be In Core?

Minor update.

### Benefits

Increased clarity by removing unused code.

### Possible Drawbacks

None.

### Verification Process

- Used NetBeans to check for usages of the `locate()` method in the entire Core, and addressed those usages.
- Used NetBeans to check that `ConstellationInstalledFileLocator` has no occurrences of polymorphism (eg inheritance) and method overrides.
- Ran the unit test suite as problems with changing method signatures manifest as compile time errors.
- Ran Constellation, clicked around the Map View and the Scripting View.

### Applicable Issues

None.