### PR TITLE
Add in the ability to do freeform selection via ALT+left mouse drawing

### DIFF
--- a/CoreInteractiveGraph/src/au/gov/asd/tac/constellation/graph/interaction/InteractiveGraphPluginRegistry.java
+++ b/CoreInteractiveGraph/src/au/gov/asd/tac/constellation/graph/interaction/InteractiveGraphPluginRegistry.java
@@ -41,6 +41,7 @@ import au.gov.asd.tac.constellation.graph.interaction.plugins.io.AutosaveGraphPl
 import au.gov.asd.tac.constellation.graph.interaction.plugins.io.CloseGraphPlugin;
 import au.gov.asd.tac.constellation.graph.interaction.plugins.io.SaveGraphPlugin;
 import au.gov.asd.tac.constellation.graph.interaction.plugins.select.BoxSelectionPlugin;
+import au.gov.asd.tac.constellation.graph.interaction.plugins.select.FreeformSelectionPlugin;
 import au.gov.asd.tac.constellation.graph.interaction.plugins.select.PointSelectionPlugin;
 import au.gov.asd.tac.constellation.graph.interaction.plugins.zoom.PreviousViewPlugin;
 import au.gov.asd.tac.constellation.graph.interaction.plugins.zoom.ResetViewPlugin;
