### PR TITLE
Move transactions to middle

### DIFF
--- a/CoreImportExportPlugins/src/au/gov/asd/tac/constellation/plugins/importexport/RunPane.java
+++ b/CoreImportExportPlugins/src/au/gov/asd/tac/constellation/plugins/importexport/RunPane.java
@@ -230,7 +230,7 @@ public final class RunPane extends BorderPane implements KeyListener {
                 USE_COMPUTED_SIZE, -1);
         attributePane.addRowConstraint(true, VPos.TOP, Priority.ALWAYS, Double.MAX_VALUE, ATTRIBUTEPANE_MIN_WIDTH,
                 USE_COMPUTED_SIZE, -1);
-        attributePane.addRow(0, sourceVertexScrollPane, destinationVertexScrollPane, transactionScrollPane);
+        attributePane.addRow(0, sourceVertexScrollPane, transactionScrollPane, destinationVertexScrollPane);
 
         // A scroll pane to hold the attribute boxes
         final ScrollPane attributeScrollPane = new ScrollPane();


### PR DESCRIPTION


### Description of the Change

- Changed the order that the 3 columns appear on the file importer

![image](https://user-images.githubusercontent.com/88649439/131948861-62c2628b-0b65-49a2-8b1a-cedcd7a675da.png)

### Why Should This Be In Core?

As per the issue for it #1308 , it improves readability by showing a more appropriate order of how elements actually appear in the graph.

### Benefits

It looks nicer.

### Possible Drawbacks

long term users might get confused initially. 

### Verification Process

- I ensured that the + button associated with transactions was still associated with it.
- I did not change any functional code, only the order in which they appear.


### Applicable Issues

#1308

<!-- Link any applicable issues here -->
