### PR TITLE
Added horizontal scroll bar to imported files

### DIFF
--- a/CoreImportExportPlugins/src/au/gov/asd/tac/constellation/plugins/importexport/delimited/DelimitedSourcePane.java
+++ b/CoreImportExportPlugins/src/au/gov/asd/tac/constellation/plugins/importexport/delimited/DelimitedSourcePane.java
@@ -87,6 +87,7 @@ public class DelimitedSourcePane extends SourcePane {
         fileScrollPane.setMaxWidth(Double.MAX_VALUE);
         fileScrollPane.setPrefHeight(FILESCROLLPANE_PREF_HEIGHT);
         fileScrollPane.setFitToWidth(true);
+        fileScrollPane.setFitToHeight(true);
         fileScrollPane.setMinWidth(0);
         fileScrollPane.setContent(fileListView);
         fileScrollPane.setHbarPolicy(ScrollBarPolicy.AS_NEEDED);


### PR DESCRIPTION
<!--

### Requirements

* Filling out the template is required. Any pull request that does not include
enough information to be reviewed in a timely manner may be closed at the
maintainers' discretion.
* Follow the check list items defined by https://github.com/constellation-app/constellation/blob/master/CONTRIBUTING.md#pull-requests
* All new code requires unit tests to ensure they work as expected and will
continue to work as new code is added in the future (regression testing).
* Make sure your branch name is prefixed by `feature`, `bugfix`, `hotfix` or `release`
* Have you read Constellation's Code of Conduct? By filing an issue, you are
expected to comply with it, including treating everyone with respect:
https://github.com/constellation-app/constellation/blob/master/CODE_OF_CONDUCT.md

-->

### Description of the Change

There was an already existing scroll bar but it was present at the bottom of the enlarged file name list. I added a change that shrunk the original size of the file name list and made the scroll bar present as soon as a file name was large enough to show it.

![image](https://user-images.githubusercontent.com/88649439/131623273-c3df2990-3180-4efb-b6a5-086050c977f9.png)
![image](https://user-images.githubusercontent.com/88649439/131623391-79d1212d-91de-4211-b448-a5c40dee7791.png)


<!--

We must be able to understand the design of your change from this description.
If we can't get a good idea of what the code will be doing from the description
here, the pull request may be closed at the maintainers' discretion. Keep in
mind that the maintainer reviewing this PR may not be familiar with or have
worked with the code here recently, so please walk us through the concepts.

-->

### Why Should This Be In Core?

Increases usability, allowing users to see the full file path

### Benefits

Increases usability, allowing users to see the full file path

### Verification Process

I ensured clicking on a valid file path would still have the same effect on the rest of the view.

### Applicable Issues

#1145 