### PR TITLE
Resolve Concurrent Mod Error #1342 and Notes View fixes

### DIFF
--- a/CoreNotesView/src/au/gov/asd/tac/constellation/views/notes/NotesViewController.java
+++ b/CoreNotesView/src/au/gov/asd/tac/constellation/views/notes/NotesViewController.java
@@ -115,6 +115,12 @@ public class NotesViewController {
                 return;
             }
 
+            // TODO: A copy of the list is being passed here instead because
+            // the Notes View is reading and writing state all the time.
+            // Review why the notes view needs to be read and written to so
+            // often. If this can be reduced significantly then the chance of
+            // reading and writing happening at the same time is reduced and we
+            // can simply pass by reference again
             pane.setNotes(new ArrayList<>(currentState.getNotes()));
             pane.setFilters(currentState.getFilters());
         }

--- a/CoreNotesView/src/au/gov/asd/tac/constellation/views/notes/NotesViewController.java
+++ b/CoreNotesView/src/au/gov/asd/tac/constellation/views/notes/NotesViewController.java
@@ -29,6 +29,7 @@ import au.gov.asd.tac.constellation.plugins.templates.SimpleReadPlugin;
 import au.gov.asd.tac.constellation.views.notes.state.NotesViewConcept;
 import au.gov.asd.tac.constellation.views.notes.state.NotesViewEntry;
 import au.gov.asd.tac.constellation.views.notes.state.NotesViewState;
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -88,7 +89,7 @@ public class NotesViewController {
     /**
      * Read the current state from the graph.
      */
-    @PluginInfo(pluginType = PluginType.UPDATE, tags = {"EXPERIMENTAL", "LOW LEVEL"})
+    @PluginInfo(pluginType = PluginType.UPDATE, tags = {"LOW LEVEL"})
     public static final class NotesViewStateReader extends SimpleReadPlugin {
 
         private final NotesViewPane pane;
@@ -114,7 +115,7 @@ public class NotesViewController {
                 return;
             }
 
-            pane.setNotes(currentState.getNotes());
+            pane.setNotes(new ArrayList<>(currentState.getNotes()));
             pane.setFilters(currentState.getFilters());
         }
 
@@ -127,7 +128,7 @@ public class NotesViewController {
     /**
      * Write the current state to the graph.
      */
-    @PluginInfo(pluginType = PluginType.UPDATE, tags = {"EXPERIMENTAL", "LOW LEVEL"})
+    @PluginInfo(pluginType = PluginType.UPDATE, tags = {"LOW LEVEL"})
     private static final class NotesViewStateWriter extends SimpleEditPlugin {
 
         private final List<NotesViewEntry> notes;

--- a/CoreTimelineView/src/au/gov/asd/tac/constellation/views/timeline/clustering/ClusteringManager.java
+++ b/CoreTimelineView/src/au/gov/asd/tac/constellation/views/timeline/clustering/ClusteringManager.java
@@ -402,7 +402,7 @@ public class ClusteringManager {
         }
     }
 
-    @PluginInfo(tags = {"MODIFY"})
+    @PluginInfo(tags = {"LOW LEVEL"})
     public final class UpdateDimOrHidePlugin extends SimplePlugin {
 
         final long lowerTimeExtent;

--- a/CoreTimelineView/src/au/gov/asd/tac/constellation/views/timeline/clustering/ClusteringManager.java
+++ b/CoreTimelineView/src/au/gov/asd/tac/constellation/views/timeline/clustering/ClusteringManager.java
@@ -402,7 +402,13 @@ public class ClusteringManager {
         }
     }
 
-    @PluginInfo(tags = {"LOW LEVEL"})
+    // TODO: Adding "LOW LEVEL" to omit this plugin flooding the Notes View with
+    // this call every time a selection is made and the timeline view is open.
+    // Review why this plugin is called so oftern and see if there is a need for
+    // this to even be a plugin if there is no direct user interaction required
+    // manually or programatically. If not then perhaps this should not be a
+    // plugin but rather a function call.
+    @PluginInfo(tags = {"LOW LEVEL", "MODIFY"})
     public final class UpdateDimOrHidePlugin extends SimplePlugin {
 
         final long lowerTimeExtent;

--- a/CoreWhatsNewView/src/au/gov/asd/tac/constellation/views/whatsnew/whatsnew.txt
+++ b/CoreWhatsNewView/src/au/gov/asd/tac/constellation/views/whatsnew/whatsnew.txt
@@ -26,7 +26,7 @@
 
 == 2021-07-26 Quality Control Category Changes
 <p>Quality Control category names and colours have been updated to match commonly seen category names and colours. The category names are now Minor, Medium, Major, Severe and Critical.</p>
-<p>A new category OK has been added for when a Quality Control rule has not been flagged.<p>
+<p>A new category OK has been added for when a Quality Control rule has not been flagged.</p>
 
 == 2021-07-21 Conversation View
 <p>The Conversation View now has a search bar where a letter or passage can be searched for within the currently visible conversation.</p>


### PR DESCRIPTION
<!--

### Requirements

* Filling out the template is required. Any pull request that does not include
enough information to be reviewed in a timely manner may be closed at the
maintainers' discretion.
* Follow the check list items defined by https://github.com/constellation-app/constellation/blob/master/CONTRIBUTING.md#pull-requests
* All new code requires unit tests to ensure they work as expected and will
continue to work as new code is added in the future (regression testing).
* Make sure your branch name is prefixed by `feature`, `bugfix`, `hotfix` or `release`
* Have you read Constellation's Code of Conduct? By filing an issue, you are
expected to comply with it, including treating everyone with respect:
https://github.com/constellation-app/constellation/blob/master/CODE_OF_CONDUCT.md

-->

### Description of the Change

I would like this and the related changes to go into v2.4.0

:bug: Fixed a bug with a concurrent mod issue
:art: Removed the experimental tag for Notes View
:art: Changed the UpdateDimOrHidePlugin to a "LOW LEVEL" tag
:art: Fixed a syntax error in what's new

### Alternate Designs

Every graph action triggers a plugin report which causes the notes view to read and write from the state. This is not efficient and needs to be reworked so that it can be as efficient as the plugin reporter or as close to as possible.

### Why Should This Be In Core?

<!--

Explain why this functionality should be in Constellation Core as opposed to a
different module suite. Note that this question is more applicable when adding
new functionality. If this change is a minor update to an existing file then it
is understood that this change has to be to this module suite and a response
and therefore a response to this question is not required.

-->

### Benefits

<!-- What benefits will be realized by the code change? -->

This resolves a concurrent modification issue

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

My concern was around more memory use but I have been able to confirm that this does not increase the memory use. The spike in memory has to do with the notes being rendered which are JavaFX objects.

### Verification Process

<!--

What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (e.g. buttons you clicked, text you typed,
commands you ran, etc.), and describe the results you observed.

-->

I did a lot of subsequent actions like continuously hopping out (holding ctrl+ right arrow) on a highly connected graph with the notes view (and even the table view) open and I could no longer produce the issue.

### Applicable Issues

<!-- Link any applicable issues here -->