@@ -72,6 +73,7 @@ public class InteractiveGraphPluginRegistry {
     public static final String DESTROY_ALL_COMPOSITES = DestroyAllCompositesPlugin.class.getName();
     public static final String DRAG_ELEMENTS = DragElementsPlugin.class.getName();
     public static final String EXPAND_ALL_COMPOSITES = ExpandAllCompositesPlugin.class.getName();
+    public static final String FREEFORM_SELECTION = FreeformSelectionPlugin.class.getName();
     public static final String PASTE = PasteFromClipboardPlugin.class.getName();
     public static final String PASTE_GRAPH = PasteGraphPlugin.class.getName();
     public static final String PASTE_TEXT = PasteTextPlugin.class.getName();

--- a/CoreInteractiveGraph/src/au/gov/asd/tac/constellation/graph/interaction/docs/add-and-selection-modes.html
+++ b/CoreInteractiveGraph/src/au/gov/asd/tac/constellation/graph/interaction/docs/add-and-selection-modes.html
@@ -108,15 +108,27 @@
             </tr>
             <tr>
                 <td>Left-drag</td>
-                <td>Select multiple nodes and/or transactions.</td>
+                <td>Select multiple nodes and/or transactions with a box selection.</td>
             </tr>
             <tr>
                 <td>Shift-left-drag</td>
-                <td>Select additional multiple nodes and/or transactions.</td>
+                <td>Select additional multiple nodes and/or transactions with a box selection.</td>
             </tr>
             <tr>
                 <td>Ctrl-left-drag</td>
-                <td>Toggle selection of multiple nodes and/or transactions.</td>
+                <td>Toggle selection of multiple nodes and/or transactions with a box selection.</td>
+            </tr>
+            <tr>
+                <td>Alt-left-drag</td>
+                <td>Select multiple nodes and/or transactions with a freeform selection.</td>
+            </tr>
+            <tr>
+                <td>Alt-shift-left-drag</td>
+                <td>Select additional multiple nodes and/or transactions with a freeform selection.</td>
+            </tr>
+            <tr>
+                <td>Alt-ctrl-left-drag</td>
+                <td>Toggle selection of multiple nodes and/or transactions with a freeform selection.</td>
             </tr>
             <tr>
                 <td>Middle-drag</td>

--- a/CoreInteractiveGraph/src/au/gov/asd/tac/constellation/graph/interaction/framework/VisualAnnotator.java
+++ b/CoreInteractiveGraph/src/au/gov/asd/tac/constellation/graph/interaction/framework/VisualAnnotator.java
@@ -17,6 +17,7 @@ package au.gov.asd.tac.constellation.graph.interaction.framework;
 
 import au.gov.asd.tac.constellation.graph.interaction.visual.renderables.NewLineModel;
 import au.gov.asd.tac.constellation.graph.interaction.visual.renderables.SelectionBoxModel;
+import au.gov.asd.tac.constellation.graph.interaction.visual.renderables.SelectionFreeformModel;
 import au.gov.asd.tac.constellation.utilities.visual.VisualOperation;
 import au.gov.asd.tac.constellation.utilities.visual.VisualProcessor;
 import java.util.Queue;
@@ -46,6 +47,20 @@ public interface VisualAnnotator {
      * reflect the updated selection box model.
      */
     public VisualOperation setSelectionBoxModel(final SelectionBoxModel model);
+
+    /**
+     * Sets the {@link SelectionFreeformModel} that should be displayed and returns a
+     * {@link VisualOperation} that can be scheduled to push the changes to the
+     * {@link VisualProcessor} with which this annotator is associated.
+     * <p>
+     * The selection freeform model is typically used to indicate a currently in
+     * progress freeform selection.
+     *
+     * @param model The {@link SelectionFreeformModel} that should be displayed.
+     * @return A {@link VisualOperation} that can be scheduled to visually
+     * reflect the updated selection freeform model.
+     */
+    public VisualOperation setSelectionFreeformModel(final SelectionFreeformModel model);
 
     /**
      * Sets the {@link NewLineModel} that should be displayed and returns a

--- a/CoreInteractiveGraph/src/au/gov/asd/tac/constellation/graph/interaction/plugins/select/FreeformSelectionPlugin.java
+++ b/CoreInteractiveGraph/src/au/gov/asd/tac/constellation/graph/interaction/plugins/select/FreeformSelectionPlugin.java
@@ -1,0 +1,477 @@
+/*
+ * Copyright 2010-2021 Australian Signals Directorate
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package au.gov.asd.tac.constellation.graph.interaction.plugins.select;
+
+import au.gov.asd.tac.constellation.graph.Graph;
+import au.gov.asd.tac.constellation.graph.GraphElementType;
+import au.gov.asd.tac.constellation.graph.GraphWriteMethods;
+import au.gov.asd.tac.constellation.graph.operations.SetBooleanValuesOperation;
+import au.gov.asd.tac.constellation.graph.schema.visual.concept.VisualConcept;
+import au.gov.asd.tac.constellation.graph.visual.framework.VisualGraphDefaults;
+import au.gov.asd.tac.constellation.plugins.PluginInfo;
+import au.gov.asd.tac.constellation.plugins.PluginInteraction;
+import au.gov.asd.tac.constellation.plugins.PluginType;
+import au.gov.asd.tac.constellation.plugins.parameters.PluginParameters;
+import au.gov.asd.tac.constellation.plugins.templates.SimpleEditPlugin;
+import au.gov.asd.tac.constellation.utilities.camera.Camera;
+import au.gov.asd.tac.constellation.utilities.graphics.Frame;
+import au.gov.asd.tac.constellation.utilities.graphics.Matrix33f;
+import au.gov.asd.tac.constellation.utilities.graphics.Matrix44f;
+import au.gov.asd.tac.constellation.utilities.graphics.Vector3f;
+import java.util.BitSet;
+import org.openide.util.NbBundle.Messages;
+
+/**
+ * select elements by freeform select
+ *
+ * @author CrucisGamma
+ */
+@Messages("FreeformSelectionPlugin=Select in Freeform")
+@PluginInfo(pluginType = PluginType.SELECTION, tags = {"SELECTION"})
+public final class FreeformSelectionPlugin extends SimpleEditPlugin {
+
+    private final boolean isAdd;
+    private final boolean isToggle;
+    private final Camera camera;
+    private final Float[] transformedVertices;
+    private final int numVertices;
+    private final float[] box; // left, right, top, bottom in camera coordinates
+
+    public FreeformSelectionPlugin(final boolean isAdd, final boolean isToggle, final Camera camera, final float[] box, Float[] transformedVertices, int numVertices) {
+        this.isAdd = isAdd;
+        this.isToggle = isToggle;
+        this.camera = camera;
+        this.transformedVertices = transformedVertices;
+        this.numVertices = numVertices;
+        this.box = box;
+    }
+
+    // From https://stackoverflow.com/questions/11716268/point-in-polygon-algorithm
+    private boolean inFreeformPolygons(float xPoint, float yPoint) {
+        int j = -999;
+        int i = -999;
+        boolean locatedInPolygon = false;
+
+        float testX = xPoint;
+        float testY = yPoint;
+
+        for (i = 0; i < numVertices; i++) {
+            if (i == (numVertices - 1)) {
+                j = 0;
+            } else {
+                j = i + 1;
+            }
+
+            float vertY_i = (float) transformedVertices[i * 2 + 1];
+            float vertX_i = (float) transformedVertices[i * 2];
+            float vertY_j = (float) transformedVertices[j * 2 + 1];
+            float vertX_j = (float) transformedVertices[j * 2];
+
+            boolean belowLowY = vertY_i > testY;
+            boolean belowHighY = vertY_j > testY;
+            boolean withinYsEdges = belowLowY != belowHighY;
+
+            if (withinYsEdges) {
+                float slopeOfLine = (vertX_j - vertX_i) / (vertY_j - vertY_i);
+                float pointOnLine = (slopeOfLine * (testY - vertY_i)) + vertX_i;
+                boolean isLeftToLine = testX < pointOnLine;
+
+                if (isLeftToLine) {
+                    locatedInPolygon = !locatedInPolygon;
+                }
+            }
+        }
+        return locatedInPolygon;
+    }
+
+    @Override
+    public void edit(final GraphWriteMethods graph, final PluginInteraction interaction, final PluginParameters parameters) throws InterruptedException {
+
+        final float mix = camera.getMix();
+        final float inverseMix = 1.0f - mix;
+        final Vector3f centre = new Vector3f(camera.lookAtCentre);
+
+        final float left = box[0];
+        final float right = box[1];
+        final float top = box[2];
+        final float bottom = box[3];
+
+        // Look up all the required attributes.
+        int xAttr = VisualConcept.VertexAttribute.X.get(graph);
+        int yAttr = VisualConcept.VertexAttribute.Y.get(graph);
+        int zAttr = VisualConcept.VertexAttribute.Z.get(graph);
+        final int x2Attr = VisualConcept.VertexAttribute.X2.get(graph);
+        final int y2Attr = VisualConcept.VertexAttribute.Y2.get(graph);
+        final int z2Attr = VisualConcept.VertexAttribute.Z2.get(graph);
+        final int vxSelectedAttr = VisualConcept.VertexAttribute.SELECTED.get(graph);
+        final int txSelectedAttr = VisualConcept.TransactionAttribute.SELECTED.get(graph);
+        final int vxVisibilityAttr = VisualConcept.VertexAttribute.VISIBILITY.get(graph);
+        final int txVisibilityAttr = VisualConcept.TransactionAttribute.VISIBILITY.get(graph);
+
+        final SetBooleanValuesOperation selectVerticesOperation = new SetBooleanValuesOperation(graph, GraphElementType.VERTEX, vxSelectedAttr);
+        final SetBooleanValuesOperation selectTransactionsOperation = new SetBooleanValuesOperation(graph, GraphElementType.TRANSACTION, txSelectedAttr);
+
+        final float visibilityHigh = camera.getVisibilityHigh();
+        final float visibilityLow = camera.getVisibilityLow();
+
+        // Get a copy of the current rotation matrix.
+        final Vector3f diff = Vector3f.subtract(camera.lookAtEye, camera.lookAtCentre);
+        final float cameraDistance = diff.getLength();
+
+        // Get the inverse eye rotation to match the object frame rotation.
+        final Frame frame = new Frame(camera.lookAtEye, camera.lookAtCentre, camera.lookAtUp);
+        final Matrix44f objectFrameMatrix = new Matrix44f();
+        frame.getMatrix(objectFrameMatrix, true);
+        final Matrix44f rotationMatrixt = new Matrix44f();
+        objectFrameMatrix.getRotationMatrix(rotationMatrixt);
+        final Matrix44f rotationMatrixti = new Matrix44f();
+        rotationMatrixti.invert(rotationMatrixt);
+        final Matrix33f rotationMatrix = new Matrix33f();
+        rotationMatrixti.getRotationMatrix(rotationMatrix);
+
+        // Do the vertex positions need mixing?
+        boolean requiresMix = x2Attr != Graph.NOT_FOUND && y2Attr != Graph.NOT_FOUND && z2Attr != Graph.NOT_FOUND;
+        boolean requiresVertexVisibility = vxVisibilityAttr != Graph.NOT_FOUND;
+        boolean requiresTransactionVisibility = txVisibilityAttr != Graph.NOT_FOUND;
+
+        // If the mix value is either 0 or 1 then no mixing is required
+        if (requiresMix && mix == 0.0f) {
+            requiresMix = false;
+        } else if (requiresMix && mix == 1.0f) {
+            xAttr = x2Attr;
+            yAttr = y2Attr;
+            zAttr = z2Attr;
+            requiresMix = false;
+        } else {
+            // Do nothing
+        }
+
+        final BitSet vxIncluded = new BitSet();
+        final int vxCount = graph.getVertexCount();
+
+        // Select the correct vertices.
+        for (int position = 0; position != vxCount; position++) {
+            final int vxId = graph.getVertex(position);
+
+            if (requiresVertexVisibility) {
+                final float visibility = graph.getFloatValue(vxVisibilityAttr, vxId);
+                if (visibility <= 1.0f && (visibility > visibilityHigh || visibility < visibilityLow)) {
+                    continue;
+                }
+            }
+
+            // Get the main location of the vertex.
+            float x = xAttr != Graph.NOT_FOUND ? graph.getFloatValue(xAttr, vxId) : VisualGraphDefaults.getDefaultX(vxId);
+            float y = yAttr != Graph.NOT_FOUND ? graph.getFloatValue(yAttr, vxId) : VisualGraphDefaults.getDefaultY(vxId);
+            float z = zAttr != Graph.NOT_FOUND ? graph.getFloatValue(zAttr, vxId) : VisualGraphDefaults.getDefaultZ(vxId);
+
+            // If mixing is required then mix the main location with the alternative location.
+            boolean mixed = false;
+            if (requiresMix) {
+                x = inverseMix * x + mix * graph.getFloatValue(x2Attr, vxId);
+                y = inverseMix * y + mix * graph.getFloatValue(y2Attr, vxId);
+                z = inverseMix * z + mix * graph.getFloatValue(z2Attr, vxId);
+                mixed = true;
+            }
+
+            // Convert world coordinates to camera coordinates.
+            final Vector3f sceneLocation = convertWorldToScene(x, y, z, centre, rotationMatrix, cameraDistance);
+            final int rAttr = VisualConcept.VertexAttribute.NODE_RADIUS.get(graph);
+            final float r = graph.getFloatValue(rAttr, vxId);
+
+            if (sceneLocation.getZ() < 0) {
+                final float leftMostPoint = (sceneLocation.getX() - r) / -sceneLocation.getZ();
+                final float rightMostPoint = (sceneLocation.getX() + r) / -sceneLocation.getZ();
+                final float bottomMostPoint = (sceneLocation.getY() - r) / -sceneLocation.getZ();
+                final float topMostPoint = (sceneLocation.getY() + r) / -sceneLocation.getZ();
+
+                final boolean vertexLeftOfFreeform = rightMostPoint < left;
+                final boolean vertexRightOfFreeform = right < leftMostPoint;
+                final boolean vertexBelowFreeform = topMostPoint < bottom;
+                final boolean vertexAboveFreeform = top < bottomMostPoint;
+
+                if (!vertexLeftOfFreeform && !vertexRightOfFreeform && !vertexBelowFreeform && !vertexAboveFreeform) {
+                    if (inFreeformPolygons(leftMostPoint, topMostPoint)) {
+                        vxIncluded.set(vxId);
+                    }
+                }
+            }
+        }
+
+        final BitSet txIncluded = new BitSet();
+
+        if (vxIncluded.isEmpty()) {
+            final int linkCount = graph.getLinkCount();
+            for (int position = 0; position < linkCount; position++) {
+                final int linkId = graph.getLink(position);
+
+                final int vxLo = graph.getLinkLowVertex(linkId);
+                final int vxHi = graph.getLinkHighVertex(linkId);
+
+                // Get the main location of the lo vertex.
+                float xLo = xAttr != Graph.NOT_FOUND ? graph.getFloatValue(xAttr, vxLo) : VisualGraphDefaults.getDefaultX(vxLo);
+                float yLo = yAttr != Graph.NOT_FOUND ? graph.getFloatValue(yAttr, vxLo) : VisualGraphDefaults.getDefaultY(vxLo);
+                float zLo = zAttr != Graph.NOT_FOUND ? graph.getFloatValue(zAttr, vxLo) : VisualGraphDefaults.getDefaultZ(vxLo);
+
+                // Get the main location of the lo vertex.
+                float xHi = xAttr != Graph.NOT_FOUND ? graph.getFloatValue(xAttr, vxHi) : VisualGraphDefaults.getDefaultX(vxHi);
+                float yHi = yAttr != Graph.NOT_FOUND ? graph.getFloatValue(yAttr, vxHi) : VisualGraphDefaults.getDefaultY(vxHi);
+                float zHi = zAttr != Graph.NOT_FOUND ? graph.getFloatValue(zAttr, vxHi) : VisualGraphDefaults.getDefaultZ(vxHi);
+
+                if (requiresMix) {
+                    xLo = inverseMix * xLo + mix * graph.getFloatValue(x2Attr, vxLo);
+                    yLo = inverseMix * yLo + mix * graph.getFloatValue(y2Attr, vxLo);
+                    zLo = inverseMix * zLo + mix * graph.getFloatValue(z2Attr, vxLo);
+
+                    xHi = inverseMix * xHi + mix * graph.getFloatValue(x2Attr, vxHi);
+                    yHi = inverseMix * yHi + mix * graph.getFloatValue(y2Attr, vxHi);
+                    zHi = inverseMix * zHi + mix * graph.getFloatValue(z2Attr, vxHi);
+                }
+
+                // Convert world coordinates to camera coordinates.
+                final Vector3f worldLocationLo = new Vector3f(xLo, yLo, zLo);
+                worldLocationLo.subtract(centre);
+                final Vector3f lo = new Vector3f();
+                lo.rotate(worldLocationLo, rotationMatrix);
+                lo.setZ(lo.getZ() - cameraDistance);
+
+                final Vector3f worldLocationHi = new Vector3f(xHi, yHi, zHi);
+                worldLocationHi.subtract(centre);
+                final Vector3f hi = new Vector3f();
+                hi.rotate(worldLocationHi, rotationMatrix);
+                hi.setZ(hi.getZ() - cameraDistance);
+
+                // If at least one of the end-points is in front of the eye...
+                if (lo.getZ() < 0 || hi.getZ() < 0) {
+                    final float horizontalOffsetLo;
+                    final float horizontalOffsetHi;
+                    final float verticalOffsetLo;
+                    final float verticalOffsetHi;
+                    if (lo.getZ() < 0) {
+                        final float loz = -Math.abs(lo.getZ());
+                        horizontalOffsetLo = lo.getX() / -loz;
+                        verticalOffsetLo = lo.getY() / -loz;
+                    } else if (lo.getZ() > 0) {
+                        horizontalOffsetLo = lo.getX() + (lo.getZ() * (hi.getX() - lo.getX())) / (lo.getZ() - hi.getZ());
+                        verticalOffsetLo = lo.getY() + (lo.getZ() * (hi.getY() - lo.getY()) / (lo.getZ() - hi.getZ()));
+                    } else {
+                        horizontalOffsetLo = lo.getX();
+                        verticalOffsetLo = lo.getY();
+                    }
+
+                    if (hi.getZ() < 0) {
+                        final float hiz = -Math.abs(hi.getZ());
+                        horizontalOffsetHi = hi.getX() / -hiz;
+                        verticalOffsetHi = hi.getY() / -hiz;
+                    } else if (hi.getZ() > 0) {
+                        horizontalOffsetHi = lo.getX() + (lo.getZ() * (hi.getX() - lo.getX())) / (lo.getZ() - hi.getZ());
+                        verticalOffsetHi = lo.getY() + (lo.getZ() * (hi.getY() - lo.getY()) / (lo.getZ() - hi.getZ()));
+                    } else {
+                        horizontalOffsetHi = hi.getX();
+                        verticalOffsetHi = hi.getY();
+                    }
+
+                    final boolean intersects = lineSegmentIntersectsRectangle(
+                            horizontalOffsetLo, verticalOffsetLo,
+                            horizontalOffsetHi, verticalOffsetHi,
+                            left, bottom, right, top);
+
+                    if (intersects) {
+                        final int linkTxCount = graph.getLinkTransactionCount(linkId);
+                        for (int linkPos = 0; linkPos < linkTxCount; linkPos++) {
+                            final int txId = graph.getLinkTransaction(linkId, linkPos);
+                            txIncluded.set(txId);
+                        }
+                    }
+                }
+            }
+        }
+
+        final int txCount = graph.getTransactionCount();
+
+        if (txIncluded.isEmpty()) {
+            if (isAdd) {
+
+                if (vxSelectedAttr != Graph.NOT_FOUND) {
+                    for (int vxId = vxIncluded.nextSetBit(0); vxId >= 0; vxId = vxIncluded.nextSetBit(vxId + 1)) {
+                        if (!graph.getBooleanValue(vxSelectedAttr, vxId)) {
+                            selectVerticesOperation.setValue(vxId, true);
+                        }
+                    }
+                }
+
+                if (txSelectedAttr != Graph.NOT_FOUND) {
+                    for (int position = 0; position < txCount; position++) {
+                        final int txId = graph.getTransaction(position);
+                        if (vxIncluded.get(graph.getTransactionSourceVertex(txId)) && vxIncluded.get(graph.getTransactionDestinationVertex(txId)) && !graph.getBooleanValue(txSelectedAttr, txId)) {
+                            if (requiresTransactionVisibility) {
+                                float visibility = graph.getFloatValue(txVisibilityAttr, txId);
+                                if (visibility <= 1.0f && (visibility > visibilityHigh || visibility < visibilityLow)) {
+                                    continue;
+                                }
+                            }
+                            selectTransactionsOperation.setValue(txId, true);
+                        }
+                    }
+                }
+
+            } else if (isToggle) {
+
+                if (vxSelectedAttr != Graph.NOT_FOUND) {
+                    for (int vertex = vxIncluded.nextSetBit(0); vertex >= 0; vertex = vxIncluded.nextSetBit(vertex + 1)) {
+                        selectVerticesOperation.setValue(vertex, !graph.getBooleanValue(vxSelectedAttr, vertex));
+                    }
+                }
+
+                if (txSelectedAttr != Graph.NOT_FOUND) {
+                    for (int position = 0; position < txCount; position++) {
+                        final int txId = graph.getTransaction(position);
+                        if (vxIncluded.get(graph.getTransactionSourceVertex(txId)) && vxIncluded.get(graph.getTransactionDestinationVertex(txId))) {
+                            if (requiresTransactionVisibility) {
+                                float visibility = graph.getFloatValue(txVisibilityAttr, txId);
+                                if (visibility <= 1.0f && (visibility > visibilityHigh || visibility < visibilityLow)) {
+                                    continue;
+                                }
+                            }
+                            selectTransactionsOperation.setValue(txId, !graph.getBooleanValue(txSelectedAttr, txId));
+                        }
+                    }
+                }
+
+            } else {
+
+                if (vxSelectedAttr != Graph.NOT_FOUND) {
+                    for (int position = 0; position < vxCount; position++) {
+                        final int vxId = graph.getVertex(position);
+                        final boolean included = vxIncluded.get(vxId);
+                        if (included != graph.getBooleanValue(vxSelectedAttr, vxId)) {
+                            selectVerticesOperation.setValue(vxId, included);
+                        }
+                    }
+                }
+
+                if (txSelectedAttr != Graph.NOT_FOUND) {
+                    for (int position = 0; position < txCount; position++) {
+                        final int txId = graph.getTransaction(position);
+                        boolean included = vxIncluded.get(graph.getTransactionSourceVertex(txId)) && vxIncluded.get(graph.getTransactionDestinationVertex(txId));
+                        if (requiresTransactionVisibility) {
+                            float visibility = graph.getFloatValue(txVisibilityAttr, txId);
+                            if (visibility <= 1.0f && (visibility > visibilityHigh || visibility < visibilityLow)) {
+                                included = false;
+                            }
+                        }
+                        if (included != graph.getBooleanValue(txSelectedAttr, txId)) {
+                            selectTransactionsOperation.setValue(txId, included);
+                        }
+                    }
+                }
+            }
+        } else {
+            if (isAdd) {
+                if (txSelectedAttr != Graph.NOT_FOUND) {
+                    for (int txId = txIncluded.nextSetBit(0); txId >= 0; txId = txIncluded.nextSetBit(txId + 1)) {
+                        if (!graph.getBooleanValue(txSelectedAttr, txId)) {
+                            selectTransactionsOperation.setValue(txId, true);
+                        }
+                    }
+                }
+            } else if (isToggle) {
+                if (txSelectedAttr != Graph.NOT_FOUND) {
+                    for (int txId = txIncluded.nextSetBit(0); txId >= 0; txId = txIncluded.nextSetBit(txId + 1)) {
+                        selectTransactionsOperation.setValue(txId, !graph.getBooleanValue(txSelectedAttr, txId));
+                    }
+                }
+            } else {
+                if (txSelectedAttr != Graph.NOT_FOUND) {
+                    for (int position = 0; position < txCount; position++) {
+                        final int txId = graph.getTransaction(position);
+
+                        final boolean included = txIncluded.get(txId);
+                        if (included != graph.getBooleanValue(txSelectedAttr, txId)) {
+                            selectTransactionsOperation.setValue(txId, included);
+                        }
+                    }
+                }
+
+                // Deselect any selected vertices.
+                if (vxSelectedAttr != Graph.NOT_FOUND) {
+                    for (int position = 0; position < vxCount; position++) {
+                        final int vxId = graph.getVertex(position);
+
+                        final boolean selected = graph.getBooleanValue(vxSelectedAttr, vxId);
+                        if (selected) {
+                            selectVerticesOperation.setValue(vxId, false);
+                        }
+                    }
+                }
+            }
+        }
+
+        graph.executeGraphOperation(selectVerticesOperation);
+        graph.executeGraphOperation(selectTransactionsOperation);
+    }
+
+    private static boolean lineSegmentIntersectsRectangle(
+            final float x1, final float y1,
+            final float x2, final float y2,
+            final float minX, final float minY, final float maxX, final float maxY) {
+        // Completely outside.
+        if ((x1 <= minX && x2 <= minX) || (y1 <= minY && y2 <= minY) || (x1 >= maxX && x2 >= maxX) || (y1 >= maxY && y2 >= maxY)) {
+            return false;
+        }
+
+        if (x1 == x2) {
+            return minX <= x1 && x1 <= maxX;
+        }
+
+        // Slope of line segment.
+        final float m = (y2 - y1) / (x2 - x1);
+
+        float y = m * (minX - x1) + y1;
+        if (y > minY && y < maxY) {
+            return true;
+        }
+
+        y = m * (maxX - x1) + y1;
+        if (y > minY && y < maxY) {
+            return true;
+        }
+
+        float x = (minY - y1) / m + x1;
+        if (x > minX && x < maxX) {
+            return true;
+        }
+
+        x = (maxY - y1) / m + x1;
+
+        return x > minX && x < maxX;
+    }
+
+    /*
+     * Takes the x,y,z coordinate of a point in the world and translates it into
+     * the equivalent coordinate in the current scene.
+     */
+    private Vector3f convertWorldToScene(final float x, final float y, final float z, final Vector3f centre, final Matrix33f rotationMatrix, final float cameraDistance) {
+        // Convert world coordinates to camera coordinates.
+        final Vector3f worldLocation = new Vector3f();
+        final Vector3f sceneLocation = new Vector3f();
+        worldLocation.set(x, y, z);
+        worldLocation.subtract(centre);
+        sceneLocation.rotate(worldLocation, rotationMatrix);
+        sceneLocation.setZ(sceneLocation.getZ() - cameraDistance);
+        return sceneLocation;
+    }
+}

--- a/CoreInteractiveGraph/src/au/gov/asd/tac/constellation/graph/interaction/plugins/select/FreeformSelectionPlugin.java
+++ b/CoreInteractiveGraph/src/au/gov/asd/tac/constellation/graph/interaction/plugins/select/FreeformSelectionPlugin.java
@@ -40,7 +40,7 @@ import org.openide.util.NbBundle.Messages;
  * @author CrucisGamma
  */
 @Messages("FreeformSelectionPlugin=Select in Freeform")
-@PluginInfo(pluginType = PluginType.SELECTION, tags = {"SELECTION"})
+@PluginInfo(pluginType = PluginType.SELECTION, tags = {"SELECT"})
 public final class FreeformSelectionPlugin extends SimpleEditPlugin {
 
     private final boolean isAdd;
@@ -65,29 +65,22 @@ public final class FreeformSelectionPlugin extends SimpleEditPlugin {
         int i = -999;
         boolean locatedInPolygon = false;
 
-        float testX = xPoint;
-        float testY = yPoint;
-
         for (i = 0; i < numVertices; i++) {
-            if (i == (numVertices - 1)) {
-                j = 0;
-            } else {
-                j = i + 1;
-            }
+            j = (i == numVertices - 1) ? 0 : i + 1;
 
-            float vertY_i = (float) transformedVertices[i * 2 + 1];
-            float vertX_i = (float) transformedVertices[i * 2];
-            float vertY_j = (float) transformedVertices[j * 2 + 1];
-            float vertX_j = (float) transformedVertices[j * 2];
+            final float vertY_i = (float) transformedVertices[i * 2 + 1];
+            final float vertX_i = (float) transformedVertices[i * 2];
+            final float vertY_j = (float) transformedVertices[j * 2 + 1];
+            final float vertX_j = (float) transformedVertices[j * 2];
 
-            boolean belowLowY = vertY_i > testY;
-            boolean belowHighY = vertY_j > testY;
-            boolean withinYsEdges = belowLowY != belowHighY;
+            final boolean belowLowY = vertY_i > yPoint;
+            final boolean belowHighY = vertY_j > yPoint;
+            final boolean withinYsEdges = belowLowY != belowHighY;
 
             if (withinYsEdges) {
-                float slopeOfLine = (vertX_j - vertX_i) / (vertY_j - vertY_i);
-                float pointOnLine = (slopeOfLine * (testY - vertY_i)) + vertX_i;
-                boolean isLeftToLine = testX < pointOnLine;
+                final float slopeOfLine = (vertX_j - vertX_i) / (vertY_j - vertY_i);
+                final float pointOnLine = (slopeOfLine * (yPoint - vertY_i)) + vertX_i;
+                final boolean isLeftToLine = xPoint < pointOnLine;
 
                 if (isLeftToLine) {
                     locatedInPolygon = !locatedInPolygon;
@@ -144,8 +137,8 @@ public final class FreeformSelectionPlugin extends SimpleEditPlugin {
 
         // Do the vertex positions need mixing?
         boolean requiresMix = x2Attr != Graph.NOT_FOUND && y2Attr != Graph.NOT_FOUND && z2Attr != Graph.NOT_FOUND;
-        boolean requiresVertexVisibility = vxVisibilityAttr != Graph.NOT_FOUND;
-        boolean requiresTransactionVisibility = txVisibilityAttr != Graph.NOT_FOUND;
+        final boolean requiresVertexVisibility = vxVisibilityAttr != Graph.NOT_FOUND;
+        final boolean requiresTransactionVisibility = txVisibilityAttr != Graph.NOT_FOUND;
 
         // If the mix value is either 0 or 1 then no mixing is required
         if (requiresMix && mix == 0.0f) {
@@ -203,10 +196,8 @@ public final class FreeformSelectionPlugin extends SimpleEditPlugin {
                 final boolean vertexBelowFreeform = topMostPoint < bottom;
                 final boolean vertexAboveFreeform = top < bottomMostPoint;
 
-                if (!vertexLeftOfFreeform && !vertexRightOfFreeform && !vertexBelowFreeform && !vertexAboveFreeform) {
-                    if (inFreeformPolygons(leftMostPoint, topMostPoint)) {
-                        vxIncluded.set(vxId);
-                    }
+                if (!vertexLeftOfFreeform && !vertexRightOfFreeform && !vertexBelowFreeform && !vertexAboveFreeform && inFreeformPolygons(leftMostPoint, topMostPoint)) {
+                    vxIncluded.set(vxId);
                 }
             }
         }
@@ -318,7 +309,7 @@ public final class FreeformSelectionPlugin extends SimpleEditPlugin {
                         final int txId = graph.getTransaction(position);
                         if (vxIncluded.get(graph.getTransactionSourceVertex(txId)) && vxIncluded.get(graph.getTransactionDestinationVertex(txId)) && !graph.getBooleanValue(txSelectedAttr, txId)) {
                             if (requiresTransactionVisibility) {
-                                float visibility = graph.getFloatValue(txVisibilityAttr, txId);
+                                final float visibility = graph.getFloatValue(txVisibilityAttr, txId);
                                 if (visibility <= 1.0f && (visibility > visibilityHigh || visibility < visibilityLow)) {
                                     continue;
                                 }
@@ -327,7 +318,6 @@ public final class FreeformSelectionPlugin extends SimpleEditPlugin {
                         }
                     }
                 }
-
             } else if (isToggle) {
 
                 if (vxSelectedAttr != Graph.NOT_FOUND) {
@@ -341,7 +331,7 @@ public final class FreeformSelectionPlugin extends SimpleEditPlugin {
                         final int txId = graph.getTransaction(position);
                         if (vxIncluded.get(graph.getTransactionSourceVertex(txId)) && vxIncluded.get(graph.getTransactionDestinationVertex(txId))) {
                             if (requiresTransactionVisibility) {
-                                float visibility = graph.getFloatValue(txVisibilityAttr, txId);
+                                final float visibility = graph.getFloatValue(txVisibilityAttr, txId);
                                 if (visibility <= 1.0f && (visibility > visibilityHigh || visibility < visibilityLow)) {
                                     continue;
                                 }
@@ -368,7 +358,7 @@ public final class FreeformSelectionPlugin extends SimpleEditPlugin {
                         final int txId = graph.getTransaction(position);
                         boolean included = vxIncluded.get(graph.getTransactionSourceVertex(txId)) && vxIncluded.get(graph.getTransactionDestinationVertex(txId));
                         if (requiresTransactionVisibility) {
-                            float visibility = graph.getFloatValue(txVisibilityAttr, txId);
+                            final float visibility = graph.getFloatValue(txVisibilityAttr, txId);
                             if (visibility <= 1.0f && (visibility > visibilityHigh || visibility < visibilityLow)) {
                                 included = false;
                             }

--- a/CoreInteractiveGraph/src/au/gov/asd/tac/constellation/graph/interaction/visual/DefaultInteractionEventHandler.java
+++ b/CoreInteractiveGraph/src/au/gov/asd/tac/constellation/graph/interaction/visual/DefaultInteractionEventHandler.java
@@ -560,7 +560,7 @@ public class DefaultInteractionEventHandler implements InteractionEventHandler {
                             break;
                         case FREEFORM_SELECTING:
                             if (eventState.isMouseDragged()) {
-                                performFreeformSelection(wg, point, eventState.getPoint(EventState.PRESSED_POINT), event.isShiftDown(), event.isControlDown());
+                                performFreeformSelection(wg, event.isShiftDown(), event.isControlDown());
                                 clearSelectionFreeformModel();
                             } else {
                                 // If the mouse has clicked on an element (and neither pan nor control are pressed),
@@ -1140,46 +1140,20 @@ public class DefaultInteractionEventHandler implements InteractionEventHandler {
     }
 
     /**
-     * Performs a selection based on a given start and end point.
+     * Performs a selection based on a given polygon in the freeformModel.
      *
-     * If the start and end point are equal, a point selection is performed based on the hit tester.
-     *
-     * If the start and end point differ, a box selection is performed with the two points representing diagonally
-     * opposite corners of the box.
-     *
-     * In the latter case, the 2d box is actually converted to a 3d frustrum in order to make the correct selection on
-     * the 3 dimensional graph.
-     *
-     * @param selectTo the point where selection ends
-     * @param selectFrom the point where selection begins.
      * @param appendSelection whether or not the selection will be appended to the current selection
      * @param toggleSelection whether or not the selection will toggle the current selection. Note that if
      * appendSelection is true, this parameter has no effect.
      */
-    private void performFreeformSelection(final GraphReadMethods rg, final Point selectTo, final Point selectFrom, final boolean appendSelection, final boolean toggleSelection) {
-
-        // Sort the press/release coordinates to look like a drag from top-left to bottom-right: pressed<=released.
-        Point bottomRight = new Point();
-        if (selectTo.x < selectFrom.x) {
-            bottomRight.x = selectFrom.x;
-            selectFrom.x = selectTo.x;
-        } else {
-            bottomRight.x = selectTo.x;
-        }
-
-        if (selectTo.y < selectFrom.y) {
-            bottomRight.y = selectFrom.y;
-            selectFrom.y = selectTo.y;
-        } else {
-            bottomRight.y = selectTo.y;
-        }
+    private void performFreeformSelection(final GraphReadMethods rg, final boolean appendSelection, final boolean toggleSelection) {
 
         final float[] boxCameraCoordinates = visualInteraction.windowBoxToCameraBox(freeformModel.getLeftMost(), freeformModel.getRightMost(), freeformModel.getTopMost(), freeformModel.getBottomMost());
 
         freeformModel.setWindowBoxToCameraBox(boxCameraCoordinates);
-         Float [] transformedVertices = freeformModel.getTransformedVertices();
+        final Float[] transformedVertices = freeformModel.getTransformedVertices();
 
-        Plugin plugin = new FreeformSelectionPlugin(appendSelection, toggleSelection, VisualGraphUtilities.getCamera(rg), boxCameraCoordinates, transformedVertices, freeformModel.getNumPoints());
+        final Plugin plugin = new FreeformSelectionPlugin(appendSelection, toggleSelection, VisualGraphUtilities.getCamera(rg), boxCameraCoordinates, transformedVertices, freeformModel.getNumPoints());
         PluginExecution.withPlugin(plugin).executeLater(graph);
     }
 

--- a/CoreInteractiveGraph/src/au/gov/asd/tac/constellation/graph/interaction/visual/DefaultInteractionEventHandler.java
+++ b/CoreInteractiveGraph/src/au/gov/asd/tac/constellation/graph/interaction/visual/DefaultInteractionEventHandler.java
@@ -29,11 +29,13 @@ import au.gov.asd.tac.constellation.graph.interaction.framework.VisualInteractio
 import au.gov.asd.tac.constellation.graph.interaction.plugins.draw.CreateTransactionPlugin;
 import au.gov.asd.tac.constellation.graph.interaction.plugins.draw.CreateVertexPlugin;
 import au.gov.asd.tac.constellation.graph.interaction.plugins.select.BoxSelectionPlugin;
+import au.gov.asd.tac.constellation.graph.interaction.plugins.select.FreeformSelectionPlugin;
 import au.gov.asd.tac.constellation.graph.interaction.plugins.select.PointSelectionPlugin;
 import au.gov.asd.tac.constellation.graph.interaction.visual.EventState.CreationMode;
 import au.gov.asd.tac.constellation.graph.interaction.visual.EventState.SceneAction;
 import au.gov.asd.tac.constellation.graph.interaction.visual.renderables.NewLineModel;
 import au.gov.asd.tac.constellation.graph.interaction.visual.renderables.SelectionBoxModel;
+import au.gov.asd.tac.constellation.graph.interaction.visual.renderables.SelectionFreeformModel;
 import au.gov.asd.tac.constellation.graph.schema.visual.concept.VisualConcept;
 import au.gov.asd.tac.constellation.graph.visual.contextmenu.ContextMenuProvider;
 import au.gov.asd.tac.constellation.graph.visual.utilities.VisualGraphUtilities;
@@ -147,6 +149,8 @@ public class DefaultInteractionEventHandler implements InteractionEventHandler {
     private VisualInteraction visualInteraction;
     // The connection to the visual annotator that this handler uses
     private VisualAnnotator visualAnnotator;
+
+    private final SelectionFreeformModel freeformModel = new SelectionFreeformModel();
 
     private boolean announceNextFlush = false;
     private boolean handleEvents;
@@ -444,6 +448,10 @@ public class DefaultInteractionEventHandler implements InteractionEventHandler {
                         case SELECTING:
                             updateSelectionBoxModel(new SelectionBoxModel(eventState.getPoint(EventState.PRESSED_POINT), point));
                             break;
+                        case FREEFORM_SELECTING:
+                            freeformModel.addPoint(point);
+                            updateSelectionFreeformModel(freeformModel);
+                            break;
                         default:
                             break;
                     }
@@ -499,7 +507,9 @@ public class DefaultInteractionEventHandler implements InteractionEventHandler {
                 } else if (SwingUtilities.isRightMouseButton(event) && !eventState.getCurrentHitType().equals(HitType.NO_ELEMENT)) {
                     eventState.setCurrentAction(SceneAction.DRAG_NODES);
                 } else if (SwingUtilities.isLeftMouseButton(event)) {
-                    if (wg == null || !VisualGraphUtilities.getIsDrawingMode(wg)) {
+                    if ((wg == null || !VisualGraphUtilities.getIsDrawingMode(wg)) && event.isAltDown()) {
+                        eventState.setCurrentAction(SceneAction.FREEFORM_SELECTING);
+                    } else if (wg == null || !VisualGraphUtilities.getIsDrawingMode(wg)) {
                         eventState.setCurrentAction(SceneAction.SELECTING);
                     } else {
                         eventState.setCurrentAction(SceneAction.CREATING);
@@ -541,6 +551,17 @@ public class DefaultInteractionEventHandler implements InteractionEventHandler {
                             if (eventState.isMouseDragged()) {
                                 performBoxSelection(wg, point, eventState.getPoint(EventState.PRESSED_POINT), event.isShiftDown(), event.isControlDown());
                                 clearSelectionBoxModel();
+                            } else {
+                                // If the mouse has clicked on an element (and neither pan nor control are pressed),
+                                // or has double-clicked on the background, clear the selection.
+                                final boolean clearSelection = !event.isControlDown() && !event.isShiftDown() && (!eventState.getCurrentHitType().equals(HitType.NO_ELEMENT) || event.getClickCount() == 2);
+                                performPointSelection(event.isControlDown(), clearSelection, eventState.getCurrentHitType().elementType, eventState.getCurrentHitId());
+                            }
+                            break;
+                        case FREEFORM_SELECTING:
+                            if (eventState.isMouseDragged()) {
+                                performFreeformSelection(wg, point, eventState.getPoint(EventState.PRESSED_POINT), event.isShiftDown(), event.isControlDown());
+                                clearSelectionFreeformModel();
                             } else {
                                 // If the mouse has clicked on an element (and neither pan nor control are pressed),
                                 // or has double-clicked on the background, clear the selection.
@@ -841,6 +862,23 @@ public class DefaultInteractionEventHandler implements InteractionEventHandler {
     }
 
     /**
+     * Schedule a {@link VisualOperation} to clear the selection freeform model
+     */
+    private void clearSelectionFreeformModel() {
+        freeformModel.resetModel();
+        manager.addOperation(visualAnnotator.setSelectionFreeformModel(freeformModel));
+    }
+
+    /**
+     * Schedule a {@link VisualOperation} to update the selection freeform model
+     *
+     * @param model The model to update to.
+     */
+    private void updateSelectionFreeformModel(final SelectionFreeformModel model) {
+        manager.addOperation(visualAnnotator.setSelectionFreeformModel(model));
+    }
+
+    /**
      * Schedule a {@link VisualOperation} to clear the new line model
      */
     private void clearNewLineModel(final Camera camera) {
@@ -1098,6 +1136,50 @@ public class DefaultInteractionEventHandler implements InteractionEventHandler {
         final float[] boxCameraCoordinates = visualInteraction.windowBoxToCameraBox(selectFrom.x, bottomRight.x, selectFrom.y, bottomRight.y);
 
         Plugin plugin = new BoxSelectionPlugin(appendSelection, toggleSelection, VisualGraphUtilities.getCamera(rg), boxCameraCoordinates);
+        PluginExecution.withPlugin(plugin).executeLater(graph);
+    }
+
+    /**
+     * Performs a selection based on a given start and end point.
+     *
+     * If the start and end point are equal, a point selection is performed based on the hit tester.
+     *
+     * If the start and end point differ, a box selection is performed with the two points representing diagonally
+     * opposite corners of the box.
+     *
+     * In the latter case, the 2d box is actually converted to a 3d frustrum in order to make the correct selection on
+     * the 3 dimensional graph.
+     *
+     * @param selectTo the point where selection ends
+     * @param selectFrom the point where selection begins.
+     * @param appendSelection whether or not the selection will be appended to the current selection
+     * @param toggleSelection whether or not the selection will toggle the current selection. Note that if
+     * appendSelection is true, this parameter has no effect.
+     */
+    private void performFreeformSelection(final GraphReadMethods rg, final Point selectTo, final Point selectFrom, final boolean appendSelection, final boolean toggleSelection) {
+
+        // Sort the press/release coordinates to look like a drag from top-left to bottom-right: pressed<=released.
+        Point bottomRight = new Point();
+        if (selectTo.x < selectFrom.x) {
+            bottomRight.x = selectFrom.x;
+            selectFrom.x = selectTo.x;
+        } else {
+            bottomRight.x = selectTo.x;
+        }
+
+        if (selectTo.y < selectFrom.y) {
+            bottomRight.y = selectFrom.y;
+            selectFrom.y = selectTo.y;
+        } else {
+            bottomRight.y = selectTo.y;
+        }
+
+        final float[] boxCameraCoordinates = visualInteraction.windowBoxToCameraBox(freeformModel.getLeftMost(), freeformModel.getRightMost(), freeformModel.getTopMost(), freeformModel.getBottomMost());
+
+        freeformModel.setWindowBoxToCameraBox(boxCameraCoordinates);
+         Float [] transformedVertices = freeformModel.getTransformedVertices();
+
+        Plugin plugin = new FreeformSelectionPlugin(appendSelection, toggleSelection, VisualGraphUtilities.getCamera(rg), boxCameraCoordinates, transformedVertices, freeformModel.getNumPoints());
         PluginExecution.withPlugin(plugin).executeLater(graph);
     }
 

--- a/CoreInteractiveGraph/src/au/gov/asd/tac/constellation/graph/interaction/visual/EventState.java
+++ b/CoreInteractiveGraph/src/au/gov/asd/tac/constellation/graph/interaction/visual/EventState.java
@@ -49,6 +49,7 @@ final class EventState extends HitState {
         PANNING("Pan"),
         DRAG_NODES("Drag"),
         SELECTING("Selection"),
+        FREEFORM_SELECTING("Freeform Selection"),
         CREATING("Add Nodes"),
         NONE(""),;
 

--- a/CoreInteractiveGraph/src/au/gov/asd/tac/constellation/graph/interaction/visual/InteractiveGLVisualProcessor.java
+++ b/CoreInteractiveGraph/src/au/gov/asd/tac/constellation/graph/interaction/visual/InteractiveGLVisualProcessor.java
@@ -200,14 +200,14 @@ public class InteractiveGLVisualProcessor extends GLVisualProcessor implements V
     }
 
     @Override
-    public VisualOperation setSelectionBoxModel(SelectionBoxModel model) {
+    public VisualOperation setSelectionBoxModel(final SelectionBoxModel model) {
         selectionBoxRenderable.queueModel(model);
         return () -> Arrays.asList(new VisualChangeBuilder(VisualProperty.EXTERNAL_CHANGE)
                 .withId(selectionBoxUpdateId).build());
     }
 
     @Override
-    public VisualOperation setSelectionFreeformModel(SelectionFreeformModel model) {
+    public VisualOperation setSelectionFreeformModel(final SelectionFreeformModel model) {
         selectionFreeformRenderable.queueModel(model);
         return () -> Arrays.asList(new VisualChangeBuilder(VisualProperty.EXTERNAL_CHANGE)
                 .withId(selectionFreeformUpdateId).build());

--- a/CoreInteractiveGraph/src/au/gov/asd/tac/constellation/graph/interaction/visual/InteractiveGLVisualProcessor.java
+++ b/CoreInteractiveGraph/src/au/gov/asd/tac/constellation/graph/interaction/visual/InteractiveGLVisualProcessor.java
@@ -28,6 +28,8 @@ import au.gov.asd.tac.constellation.graph.interaction.visual.renderables.NewLine
 import au.gov.asd.tac.constellation.graph.interaction.visual.renderables.PlanesRenderable;
 import au.gov.asd.tac.constellation.graph.interaction.visual.renderables.SelectionBoxModel;
 import au.gov.asd.tac.constellation.graph.interaction.visual.renderables.SelectionBoxRenderable;
+import au.gov.asd.tac.constellation.graph.interaction.visual.renderables.SelectionFreeformModel;
+import au.gov.asd.tac.constellation.graph.interaction.visual.renderables.SelectionFreeformRenderable;
 import au.gov.asd.tac.constellation.graph.visual.utilities.VisualGraphUtilities;
 import au.gov.asd.tac.constellation.utilities.camera.Camera;
 import au.gov.asd.tac.constellation.utilities.camera.CameraUtilities;
@@ -65,12 +67,14 @@ import java.util.stream.Stream;
 public class InteractiveGLVisualProcessor extends GLVisualProcessor implements VisualInteraction, VisualAnnotator {
 
     private final long selectionBoxUpdateId = VisualChangeBuilder.generateNewId();
+    private final long selectionFreeformUpdateId = VisualChangeBuilder.generateNewId();
     private final long newLineUpdateId = VisualChangeBuilder.generateNewId();
     private final long greyscaleUpdateId = VisualChangeBuilder.generateNewId();
     private final long hitTestId = VisualChangeBuilder.generateNewId();
     private final long hitTestPointId = VisualChangeBuilder.generateNewId();
     private final HitTester hitTester;
     private final SelectionBoxRenderable selectionBoxRenderable = new SelectionBoxRenderable();
+    private final SelectionFreeformRenderable selectionFreeformRenderable = new SelectionFreeformRenderable();
     private final NewLineRenderable newLineRenderable = new NewLineRenderable(this);
     private final PlanesRenderable planesRenderable = new PlanesRenderable();
     private final TransformableGraphDisplayer graphDisplayer = new TransformableGraphDisplayer();
@@ -94,6 +98,7 @@ public class InteractiveGLVisualProcessor extends GLVisualProcessor implements V
         setGraphDisplayer(graphDisplayer);
         addRenderable(newLineRenderable);
         addRenderable(selectionBoxRenderable);
+        addRenderable(selectionFreeformRenderable);
         addRenderable(planesRenderable);
         hitTester = new HitTester(this);
         addRenderable(hitTester);
@@ -199,6 +204,13 @@ public class InteractiveGLVisualProcessor extends GLVisualProcessor implements V
         selectionBoxRenderable.queueModel(model);
         return () -> Arrays.asList(new VisualChangeBuilder(VisualProperty.EXTERNAL_CHANGE)
                 .withId(selectionBoxUpdateId).build());
+    }
+
+    @Override
+    public VisualOperation setSelectionFreeformModel(SelectionFreeformModel model) {
+        selectionFreeformRenderable.queueModel(model);
+        return () -> Arrays.asList(new VisualChangeBuilder(VisualProperty.EXTERNAL_CHANGE)
+                .withId(selectionFreeformUpdateId).build());
     }
 
     @Override

--- a/CoreInteractiveGraph/src/au/gov/asd/tac/constellation/graph/interaction/visual/renderables/SelectionFreeformModel.java
+++ b/CoreInteractiveGraph/src/au/gov/asd/tac/constellation/graph/interaction/visual/renderables/SelectionFreeformModel.java
@@ -1,0 +1,243 @@
+/*
+ * Copyright 2010-2021 Australian Signals Directorate
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package au.gov.asd.tac.constellation.graph.interaction.visual.renderables;
+
+import java.awt.Point;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * A logical model for drawing selection freeform as an annotation layer on top
+ * of a graph.
+ *
+ * @author CrucisGamma
+ */
+public class SelectionFreeformModel {
+
+    private List<Point> points = null;
+
+    private final int BIG_NUMBER = 1000000;
+    private final int BIG_NEGATIVE_NUMBER = -BIG_NUMBER;
+    private final int MAX_POINTS = 50;
+
+    private Point zeroPoint = new Point(0, 0);
+    private int leftMost = BIG_NUMBER;
+    private int rightMost = BIG_NEGATIVE_NUMBER;
+    private int bottomMost = BIG_NEGATIVE_NUMBER;
+    private int topMost = BIG_NUMBER;
+
+    private float leftBoxCameraCoordinates;
+    private float rightBoxCameraCoordinates;
+    private float topBoxCameraCoordinates;
+    private float bottomBoxCameraCoordinates;
+
+    public SelectionFreeformModel() {
+        this.points = new ArrayList<>();
+    }
+
+    /**
+     * Create a model with the specified points.
+     *
+     * @param startPoint The starting corner of the selection freeform.
+     * @param endPoint The end corner of the selection freeform (diagonally
+     * opposite to the start corner).
+     */
+    public SelectionFreeformModel(final Point startPoint, final Point endPoint) {
+        this.points = new ArrayList<>();
+        points.add(startPoint);
+        points.add(endPoint);
+    }
+
+    /**
+     * Add a new point to an existing model
+     *
+     * @param nextPoint The next point the user wants to add to the start
+     * corner).
+     */
+    static private final int THRESHOLD = 8;
+
+    public void addPoint(final Point nextPoint) {
+        if (nextPoint == null) {
+            return;
+        }
+
+        if (getNumPoints() < 2) {
+            points.add(nextPoint);
+            return;
+        }
+
+        if (Math.abs(getEndPoint().getX() - nextPoint.getX()) > THRESHOLD
+                && Math.abs(getEndPoint().getY() - nextPoint.getY()) > THRESHOLD) {
+            if (leftMost > nextPoint.getX()) {
+                leftMost = (int) nextPoint.getX();
+            }
+            if (rightMost < nextPoint.getX()) {
+                rightMost = (int) nextPoint.getX();
+            }
+            if (topMost > nextPoint.getY()) {
+                topMost = (int) nextPoint.getY();
+            }
+            if (bottomMost < nextPoint.getY()) {
+                bottomMost = (int) nextPoint.getY();
+            }
+            points.add(nextPoint);
+        }
+    }
+
+    /**
+     * Create a model with no corner points signifying that no selection
+     * freeform should be displayed.
+     *
+     * @return A model with no corner points.
+     */
+    public static SelectionFreeformModel getClearModel() {
+        return new SelectionFreeformModel(null, null);
+    }
+
+    public int getNumPoints() {
+        if (this.points == null) {
+            return 0;
+        }
+
+        for (int i = 0; i < this.points.size(); i++) {
+            if (this.points.get(i) == null) {
+                return 0;
+            }
+        }
+
+        if (points.size() > MAX_POINTS - 2) {
+            return MAX_POINTS - 2;
+        }
+        return points.size();
+    }
+
+    /**
+     * Is the model clear
+     *
+     * @return Whether or not this model is clear.
+     */
+    public boolean isClear() {
+        return getNumPoints() > 0;
+    }
+
+    /**
+     * Get the starting corner point of the selection freeform described by this
+     * model
+     *
+     * @return A point indicating the start of the selection freeform, or a
+     * zeroised point if the model is clear (represents no selection freeform).
+     */
+    public Point getStartPoint() {
+        if (!isClear()) {
+            return zeroPoint;
+        }
+        return getPoint(0);
+    }
+
+    /**
+     * Get the end corner point of the selection freeform (diagonally opposite
+     * to the start corner) described by this model
+     *
+     * @return A 3D vector representing the end of the selection freeform, or
+     * <code>null</code> if the model is clear (represents no selection
+     * freeform).
+     */
+    public Point getEndPoint() {
+        if (!isClear()) {
+            return null;
+        }
+        return getPoint(getNumPoints() - 1);
+    }
+
+    /**
+     * Get the starting corner point of the selection freeform described by this
+     * model
+     *
+     * @return A 3D vector representing the start of the selection freeform, or
+     * <code>null</code> if the model is clear (represents no selection
+     * freeform).
+     */
+    public Point getPoint(int i) {
+        if (i < 0 || i >= getNumPoints()) {
+            return getStartPoint();
+        }
+        return points.get(i);
+    }
+
+    /**
+     * Get the end corner point of the selection freeform (diagonally opposite
+     * to the start corner) described by this model
+     *
+     * @return A 3D vector representing the end of the selection freeform, or
+     * <code>null</code> if the model is clear (represents no selection
+     * freeform).
+     */
+    public void resetModel() {
+        leftMost = BIG_NUMBER;
+        rightMost = BIG_NEGATIVE_NUMBER;
+        bottomMost = BIG_NEGATIVE_NUMBER;
+        topMost = BIG_NUMBER;
+        this.points = new ArrayList<>();
+    }
+
+    /**
+     * Get the left,top,right or bottom most values
+     *
+     * @return An int for the left most point
+     */
+    public int getLeftMost() {
+        return leftMost;
+    }
+
+    public int getRightMost() {
+        return rightMost;
+    }
+
+    public int getTopMost() {
+        return topMost;
+    }
+
+    public int getBottomMost() {
+        return bottomMost;
+    }
+
+    public Float[] getTransformedVertices() {
+        int width = rightMost - leftMost;
+        int height = bottomMost - topMost;
+        float newWidth = rightBoxCameraCoordinates - leftBoxCameraCoordinates;
+        float newHeight = bottomBoxCameraCoordinates - topBoxCameraCoordinates;
+
+        ArrayList<Float> vertices = new ArrayList<>();
+
+        for (int i = 0; i < MAX_POINTS; i++) {
+            float x = (getPoint(i).x - leftMost) / ((float) width) * newWidth + leftBoxCameraCoordinates;
+            float y = (getPoint(i).y - topMost) / ((float) height) * newHeight + topBoxCameraCoordinates;
+
+            vertices.add(x);
+            vertices.add(y);
+        }
+
+        return vertices.toArray(new Float[0]);
+    }
+
+    public void setWindowBoxToCameraBox(float[] boxCameraCoordinates) {
+        leftBoxCameraCoordinates = boxCameraCoordinates[0];
+        rightBoxCameraCoordinates = boxCameraCoordinates[1];
+        topBoxCameraCoordinates = boxCameraCoordinates[2];
+        bottomBoxCameraCoordinates = boxCameraCoordinates[3];
+    }
+}
+

--- a/CoreInteractiveGraph/src/au/gov/asd/tac/constellation/graph/interaction/visual/renderables/SelectionFreeformModel.java
+++ b/CoreInteractiveGraph/src/au/gov/asd/tac/constellation/graph/interaction/visual/renderables/SelectionFreeformModel.java
@@ -67,7 +67,7 @@ public class SelectionFreeformModel {
      * @param nextPoint The next point the user wants to add to the start
      * corner).
      */
-    static private final int THRESHOLD = 8;
+    private static final int THRESHOLD = 8;
 
     public void addPoint(final Point nextPoint) {
         if (nextPoint == null) {
@@ -170,7 +170,7 @@ public class SelectionFreeformModel {
      * <code>null</code> if the model is clear (represents no selection
      * freeform).
      */
-    public Point getPoint(int i) {
+    public final Point getPoint(final int i) {
         if (i < 0 || i >= getNumPoints()) {
             return getStartPoint();
         }
@@ -215,16 +215,16 @@ public class SelectionFreeformModel {
     }
 
     public Float[] getTransformedVertices() {
-        int width = rightMost - leftMost;
-        int height = bottomMost - topMost;
-        float newWidth = rightBoxCameraCoordinates - leftBoxCameraCoordinates;
-        float newHeight = bottomBoxCameraCoordinates - topBoxCameraCoordinates;
+        final int width = rightMost - leftMost;
+        final int height = bottomMost - topMost;
+        final float newWidth = rightBoxCameraCoordinates - leftBoxCameraCoordinates;
+        final float newHeight = bottomBoxCameraCoordinates - topBoxCameraCoordinates;
 
-        ArrayList<Float> vertices = new ArrayList<>();
+        List<Float> vertices = new ArrayList<>();
 
         for (int i = 0; i < MAX_POINTS; i++) {
-            float x = (getPoint(i).x - leftMost) / ((float) width) * newWidth + leftBoxCameraCoordinates;
-            float y = (getPoint(i).y - topMost) / ((float) height) * newHeight + topBoxCameraCoordinates;
+            final float x = (getPoint(i).x - leftMost) / ((float) width) * newWidth + leftBoxCameraCoordinates;
+            final float y = (getPoint(i).y - topMost) / ((float) height) * newHeight + topBoxCameraCoordinates;
 
             vertices.add(x);
             vertices.add(y);
@@ -233,11 +233,10 @@ public class SelectionFreeformModel {
         return vertices.toArray(new Float[0]);
     }
 
-    public void setWindowBoxToCameraBox(float[] boxCameraCoordinates) {
+    public void setWindowBoxToCameraBox(final float[] boxCameraCoordinates) {
         leftBoxCameraCoordinates = boxCameraCoordinates[0];
         rightBoxCameraCoordinates = boxCameraCoordinates[1];
         topBoxCameraCoordinates = boxCameraCoordinates[2];
         bottomBoxCameraCoordinates = boxCameraCoordinates[3];
     }
 }
-

--- a/CoreInteractiveGraph/src/au/gov/asd/tac/constellation/graph/interaction/visual/renderables/SelectionFreeformRenderable.java
+++ b/CoreInteractiveGraph/src/au/gov/asd/tac/constellation/graph/interaction/visual/renderables/SelectionFreeformRenderable.java
@@ -1,0 +1,181 @@
+/*
+ * Copyright 2010-2021 Australian Signals Directorate
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package au.gov.asd.tac.constellation.graph.interaction.visual.renderables;
+
+import au.gov.asd.tac.constellation.utilities.graphics.Matrix44f;
+import au.gov.asd.tac.constellation.utilities.graphics.Vector3f;
+import au.gov.asd.tac.constellation.utilities.graphics.Vector4f;
+import au.gov.asd.tac.constellation.visual.opengl.renderer.GLRenderable;
+import au.gov.asd.tac.constellation.visual.opengl.renderer.GLVisualProcessor;
+import au.gov.asd.tac.constellation.visual.opengl.renderer.batcher.Batch;
+import au.gov.asd.tac.constellation.visual.opengl.utilities.GLTools;
+import au.gov.asd.tac.constellation.visual.opengl.utilities.ShaderManager;
+import com.jogamp.opengl.GL;
+import com.jogamp.opengl.GL3;
+import com.jogamp.opengl.GLAutoDrawable;
+import java.awt.Point;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.FloatBuffer;
+import java.util.concurrent.BlockingDeque;
+import java.util.concurrent.LinkedBlockingDeque;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import org.apache.commons.collections4.CollectionUtils;
+
+/**
+ * Draw a selection freeform shape.
+ *
+ * @author CrucisGamma
+ */
+public class SelectionFreeformRenderable implements GLRenderable {
+
+    // How many vertices do we need to draw a freeform shape?
+    // What color is the selection freeform shape?
+    private static final Vector4f SELECTION_COLOR = new Vector4f(0, 0.5f, 1, 0.375f);
+    private static final Vector4f SECOND_SELECTION_COLOR = new Vector4f(1, 0.5f, 0, 0.375f);
+    private static final Vector3f ZERO_3F = new Vector3f(0, 0, 0);
+    private int shader;
+    private int shaderMvp;
+    private final Batch batch;
+    private SelectionFreeformModel selectionFreeformModel;
+    private final BlockingDeque<SelectionFreeformModel> modelQueue = new LinkedBlockingDeque<>();
+
+    private static final int NUMBER_OF_VERTICES = 50;
+    private static final int COLOR_BUFFER_WIDTH = 4;
+    private static final int VERTEX_BUFFER_WIDTH = 3;
+
+    private final int colorTarget;
+    private final int vertexTarget;
+
+    public SelectionFreeformRenderable() {
+        batch = new Batch(GL3.GL_TRIANGLE_FAN);
+        vertexTarget = batch.newFloatBuffer(VERTEX_BUFFER_WIDTH, true);
+        colorTarget = batch.newFloatBuffer(COLOR_BUFFER_WIDTH, true);
+    }
+
+    @Override
+    public int getPriority() {
+        return RenderablePriority.ANNOTATIONS_PRIORITY.getValue();
+    }
+
+    @Override
+    public void init(final GLAutoDrawable drawable) {
+        final GL3 gl = drawable.getGL().getGL3();
+        String vs = null;
+        String gs = null;
+        String fs = null;
+
+        try {
+            vs = GLTools.loadFile(GLVisualProcessor.class, "shaders/PassThru.vs");
+            gs = GLTools.loadFile(GLVisualProcessor.class, "shaders/PassThruTriangle.gs");
+            fs = GLTools.loadFile(GLVisualProcessor.class, "shaders/PassThru.fs");
+        } catch (IOException ex) {
+            Logger.getLogger(SelectionFreeformRenderable.class.getName()).log(Level.SEVERE, null, ex);
+        }
+
+        shader = GLTools.loadShaderSourceWithAttributes(gl, "PassThru selection", vs, gs, fs,
+                vertexTarget, "vertex",
+                colorTarget, "color",
+                ShaderManager.FRAG_BASE, "fragColor");
+        shaderMvp = gl.glGetUniformLocation(shader, "mvpMatrix");
+
+        batch.initialise(NUMBER_OF_VERTICES);
+        for (int i = 0; i < NUMBER_OF_VERTICES; i++) {
+            batch.stage(vertexTarget, ZERO_3F);
+            batch.stage(colorTarget, SELECTION_COLOR);
+        }
+        batch.finalise(gl);
+    }
+
+    public void setSelectionFreeformModel(final SelectionFreeformModel selectionFreeformModel) {
+        this.selectionFreeformModel = selectionFreeformModel;
+    }
+
+    public void queueModel(final SelectionFreeformModel model) {
+        modelQueue.add(model);
+    }
+
+    private int width;
+    private int height;
+
+    @Override
+    public void reshape(final int x, final int y, final int width, final int height) {
+        this.width = width;
+        this.height = height;
+    }
+
+    @Override
+    public void update(final GLAutoDrawable drawable) {
+        if (CollectionUtils.isNotEmpty(modelQueue)) {
+            selectionFreeformModel = modelQueue.getLast();
+            modelQueue.clear();
+        }
+    }
+
+    @Override
+    public void display(final GLAutoDrawable drawable, final Matrix44f pMatrix) {
+        if (selectionFreeformModel != null && selectionFreeformModel.isClear()) {
+            final Point begin = selectionFreeformModel.getStartPoint();
+            final Point end = selectionFreeformModel.getEndPoint();
+            final GL3 gl = drawable.getGL().getGL3();
+
+            // Map the vertex buffer.
+            gl.glBindBuffer(GL3.GL_ARRAY_BUFFER, batch.getBufferName(vertexTarget));
+            final ByteBuffer bbuf = gl.glMapBuffer(GL3.GL_ARRAY_BUFFER, GL3.GL_WRITE_ONLY);
+            final FloatBuffer fbuf = bbuf.asFloatBuffer();
+
+            // We should have the same buffer size we started with.
+            assert fbuf.limit() == NUMBER_OF_VERTICES * 3;
+
+            // Find the location of the Freeform in projected coordinates and update the TRIANGLE_FAN coordinates in the vertex buffer.
+            float[] v = new float[150];
+
+            for (int i = 0; i < 50; i++) {
+                v[i * 3] = ((float) selectionFreeformModel.getPoint(i).getX() / width) * 2 - 1f;
+                v[i * 3 + 1] = ((float) (height - selectionFreeformModel.getPoint(i).getY()) / height) * 2 - 1f;
+                v[i * 3 + 2] = 0.0f;
+            }
+
+            fbuf.put(v);
+
+            gl.glUnmapBuffer(GL3.GL_ARRAY_BUFFER);
+
+            // Disable depth so the freeform shape is drawn over everything else.
+            gl.glDisable(GL3.GL_DEPTH_TEST);
+            gl.glDepthMask(false);
+
+            Matrix44f mvpMatrix = new Matrix44f();
+            mvpMatrix.makeIdentity();
+
+            // Draw.
+            gl.glUseProgram(shader);
+            gl.glUniformMatrix4fv(shaderMvp, 1, false, mvpMatrix.a, 0);
+            batch.draw(gl);
+
+            // Reenable depth.
+            gl.glEnable(GL3.GL_DEPTH_TEST);
+            gl.glDepthMask(true);
+        }
+    }
+
+    @Override
+    public void dispose(final GLAutoDrawable drawable) {
+        final GL3 gl = drawable.getGL().getGL3();
+        batch.dispose(gl);
+    }
+}

--- a/CoreInteractiveGraph/src/au/gov/asd/tac/constellation/graph/interaction/visual/renderables/SelectionFreeformRenderable.java
+++ b/CoreInteractiveGraph/src/au/gov/asd/tac/constellation/graph/interaction/visual/renderables/SelectionFreeformRenderable.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package au.gov.asd.tac.constellation.graph.interaction.visual.renderables;
 
 import au.gov.asd.tac.constellation.utilities.graphics.Matrix44f;
@@ -24,7 +23,6 @@ import au.gov.asd.tac.constellation.visual.opengl.renderer.GLVisualProcessor;
 import au.gov.asd.tac.constellation.visual.opengl.renderer.batcher.Batch;
 import au.gov.asd.tac.constellation.visual.opengl.utilities.GLTools;
 import au.gov.asd.tac.constellation.visual.opengl.utilities.ShaderManager;
-import com.jogamp.opengl.GL;
 import com.jogamp.opengl.GL3;
 import com.jogamp.opengl.GLAutoDrawable;
 import java.awt.Point;
@@ -43,6 +41,8 @@ import org.apache.commons.collections4.CollectionUtils;
  * @author CrucisGamma
  */
 public class SelectionFreeformRenderable implements GLRenderable {
+
+    private static final Logger LOGGER = Logger.getLogger(SelectionFreeformRenderable.class.getName());
 
     // How many vertices do we need to draw a freeform shape?
     // What color is the selection freeform shape?
@@ -84,8 +84,8 @@ public class SelectionFreeformRenderable implements GLRenderable {
             vs = GLTools.loadFile(GLVisualProcessor.class, "shaders/PassThru.vs");
             gs = GLTools.loadFile(GLVisualProcessor.class, "shaders/PassThruTriangle.gs");
             fs = GLTools.loadFile(GLVisualProcessor.class, "shaders/PassThru.fs");
-        } catch (IOException ex) {
-            Logger.getLogger(SelectionFreeformRenderable.class.getName()).log(Level.SEVERE, null, ex);
+        } catch (final IOException ex) {
+            LOGGER.log(Level.SEVERE, ex.getMessage(), ex);
         }
 
         shader = GLTools.loadShaderSourceWithAttributes(gl, "PassThru selection", vs, gs, fs,
@@ -143,7 +143,7 @@ public class SelectionFreeformRenderable implements GLRenderable {
             assert fbuf.limit() == NUMBER_OF_VERTICES * 3;
 
             // Find the location of the Freeform in projected coordinates and update the TRIANGLE_FAN coordinates in the vertex buffer.
-            float[] v = new float[150];
+            final float[] v = new float[150];
 
             for (int i = 0; i < 50; i++) {
                 v[i * 3] = ((float) selectionFreeformModel.getPoint(i).getX() / width) * 2 - 1f;
@@ -159,7 +159,7 @@ public class SelectionFreeformRenderable implements GLRenderable {
             gl.glDisable(GL3.GL_DEPTH_TEST);
             gl.glDepthMask(false);
 
-            Matrix44f mvpMatrix = new Matrix44f();
+            final Matrix44f mvpMatrix = new Matrix44f();
             mvpMatrix.makeIdentity();
 
             // Draw.

--- a/CoreWhatsNewView/src/au/gov/asd/tac/constellation/views/whatsnew/whatsnew.txt
+++ b/CoreWhatsNewView/src/au/gov/asd/tac/constellation/views/whatsnew/whatsnew.txt
@@ -1,6 +1,9 @@
 == 3030-12-31 Getting Started
 <p>If you're new to Constellation, read the <a href="" helpId="au.gov.asd.tac.constellation.functionality.gettingstarted">getting started guide</a>.</p>
 
+== 2021-09-06 Freeform Selection 
+<p>You can now draw a freeform selection shape by holding down Alt whilst selecting.</p>
+
 == 2021-08-23 Moved Notes View to Views menu
 <p>The Notes View can now be found in the Views menu instead of in the Experimental > Views menu.</p>
 


### PR DESCRIPTION
### Description of the Change

Add in a way for a user to be able to run a freeform selection in the main graph view (similar to the box select)

### Alternate Designs

The alternate design was modelled on graphics tools

### Why Should This Be In Core?

It's adding to the functionality of the program and not having to do multiple little box selects at one time

### Benefits

The user will be able to do freeform selections to selectively pick out bits and pieces of the graph 

### Possible Drawbacks

Potential for some duplicated code requiring a refactor.  No speed or memory increase was noticed in the testing 

### Verification Process

Ran through multiple selections and box selections over multiple graphs with no loss of speed or noticeable slowdown after some time doing this.  No exceptions noted or odd behaviour encountered.

### Applicable Issues

#1268 

