### PR TITLE
JSON IO Unit Testing

### DIFF
--- a/.github/workflows/build-and-scan.yml
+++ b/.github/workflows/build-and-scan.yml
@@ -14,7 +14,7 @@ jobs:
     name: Unit Tests
     runs-on: ubuntu-latest
     env:
-      RUNNER_IMAGE: "constellationapplication/netbeans-runner:12.0.3"
+      RUNNER_IMAGE: "constellationapplication/netbeans-runner:12.0.4"
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
       TRAVIS_REPO_SLUG: "${{ github.repository }}"

--- a/CoreDataAccessView/src/au/gov/asd/tac/constellation/views/dataaccess/io/ParameterIOUtilities.java
+++ b/CoreDataAccessView/src/au/gov/asd/tac/constellation/views/dataaccess/io/ParameterIOUtilities.java
@@ -38,6 +38,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.prefs.Preferences;
 import javafx.scene.control.ScrollPane;
@@ -220,12 +221,12 @@ public class ParameterIOUtilities {
         }
 
         if (queryName != null) {
-            JsonIO.saveJsonPreferences(DATA_ACCESS_DIR, mapper, rootNode);
+            JsonIO.saveJsonPreferences(Optional.of(DATA_ACCESS_DIR), mapper, rootNode);
         }
     }
 
     public static void loadParameters(final DataAccessPane dap) {
-        final JsonNode root = JsonIO.loadJsonPreferences(DATA_ACCESS_DIR);
+        final JsonNode root = JsonIO.loadJsonPreferences(Optional.of(DATA_ACCESS_DIR));
         if ((root != null) && (root.isArray())) {
             // Remove all the existing tabs and start some new ones.
             dap.removeTabs();

--- a/CoreTableView/src/au/gov/asd/tac/constellation/views/tableview2/io/TableViewPreferencesIOUtilities.java
+++ b/CoreTableView/src/au/gov/asd/tac/constellation/views/tableview2/io/TableViewPreferencesIOUtilities.java
@@ -28,6 +28,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.prefs.Preferences;
 import javafx.collections.ObservableList;
 import javafx.scene.control.TableColumn;
@@ -111,7 +112,7 @@ public class TableViewPreferencesIOUtilities {
             // the table isn't being sorted by any column so don't save anything
             colSortNode.put("", "");
         }
-        JsonIO.saveJsonPreferences(TABLE_VIEW_PREF_DIR, mapper, rootNode, filePrefix);
+        JsonIO.saveJsonPreferences(Optional.of(TABLE_VIEW_PREF_DIR), mapper, rootNode, Optional.of(filePrefix));
     }
 
     /**
@@ -128,7 +129,7 @@ public class TableViewPreferencesIOUtilities {
     public static ThreeTuple<List<String>, Tuple<String, TableColumn.SortType>, Integer> getPreferences(final GraphElementType tableType,
             final int defaultPageSize) {
         final String filePrefix = (tableType == GraphElementType.VERTEX ? VERTEX_FILE_PREFIX : TRANSACTION_FILE_PREFIX);
-        final JsonNode root = JsonIO.loadJsonPreferences(TABLE_VIEW_PREF_DIR, filePrefix);
+        final JsonNode root = JsonIO.loadJsonPreferences(Optional.of(TABLE_VIEW_PREF_DIR), Optional.of(filePrefix));
         final List<String> colOrder = new ArrayList<>();
         String sortColumn = "";
         TableColumn.SortType sortType = TableColumn.SortType.ASCENDING;

--- a/CoreTableView/test/unit/src/au/gov/asd/tac/constellation/views/tableview2/io/TableViewPreferencesIOUtilitiesNGTest.java
+++ b/CoreTableView/test/unit/src/au/gov/asd/tac/constellation/views/tableview2/io/TableViewPreferencesIOUtilitiesNGTest.java
@@ -27,6 +27,7 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import javafx.collections.ObservableList;
 import javafx.scene.control.TableColumn;
 import javafx.scene.control.TableView;
@@ -95,7 +96,7 @@ public class TableViewPreferencesIOUtilitiesNGTest {
                 new FileInputStream(getClass().getResource("resources/vertex-preferences.json").getPath())
         );
 
-        jsonIOStaticMock.when(() -> JsonIO.loadJsonPreferences("TableViewPreferences", "vertex-"))
+        jsonIOStaticMock.when(() -> JsonIO.loadJsonPreferences(Optional.of("TableViewPreferences"), Optional.of("vertex-")))
                 .thenReturn(jsonNode);
 
         final ThreeTuple<List<String>, Tuple<String, TableColumn.SortType>, Integer> preferences
@@ -117,7 +118,7 @@ public class TableViewPreferencesIOUtilitiesNGTest {
                 new FileInputStream(getClass().getResource("resources/transaction-preferences.json").getPath())
         );
 
-        jsonIOStaticMock.when(() -> JsonIO.loadJsonPreferences("TableViewPreferences", "transaction-"))
+        jsonIOStaticMock.when(() -> JsonIO.loadJsonPreferences(Optional.of("TableViewPreferences"), Optional.of("transaction-")))
                 .thenReturn(jsonNode);
 
         final ThreeTuple<List<String>, Tuple<String, TableColumn.SortType>, Integer> preferences
@@ -134,7 +135,7 @@ public class TableViewPreferencesIOUtilitiesNGTest {
 
     @Test
     public void getPreferencesNullPrefs() throws IOException {
-        jsonIOStaticMock.when(() -> JsonIO.loadJsonPreferences("TableViewPreferences", "vertex-"))
+        jsonIOStaticMock.when(() -> JsonIO.loadJsonPreferences(Optional.of("TableViewPreferences"), Optional.of("vertex-")))
                 .thenReturn(null);
 
         final ThreeTuple<List<String>, Tuple<String, TableColumn.SortType>, Integer> preferences
@@ -199,10 +200,10 @@ public class TableViewPreferencesIOUtilitiesNGTest {
         );
 
         jsonIOStaticMock.verify(() -> JsonIO.saveJsonPreferences(
-                eq("TableViewPreferences"),
+                eq(Optional.of("TableViewPreferences")),
                 any(ObjectMapper.class),
                 eq(expectedJsonTree),
-                eq("transaction-")
+                eq(Optional.of("transaction-"))
         ));
     }
 }

--- a/CoreUtilities/src/au/gov/asd/tac/constellation/utilities/genericjsonio/JsonIO.java
+++ b/CoreUtilities/src/au/gov/asd/tac/constellation/utilities/genericjsonio/JsonIO.java
@@ -117,12 +117,12 @@ public class JsonIO {
         // Obtain a filename from the user. If no filename is supplied, and the user didn't hit cancel, then
         // generate a filename for them based on username and timestamp. If cancel was hit, no more processing
         // is required.
-        Tuple<Boolean, String> preferenceNameDetails = JsonIODialog.getName();
-        if (!preferenceNameDetails.getFirst()) {
+        Optional<String> preferenceNameDetails = JsonIODialog.getPreferenceFileName();
+        if (preferenceNameDetails.isEmpty()) {
             // Cancel was pressed, lets exit straight away - nothing to do here
             return;
         }
-        String fileName = preferenceNameDetails.getSecond();
+        String fileName = preferenceNameDetails.get();
         if (fileName.isEmpty()) {
             // User didn't enter anyhting but hit OK ... this is a trigger to auto generate a filename
             fileName = String.format("%s at %s", System.getProperty("user.name"), TIMESTAMP_FORMAT.format(Instant.now()));
@@ -261,18 +261,17 @@ public class JsonIO {
     }
 
     /**
-     * Deletes the selected JSON file from disk, and hence from the selection
-     * dialog
+     * Deletes the selected JSON file from disk.
      *
-     * @param filenameToDelete name of file to delete
+     * @param filename name of file to delete
      */
-    public static void deleteJsonPreference(final String filenameToDelete) {
+    public static void deleteJsonPreference(final String filename) {
         final Preferences prefs = NbPreferences.forModule(ApplicationPreferenceKeys.class);
         final String userDir = ApplicationPreferenceKeys.getUserDir(prefs);
         final File prefDir = new File(userDir, currentDir);
 
-        if (filenameToDelete != null) {
-            final String encodedFilename = FilenameEncoder.encode(currentPrefix.concat(filenameToDelete)) + FILE_EXT;
+        if (filename != null) {
+            final String encodedFilename = FilenameEncoder.encode(currentPrefix.concat(filename)) + FILE_EXT;
 
             // Loop through files in preference directory looking for one matching selected item
             // delete it when found
@@ -290,5 +289,12 @@ public class JsonIO {
                 }
             }
         }
+    }
+    
+    private static File getPrefereceFileDirectory(final String subDirectory) {
+        final Preferences prefs = NbPreferences.forModule(ApplicationPreferenceKeys.class);
+        final String userDir = ApplicationPreferenceKeys.getUserDir(prefs);
+        
+        return new File(userDir, subDirectory);
     }
 }

--- a/CoreUtilities/src/au/gov/asd/tac/constellation/utilities/genericjsonio/JsonIO.java
+++ b/CoreUtilities/src/au/gov/asd/tac/constellation/utilities/genericjsonio/JsonIO.java
@@ -16,9 +16,7 @@
 package au.gov.asd.tac.constellation.utilities.genericjsonio;
 
 import au.gov.asd.tac.constellation.preferences.ApplicationPreferenceKeys;
-import au.gov.asd.tac.constellation.utilities.datastructure.Tuple;
 import au.gov.asd.tac.constellation.utilities.file.FilenameEncoder;
-import au.gov.asd.tac.constellation.utilities.gui.NotifyDisplayer;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
@@ -28,10 +26,13 @@ import java.io.IOException;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
+import java.util.Arrays;
 import java.util.Optional;
+import java.util.function.Function;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.prefs.Preferences;
+import java.util.stream.Collectors;
 import javafx.scene.control.Alert;
 import javafx.scene.control.ButtonType;
 import org.apache.commons.lang3.StringUtils;
@@ -47,14 +48,21 @@ import org.openide.util.NbPreferences;
  * @author serpens24
  */
 public class JsonIO {
-
     private static final Logger LOGGER = Logger.getLogger(JsonIO.class.getName());
+    
     private static final String FILE_EXT = ".json";
     private static final DateTimeFormatter TIMESTAMP_FORMAT = DateTimeFormatter
             .ofPattern("yyyy-MM-dd HH:mm:ss z").withZone(ZoneId.systemDefault());
-    private static String currentDir = "";  // Stores directory used by load dialog for reuse in delete call
-    private static String currentPrefix = "";  // Stores prefix used by load dialog for reuse in delete call
-
+    
+    private static final String PREFERENCE_FILE_EXISTS_ALERT_TITLE = "Preference File Exists";
+    private static final String PREFERENCE_FILE_EXISTS_ALERT_ERROR_MSG_FORMAT
+            = "'%s' already exists. Do you want to overwrite it?";
+    
+    private static final String PREFERENCE_FILE_SAVED_MSG_FORMAT
+            = "Preference saved to %s.";
+    
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    
     /**
      * Private constructor to hide implicit public one.
      */
@@ -65,236 +73,356 @@ public class JsonIO {
     /**
      * Save the supplied JSON data in a file, within an allocated subdirectory
      * of the users configuration directory. The filename can optionally be
-     * prefixed with a string, which can be used to categorize it. Refer to
-     * further comments inline.
+     * prefixed with a string, which can be used to categorize it.
+     * <p/>
+     * Normal operation sees an empty filePrefix string supplied. In this case,
+     * the name of the file will contain only the filename entered by the user.
+     * <p/>
+     * If however a non-empty filePrefix is supplied, then the filename provided
+     * by the user will be prefixed with this.
+     * <p/>
+     * This is MOST useful when a dedicated directory exists for similar 'type'
+     * configuration files, like the example below:
+     * 
+     * <pre><code>
+     * user-dir
+     *   +-- tableconfigs
+     *   +--- transaction_config1.json
+     *   +--- transaction_config2.json
+     *   +--- transaction_config3.json
+     *   +--- vertex_configa.json
+     *   +--- vertex_configb.json
+     *   +--- vertex_configc.json
+     * </code></pre>
+     * 
+     * The above structure could have been constructed with multiple calls to
+     * {@link #saveJsonPreferences(String, ObjectMapper, ArrayNode, String)} all using
+     * 'tableconfigs' as the value for {@code saveDir}, three using 'transaction_'
+     * for {@code filePrefix} and the other three using 'vertex_'.
+     * <p/>
+     * This functionality is integrated with {@link #loadJsonPreferences(String, String)}
+     * such that if a {@code filePrefix} is supplied in the
+     * {@link #loadJsonPreferences(String, String)} call then only files that
+     * contain the prefix are offered to the user to load. Hence, it allows a form
+     * of configuration file filtering.
      *
-     * @param saveDir Directory name within users directory to save the
-     * configuration file to
-     * @param mapper ObjectMapper tied to the JSON object being written to file
-     * @param rootNode The root node of the JSON object being written
-     * @param filePrefix Ignored if blank, if not, a string to prefix the
-     * filename with.
+     * @param saveDir directory name within the users directory to save the
+     *     preference file to or empty if it is to be save at the top level
+     * @param mapper configured object mapper to write serialize the root node
+     * @param rootNode the root object representing the preferences to be written
+     * @param filePrefix prefix to be pre-pended to the file name the user provides
+     *     or empty if no prefix to be provided
      *
      */
-    public static void saveJsonPreferences(String saveDir, ObjectMapper mapper, ArrayNode rootNode, String filePrefix) {
-        // Normal operation sees an empty filePrefix string supplied. In this case, the name of the file will contain
-        // only the filename entered by the user. If however a non-empty filePrefix is supplied, then the filename
-        // privided by the user will be prefixed with this.
-        // This is MOST useful when a dedicated directory exists for similar 'type' config files, like the example
-        // directory structure below:
-        // <user-dir>
-        //     +-- tableconfigs
-        //              +--- transaction_config1.json
-        //              +--- transaction_config2.json
-        //              +--- transaction_config3.json
-        //              +--- vertex_configa.json
-        //              +--- vertex_configb.json
-        //              +--- vertex_configc.json
-        //
-        // The above structure could have been contructed with multiple calls to saveJsonPreferences all using
-        // tableconfigs as the value for saveDir, three using 'transaction_' for filePrefix and the other three
-        // using 'vertex_'.
-        // This functionality is integrated with loadJsonPreferences such that if a filePrefix is supplied in the
-        // loadJsonPreferences call then only files that contain the prefix are offered to the user to load. Hence,
-        // it allows a form of config file filtering.
-        final Preferences prefs = NbPreferences.forModule(ApplicationPreferenceKeys.class);
-        final File prefDir = new File(ApplicationPreferenceKeys.getUserDir(prefs), saveDir);
-
-        // Create containing directory if it doesn't exist, wnsure it was successful.
-        if (!prefDir.exists()) {
-            prefDir.mkdir();
-        }
-        if (!prefDir.isDirectory()) {
-            final String msg = String.format("Can't create data access directory '%s'.", prefDir);
-            final NotifyDescriptor nd = new NotifyDescriptor.Message(msg, NotifyDescriptor.ERROR_MESSAGE);
+    public static void saveJsonPreferences(final Optional<String> saveDir,
+                                           final ObjectMapper mapper,
+                                           final Object rootNode,
+                                           final Optional<String> filePrefix) {
+        final File preferenceDirectory = getPrefereceFileDirectory(saveDir);
+        
+        // If the preference directory cannot be accessed then return
+        if (!preferenceDirectory.isDirectory()) {
+            final NotifyDescriptor nd = new NotifyDescriptor.Message(
+                    String.format("Can't create preference directory '%s'.", preferenceDirectory),
+                    NotifyDescriptor.ERROR_MESSAGE
+            );
             DialogDisplayer.getDefault().notify(nd);
-        }
-
-        // Configure the mapper
-        mapper.configure(SerializationFeature.INDENT_OUTPUT, true);
-        mapper.configure(SerializationFeature.CLOSE_CLOSEABLE, true);
-
-        // Obtain a filename from the user. If no filename is supplied, and the user didn't hit cancel, then
-        // generate a filename for them based on username and timestamp. If cancel was hit, no more processing
-        // is required.
-        Optional<String> preferenceNameDetails = JsonIODialog.getPreferenceFileName();
-        if (preferenceNameDetails.isEmpty()) {
-            // Cancel was pressed, lets exit straight away - nothing to do here
+            
             return;
         }
-        String fileName = preferenceNameDetails.get();
-        if (fileName.isEmpty()) {
-            // User didn't enter anyhting but hit OK ... this is a trigger to auto generate a filename
-            fileName = String.format("%s at %s", System.getProperty("user.name"), TIMESTAMP_FORMAT.format(Instant.now()));
+
+        // Ask the user to provide a file name
+        final Optional<String> userInput = JsonIODialog.getPreferenceFileName();
+        
+        // Cancel was pressed. So stop the save.
+        if (userInput.isEmpty()) {
+            return;
+        }
+        
+        // If the user hit ok but provided an empty string, then generate one
+        final String fileName = StringUtils.isBlank(userInput.get()) 
+                ? String.format(
+                        "%s at %s",
+                        System.getProperty("user.name"),
+                        TIMESTAMP_FORMAT.format(Instant.now())
+                )
+                : userInput.get();
+
+        // Pre-pend filePrefix
+        final String prefixedFileName = filePrefix.orElse("").concat(fileName);
+
+        final File preferenceFile = new File(
+                preferenceDirectory,
+                FilenameEncoder.encode(prefixedFileName + FILE_EXT)
+        );
+        
+        boolean go = true;
+
+        // If the file exist, ask the user if they want to overwrite
+        if (preferenceFile.exists()) {
+            final Alert alert = new Alert(Alert.AlertType.CONFIRMATION);
+            alert.setHeaderText(PREFERENCE_FILE_EXISTS_ALERT_TITLE);
+            alert.setContentText(String.format(
+                    PREFERENCE_FILE_EXISTS_ALERT_ERROR_MSG_FORMAT,
+                    prefixedFileName
+            ));
+            
+            final Optional<ButtonType> option = alert.showAndWait();
+            go = option.isPresent() && option.get() == ButtonType.OK;
         }
 
-        // At this point ensure the filename isn't all whitespace, if it is, the user may have entered multiple spaces
-        // or similar which is a bad filename.
-        if (fileName.trim().length() > 0) {
-            // Append filePrefix - it may well be empty, in which case the final fileName is unchanged.
-            fileName = filePrefix.concat(fileName);
-
-            // Configure JSON mapper settings
-            mapper.configure(SerializationFeature.INDENT_OUTPUT, true);
-            mapper.configure(SerializationFeature.CLOSE_CLOSEABLE, true);
-
-            // Create the file and write its contents. IF the file already exists, confirm from the user that they
-            // wish to continue (and overwrite the existing file).
-            final File f = new File(prefDir, FilenameEncoder.encode(fileName + FILE_EXT));
-            boolean go = true;
-            if (f.exists()) {
-                final String msg = String.format("'%s' already exists. Do you want to overwrite it?", fileName);
-                final Alert alert = new Alert(Alert.AlertType.CONFIRMATION);
-                alert.setHeaderText("Preference file exists");
-                alert.setContentText(msg);
-                final Optional<ButtonType> option = alert.showAndWait();
-                go = option.isPresent() && option.get() == ButtonType.OK;
+        if (go) {
+            try {
+                // Configure JSON mapper settings
+                mapper.configure(SerializationFeature.INDENT_OUTPUT, true);
+                mapper.configure(SerializationFeature.CLOSE_CLOSEABLE, true);
+                
+                mapper.writeValue(preferenceFile, rootNode);
+                
+                StatusDisplayer.getDefault().setStatusText(
+                        String.format(
+                                PREFERENCE_FILE_SAVED_MSG_FORMAT,
+                                preferenceFile.getPath()
+                        )
+                );
+            } catch (IOException ex) {
+                final NotifyDescriptor nd = new NotifyDescriptor.Message(
+                        String.format("Can't save preference file: %s", ex.getMessage()),
+                        NotifyDescriptor.ERROR_MESSAGE
+                );
+                DialogDisplayer.getDefault().notify(nd);
             }
-
-            if (go) {
-                try {
-                    mapper.writeValue(f, rootNode);
-                    StatusDisplayer.getDefault().setStatusText(String.format("Preference saved to %s.", f.getPath()));
-                } catch (IOException ex) {
-                    final String msg = String.format("Can't save table view preference: %s", ex.getMessage());
-                    final NotifyDescriptor nd = new NotifyDescriptor.Message(msg, NotifyDescriptor.ERROR_MESSAGE);
-                    DialogDisplayer.getDefault().notify(nd);
-                }
-            }
-        } else {
-            NotifyDisplayer.display("There must be a valid preference name.", NotifyDescriptor.ERROR_MESSAGE);
         }
     }
 
     /**
-     * Wrapper around base saveJsonPreferences method which sets an empty prefix
-     * string meaning no prefix is supplied.
+     * Save the supplied JSON data in a file, within an allocated subdirectory
+     * of the users configuration directory.
      *
-     * @param saveDir Directory name within users directory to save the
-     * configuration file to
-     * @param mapper ObjectMapper tied to the JSON object being written to file
-     * @param rootNode The root node of the JSON object being written
+     * @param saveDir directory name within the users directory to save the
+     *     configuration file to or empty if it is to be save at the top level
+     * @param mapper configured object mapper to write serialize the root node
+     * @param rootNode the root object representing the preferences to be written
+     * @see #saveJsonPreferences(Optional, ObjectMapper, ArrayNode, Optional) 
      */
-    public static void saveJsonPreferences(String saveDir, ObjectMapper mapper, ArrayNode rootNode) {
-        saveJsonPreferences(saveDir, mapper, rootNode, "");
+    public static void saveJsonPreferences(final Optional<String> saveDir,
+                                           final ObjectMapper mapper,
+                                           final Object rootNode) {
+        saveJsonPreferences(saveDir, mapper, rootNode, Optional.empty());
     }
 
     /**
      * Allow user to select a preference file to load from the supplied
-     * directory. If filePrefix was provided as a non empty string, then only
-     * files prefixed with this value are available to the user to load.
+     * directory. If filePrefix was provided, then only files prefixed with this
+     * value are available to the user to load.
      *
-     * @param loadDir the directory location of the JSON files as a string
-     * @param filePrefix if not blank a prefix string is pre-pended to the
-     * beginning of the filename this can be used to create categorized JSON
-     * files with forced name groupings
-     *
-     * @return The JsonNode of the selected preference or null if nothing is
-     * selected
+     * @param loadDir directory name within the users directory to load the
+     *     preference file from or empty if it is to be loaded at the top level
+     * @param filePrefix prefix that is expected to be pre-pended to the file name
+     *     of the preference file being loaded or empty if no prefix filter is required
+     * @return the processed JSON of the selected preference file or null if nothing
+     *     is selected
+     * @see #loadJsonPreferences(Optional, Optional, Function) 
+     * @deprecated use {@link #loadJsonPreferences(Optional, Optional, Class)} instead
      */
-    public static JsonNode loadJsonPreferences(final String loadDir, String filePrefix) {
-        final Preferences prefs = NbPreferences.forModule(ApplicationPreferenceKeys.class);
-        final String userDir = ApplicationPreferenceKeys.getUserDir(prefs);
-        final File prefDir = new File(userDir, loadDir);
-        final String[] names;
-        final ObjectMapper mapper = new ObjectMapper();
-
-        // Store the load directory/prefix so that they can be used by deleteJsonPreference
-        currentDir = loadDir;
-        currentPrefix = filePrefix;
-
-        // Check the supplied directory for any files, if filePrefix was supplied, only files
-        // containing the prefix are returned. Return a list of filenames for the user to select from.
-        if (prefDir.isDirectory()) {
-            names = prefDir.list((File dir, String name) -> {
-                if (filePrefix.isEmpty()) {
-                    return name.toLowerCase().endsWith(FILE_EXT);
-                }
-                return (name.toLowerCase().startsWith(filePrefix) && name.toLowerCase().endsWith(FILE_EXT));
-            });
-        } else {
-            // Nothing to select from - return an empty list
-            names = new String[0];
-        }
-
-        // chop off ".json" from the filenames
-        for (int i = 0; i < names.length; i++) {
-            final String nextName = FilenameEncoder.decode(names[i].substring(0, names[i].length() - 5));
-            if (StringUtils.isNotBlank(nextName)) {
-                names[i] = nextName;
-                // Hide any file prefix which the user didn't see when saving
-                if (!filePrefix.isEmpty()) {
-                    names[i] = names[i].substring(filePrefix.length());
-                }
-            }
-        }
-
-        // Allow user to select a filename from the crafted list using the dialog.
-        String fileName = JsonIODialog.getSelection(names);
-        if (fileName != null) {
+    @Deprecated
+    public static JsonNode loadJsonPreferences(final Optional<String> loadDir,
+                                               final Optional<String> filePrefix) {
+        return loadJsonPreferences(loadDir, filePrefix, file -> {
             try {
-                // Reconsitute filename to include any file prefix
-                if (!filePrefix.isEmpty()) {
-                    fileName = filePrefix.concat(fileName);
-                }
-                return mapper.readTree(new File(prefDir, FilenameEncoder.encode(fileName) + FILE_EXT));
-            } catch (IOException ex) {
-                final String errorMsg = "An error occured reading file ".concat(FilenameEncoder.encode(fileName) + FILE_EXT);
-                LOGGER.log(Level.WARNING, errorMsg, ex);
+                return OBJECT_MAPPER.readTree(file);
+            } catch (IOException ioe) {
+                LOGGER.log(
+                        Level.WARNING,
+                        String.format(
+                                "An error occured reading file %s",
+                                file.getName()
+                        ),
+                        ioe
+                );
             }
-        }
-        return null;
+            return null;
+        });
     }
-
+    
     /**
-     * *
      * Allow user to select a preference file to load from the supplied
      * directory.
      *
-     * @param loadDir the directory location of the JSON files as a string
-     *
-     * @return The JsonNode of the selected preference or null if nothing is
-     * selected
+     * @param loadDir directory name within the users directory to load the
+     *     preference file from or empty if it is to be loaded at the top level
+     * @return the processed JSON of the selected preference file or null if nothing
+     *     is selected
+     * @see #loadJsonPreferences(Optional, Optional, Function) 
+     * @deprecated use {@link #loadJsonPreferences(Optional, Class)} instead
      */
-    public static JsonNode loadJsonPreferences(final String loadDir) {
-        return loadJsonPreferences(loadDir, "");
+    @Deprecated
+    public static JsonNode loadJsonPreferences(final Optional<String> loadDir) {
+        return loadJsonPreferences(loadDir, Optional.empty());
     }
 
+    /**
+     * Allow user to select a preference file to load from the supplied
+     * directory. If filePrefix was provided, then only files prefixed with this
+     * value are available to the user to load.
+     *
+     * @param <T> the class that the JSON file to be loaded will be in
+     * @param loadDir directory name within the users directory to load the
+     *     preference file from or empty if it is to be loaded at the top level
+     * @param filePrefix prefix that is expected to be pre-pended to the file name
+     *     of the preference file being loaded or empty if no prefix filter is required
+     * @param expectedFormat
+     * @return the de-serialized JSON in the requested format
+     * @see #loadJsonPreferences(Optional, Optional, Function) 
+     */
+    public static <T> T loadJsonPreferences(final Optional<String> loadDir,
+                                            final Optional<String> filePrefix,
+                                            final Class<T> expectedFormat) {
+        return loadJsonPreferences(loadDir, filePrefix, file -> {
+            try {
+                return OBJECT_MAPPER.readValue(file, expectedFormat);
+            } catch (IOException ioe) {
+                LOGGER.log(
+                        Level.WARNING,
+                        String.format(
+                                "An error occured reading file %s",
+                                file.getName()
+                        ),
+                        ioe
+                );
+            }
+            return null;
+        });
+    }
+    
+    /**
+     * Allow user to select a preference file to load from the supplied
+     * directory. If filePrefix was provided, then only files prefixed with this
+     * value are available to the user to load.
+     *
+     * @param <T> the class that the JSON file to be loaded will be in
+     * @param loadDir directory name within the users directory to load the
+     *     preference file from or empty if it is to be loaded at the top level
+     * @param expectedFormat the class representing the JSON in the file to
+     *     be loaded
+     * @return the de-serialized JSON in the requested format
+     * @see #loadJsonPreferences(Optional, Optional, Function) 
+     */
+    public static <T> T loadJsonPreferences(final Optional<String> loadDir,
+                                            final Class<T> expectedFormat) {
+        return loadJsonPreferences(loadDir, Optional.empty(), expectedFormat);
+    }
+    
     /**
      * Deletes the selected JSON file from disk.
      *
      * @param filename name of file to delete
+     * @param loadDir directory name within the users directory to remove the
+     *     preference file from or empty if it is to be removed at the top level
+     * @param filePrefix prefix that is expected to be pre-pended to the file name
+     *     of the preference file being deleted or empty if no prefix filter is required
      */
-    public static void deleteJsonPreference(final String filename) {
-        final Preferences prefs = NbPreferences.forModule(ApplicationPreferenceKeys.class);
-        final String userDir = ApplicationPreferenceKeys.getUserDir(prefs);
-        final File prefDir = new File(userDir, currentDir);
+    public static void deleteJsonPreference(final String filename,
+                                            final Optional<String> loadDir,
+                                            final Optional<String> filePrefix) {
+        final File preferenceDirectory = getPrefereceFileDirectory(loadDir);
 
         if (filename != null) {
-            final String encodedFilename = FilenameEncoder.encode(currentPrefix.concat(filename)) + FILE_EXT;
-
-            // Loop through files in preference directory looking for one matching selected item
-            // delete it when found
-            if (prefDir.isDirectory()) {
-                for (File file : prefDir.listFiles()) {
-                    if (file.getName().equals(encodedFilename)) {
-                        boolean result = file.delete();
-                        if (!result) {
-                            final String msg = String.format("Failed to delete file %s from disk", file.getName());
-                            final NotifyDescriptor nd = new NotifyDescriptor.Message(msg, NotifyDescriptor.ERROR_MESSAGE);
-                            DialogDisplayer.getDefault().notify(nd);
-                        }
-                        break;
-                    }
-                }
+            // Re-add the prefix and extension
+            final File fileToDelete = new File(
+                    preferenceDirectory,
+                    FilenameEncoder.encode(filePrefix.orElse("").concat(filename)) + FILE_EXT
+            );
+            
+            // Attempt to delete
+            if (!fileToDelete.delete()) {
+                final NotifyDescriptor nd = new NotifyDescriptor.Message(
+                        String.format("Failed to delete file %s from disk", fileToDelete.getName()),
+                        NotifyDescriptor.ERROR_MESSAGE
+                );
+                DialogDisplayer.getDefault().notify(nd);
             }
         }
     }
     
-    private static File getPrefereceFileDirectory(final String subDirectory) {
+    /**
+     * Allow user to select a preference file to load from the supplied
+     * directory. If filePrefix was provided, then only files prefixed with this
+     * value are available to the user to load.
+     *
+     * @param loadDir directory name within the users directory to load the
+     *     preference file from or empty if it is to be loaded at the top level
+     * @param filePrefix prefix that is expected to be pre-pended to the file name
+     *     of the preference file being loaded or empty if no prefix filter is required
+     * @param deserializationFunction a function that take the file to be loaded and
+     *     de-serializes the JSON in the required class
+     * @return the processed JSON of the selected preference file or null if nothing
+     *     is selected
+     */
+    protected static <T> T loadJsonPreferences(final Optional<String> loadDir,
+                                               final Optional<String> filePrefix,
+                                               final Function<File, T> deserializationFunction) {
+        final File preferenceDirectory = getPrefereceFileDirectory(loadDir);
+        
+        // List the files in the supplied directory that have the required file extension
+        // and if filePrefix was supplied, start with the provided prefix.
+        final String[] names;
+        if (preferenceDirectory.isDirectory()) {
+            names = preferenceDirectory.list((File dir, String name) -> {
+                return name.toLowerCase().endsWith(FILE_EXT)
+                        && (filePrefix.isEmpty() || name.toLowerCase().startsWith(filePrefix.get()));
+            });
+        } else {
+            // Nothing to select from - return an empty array
+            names = new String[0];
+        }
+
+        // Remove the prefix and suffix from the names and pass to the selection dialog
+        final int filePrefixLength = filePrefix.orElse("").length();
+        final Optional<String> selectedFileName = JsonIODialog.getSelection(
+                Arrays.stream(names)
+                        .map(name -> FilenameEncoder.decode(name.substring(0, name.length() - 5)))
+                        .filter(StringUtils::isNotBlank)
+                        .map(name -> name.substring(filePrefixLength))
+                        .collect(Collectors.toList()),
+                loadDir,
+                filePrefix
+        );
+        
+        // Re-add the prefix and suffix, then serialize the preferences to the file
+        if (selectedFileName.isPresent()) {
+            final String prefixedFilename = filePrefix.orElse("")
+                        .concat(selectedFileName.get());
+            return deserializationFunction.apply(
+                    new File(
+                            preferenceDirectory,
+                            FilenameEncoder.encode(prefixedFilename) + FILE_EXT
+                    )
+            );
+        }
+        return null;
+    }
+    
+    /**
+     * Gets the preference file directory and appends the passed sub directory
+     * path to it. If the complete directory path is not present, it will attempt
+     * to create it.
+     *
+     * @param subDirectory the directory path to append to the system preferences
+     *     directory path
+     * @return a file with the passed sub directory appended to the system
+     *     preferences directory path
+     */
+    protected static File getPrefereceFileDirectory(final Optional<String> subDirectory) {
         final Preferences prefs = NbPreferences.forModule(ApplicationPreferenceKeys.class);
         final String userDir = ApplicationPreferenceKeys.getUserDir(prefs);
         
-        return new File(userDir, subDirectory);
+        final File preferenceDirectory = new File(userDir, subDirectory.orElse(""));
+        
+        if (!preferenceDirectory.exists()) {
+            preferenceDirectory.mkdir();
+        }
+        
+        return preferenceDirectory;
     }
 }

--- a/CoreUtilities/src/au/gov/asd/tac/constellation/utilities/genericjsonio/JsonIO.java
+++ b/CoreUtilities/src/au/gov/asd/tac/constellation/utilities/genericjsonio/JsonIO.java
@@ -17,17 +17,16 @@ package au.gov.asd.tac.constellation.utilities.genericjsonio;
 
 import au.gov.asd.tac.constellation.preferences.ApplicationPreferenceKeys;
 import au.gov.asd.tac.constellation.utilities.file.FilenameEncoder;
+import au.gov.asd.tac.constellation.utilities.gui.NotifyDisplayer;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import java.io.File;
 import java.io.IOException;
-import java.nio.file.DirectoryNotEmptyException;
 import java.nio.file.Files;
 import java.time.Instant;
 import java.time.ZoneId;
-import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
 import java.util.Optional;
@@ -125,11 +124,10 @@ public class JsonIO {
         
         // If the preference directory cannot be accessed then return
         if (!preferenceDirectory.isDirectory()) {
-            final NotifyDescriptor nd = new NotifyDescriptor.Message(
+            NotifyDisplayer.display(
                     String.format("Can't create preference directory '%s'.", preferenceDirectory),
                     NotifyDescriptor.ERROR_MESSAGE
             );
-            DialogDisplayer.getDefault().notify(nd);
             
             return;
         }
@@ -188,12 +186,11 @@ public class JsonIO {
                                 preferenceFile.getPath()
                         )
                 );
-            } catch (IOException ex) {
-                final NotifyDescriptor nd = new NotifyDescriptor.Message(
+            } catch (final IOException ex) {
+                NotifyDisplayer.display(
                         String.format("Can't save preference file: %s", ex.getMessage()),
                         NotifyDescriptor.ERROR_MESSAGE
                 );
-                DialogDisplayer.getDefault().notify(nd);
             }
         }
     }
@@ -234,7 +231,7 @@ public class JsonIO {
         return loadJsonPreferences(loadDir, filePrefix, file -> {
             try {
                 return OBJECT_MAPPER.readTree(file);
-            } catch (IOException ioe) {
+            } catch (final IOException ioe) {
                 LOGGER.log(
                         Level.WARNING,
                         String.format(
@@ -284,7 +281,7 @@ public class JsonIO {
         return loadJsonPreferences(loadDir, filePrefix, file -> {
             try {
                 return OBJECT_MAPPER.readValue(file, expectedFormat);
-            } catch (IOException ioe) {
+            } catch (final IOException ioe) {
                 LOGGER.log(
                         Level.WARNING,
                         String.format(
@@ -339,13 +336,12 @@ public class JsonIO {
             
             // Attempt to delete
             try {
-                Files.delete(fileToDelete.toPath());
-            } catch (SecurityException | IOException ex) {
-                final NotifyDescriptor nd = new NotifyDescriptor.Message(
+                Files.deleteIfExists(fileToDelete.toPath());
+            } catch (final SecurityException | IOException ex) {
+                NotifyDisplayer.display(
                         String.format("Failed to delete file %s from disk", fileToDelete.getName()),
                         NotifyDescriptor.ERROR_MESSAGE
                 );
-                DialogDisplayer.getDefault().notify(nd);
             }
         }
     }

--- a/CoreUtilities/src/au/gov/asd/tac/constellation/utilities/genericjsonio/JsonIODialog.java
+++ b/CoreUtilities/src/au/gov/asd/tac/constellation/utilities/genericjsonio/JsonIODialog.java
@@ -28,59 +28,74 @@ import javafx.scene.control.ListView;
 import javafx.scene.control.TextInputDialog;
 
 /**
- * Displays a generic dialog window that can allow the user to select a Json
- * preference from a list
+ * Displays a generic dialog window that can allow the user to select a file
+ * name from a list of provided files.
  *
  * @author formalhaut69
  * @author serpens24
  */
 public class JsonIODialog {
-
-    /**
-     * Private constructor to hide implicit public one.
-     */
+    private static final String REMOVE_BUTTON_TEXT = "Remove";
+    
+    private static final String PREFERENCE_SELECTION_DIALOG_TITLE = "Preferences";
+    private static final String PREFERENCE_SELECTION_DIALOG_HEADER_TEXT = "Select a preference to load.";
+    
+    private static final String PREFERENCE_NAME_DIALOG_TITLE = "Preference Name";
+    private static final String PREFERENCE_NAME_DIALOG_HEADER_TEXT = "Enter a name for the preference";
+    
     private JsonIODialog() {
-        throw new IllegalStateException("Invalid call to private default constructor");
     }
 
     /**
-     * *
-     * Present a dialog allowing user to select an entry from a list of
-     * available files.
+     * Present a dialog allowing the user to select an entry from a list of
+     * available files. The user is also able to select one or more files
+     * from that list and delete them before selecting one for the closure
+     * of the dialog.
      *
      * @param names list of filenames to choose from
      * @return the selected element text or null if nothing was selected
      */
     public static String getSelection(final String[] names) {
         final Alert dialog = new Alert(Alert.AlertType.CONFIRMATION);
-        final ObservableList<String> q = FXCollections.observableArrayList(names);
-        final ListView<String> nameList = new ListView<>(q);
-
-        nameList.setCellFactory(p -> new DraggableCell<>());
+        
+        final ObservableList<String> observableNamesList = FXCollections.observableArrayList(names);
+        
+        final ListView<String> nameList = new ListView<>(observableNamesList);
+        nameList.setCellFactory(param -> new DraggableCell<>());
         nameList.setEditable(false);
         nameList.setOnMouseClicked(event -> {
             if (event.getClickCount() > 1) {
                 dialog.setResult(ButtonType.OK);
             }
         });
-        ButtonType removeButton = new ButtonType("Remove");
+        
+        final ButtonType removeButtonType = new ButtonType(REMOVE_BUTTON_TEXT);
+        
         dialog.getDialogPane().setContent(nameList);
-        dialog.getButtonTypes().add(removeButton);
+        dialog.getButtonTypes().add(removeButtonType);
         dialog.setResizable(false);
-        dialog.setTitle("Preferences");
-        dialog.setHeaderText("Select a preference to load.");
+        dialog.setTitle(PREFERENCE_SELECTION_DIALOG_TITLE);
+        dialog.setHeaderText(PREFERENCE_SELECTION_DIALOG_HEADER_TEXT);
 
-        // The remove button has been wrapped inside the btOk, this has been done because any ButtonTypes added
-        // to an alert window will automatically close the window when pressed. 
-        // Wrapping it in another button can allow us to consume the closing event and keep the window open.
-        final Button btOk = (Button) dialog.getDialogPane().lookupButton(removeButton);
-        btOk.addEventFilter(ActionEvent.ACTION, event -> {
+        // The remove button has been wrapped inside the removeButtonType, this
+        // has been done because any ButtonTypes added to an alert window will
+        // automatically close the window when pressed. Wrapping it in another button
+        // can allow us to consume the closing event and keep the window open.
+        final Button removeButton = (Button) dialog.getDialogPane().lookupButton(removeButtonType);
+        
+        // The remove button has been pressed, delete the selected file and
+        // update the list by removing the selected file
+        removeButton.addEventFilter(ActionEvent.ACTION, event -> {
             JsonIO.deleteJsonPreference(nameList.getSelectionModel().getSelectedItem());
-            q.remove(nameList.getSelectionModel().getSelectedItem());
-            nameList.setCellFactory(p -> new DraggableCell<>());
+            
+            observableNamesList.remove(nameList.getSelectionModel().getSelectedItem());
+            nameList.setCellFactory(param -> new DraggableCell<>());
+            
             dialog.getDialogPane().setContent(nameList);
+            
             event.consume();
         });
+        
         final Optional<ButtonType> option = dialog.showAndWait();
         if (option.isPresent() && option.get() == ButtonType.OK) {
             return nameList.getSelectionModel().getSelectedItem();
@@ -91,27 +106,16 @@ public class JsonIODialog {
 
     /**
      * Displays a small window allowing the user to enter a name for the new
-     * preference
+     * preference file.
      *
-     * @author formalhaut69
-     * @return A tuple, the first item is a Boolean indicating whether the user
-     * selected to proceed with the operation or not, the second is the name of
-     * the file requested by the user.
+     * @return an optional name for the new file, empty if the dialog was closed
+     *     without entering a name for the file
      */
-    public static Tuple<Boolean, String> getName() {
-        String returnedName = "";
-
-        // opens up a slightly different dialog window to allow the user to name the
-        // preference when it is being saved
-        // create a text input dialog 
-        TextInputDialog td = new TextInputDialog();
-        td.setTitle("Preference name");
-        // setHeaderText 
-        td.setHeaderText("Enter a name for the preference");
-        Optional<String> result = td.showAndWait();
-        if (result.isPresent()) {
-            returnedName = td.getEditor().getText();
-        }
-        return new Tuple<>(result.isPresent(), returnedName);
+    public static Optional<String> getPreferenceFileName() {
+        final TextInputDialog td = new TextInputDialog();
+        td.setTitle(PREFERENCE_NAME_DIALOG_TITLE);
+        td.setHeaderText(PREFERENCE_NAME_DIALOG_HEADER_TEXT);
+        
+        return td.showAndWait();
     }
 }

--- a/CoreUtilities/src/au/gov/asd/tac/constellation/utilities/genericjsonio/JsonIODialog.java
+++ b/CoreUtilities/src/au/gov/asd/tac/constellation/utilities/genericjsonio/JsonIODialog.java
@@ -15,8 +15,8 @@
  */
 package au.gov.asd.tac.constellation.utilities.genericjsonio;
 
-import au.gov.asd.tac.constellation.utilities.datastructure.Tuple;
 import au.gov.asd.tac.constellation.utilities.gui.DraggableCell;
+import java.util.List;
 import java.util.Optional;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
@@ -52,10 +52,15 @@ public class JsonIODialog {
      * from that list and delete them before selecting one for the closure
      * of the dialog.
      *
-     * @param names list of filenames to choose from
+     * @param names list of file names to choose from
+     * @param loadDir the relative directory path from the user home preference directory
+     *     that the file names are located
+     * @param filePrefix the prefix if any that was removed from the file names
      * @return the selected element text or null if nothing was selected
      */
-    public static String getSelection(final String[] names) {
+    public static Optional<String> getSelection(final List<String> names,
+                                                final Optional<String> loadDir,
+                                                final Optional<String> filePrefix) {
         final Alert dialog = new Alert(Alert.AlertType.CONFIRMATION);
         
         final ObservableList<String> observableNamesList = FXCollections.observableArrayList(names);
@@ -86,7 +91,10 @@ public class JsonIODialog {
         // The remove button has been pressed, delete the selected file and
         // update the list by removing the selected file
         removeButton.addEventFilter(ActionEvent.ACTION, event -> {
-            JsonIO.deleteJsonPreference(nameList.getSelectionModel().getSelectedItem());
+            JsonIO.deleteJsonPreference(
+                    nameList.getSelectionModel().getSelectedItem(),
+                    loadDir,filePrefix
+            );
             
             observableNamesList.remove(nameList.getSelectionModel().getSelectedItem());
             nameList.setCellFactory(param -> new DraggableCell<>());
@@ -98,10 +106,10 @@ public class JsonIODialog {
         
         final Optional<ButtonType> option = dialog.showAndWait();
         if (option.isPresent() && option.get() == ButtonType.OK) {
-            return nameList.getSelectionModel().getSelectedItem();
+            return Optional.ofNullable(nameList.getSelectionModel().getSelectedItem());
         }
 
-        return null;
+        return Optional.empty();
     }
 
     /**

--- a/CoreUtilities/src/au/gov/asd/tac/constellation/utilities/genericjsonio/JsonIODialog.java
+++ b/CoreUtilities/src/au/gov/asd/tac/constellation/utilities/genericjsonio/JsonIODialog.java
@@ -93,7 +93,8 @@ public class JsonIODialog {
         removeButton.addEventFilter(ActionEvent.ACTION, event -> {
             JsonIO.deleteJsonPreference(
                     nameList.getSelectionModel().getSelectedItem(),
-                    loadDir,filePrefix
+                    loadDir,
+                    filePrefix
             );
             
             observableNamesList.remove(nameList.getSelectionModel().getSelectedItem());

--- a/CoreUtilities/test/unit/src/au/gov/asd/tac/constellation/utilities/genericjsonio/JsonIODialogNGTest.java
+++ b/CoreUtilities/test/unit/src/au/gov/asd/tac/constellation/utilities/genericjsonio/JsonIODialogNGTest.java
@@ -17,19 +17,11 @@ package au.gov.asd.tac.constellation.utilities.genericjsonio;
 
 import java.util.List;
 import java.util.Optional;
-import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
-import javafx.scene.Node;
-import javafx.scene.Parent;
 import javafx.scene.control.Button;
-import javafx.scene.control.ButtonBar;
-import javafx.scene.control.ButtonType;
-import javafx.scene.control.DialogPane;
 import javafx.scene.control.ListCell;
-import javafx.scene.control.ListView;
 import javafx.scene.control.TextField;
-import javafx.scene.input.MouseButton;
 import javafx.stage.Modality;
 import javafx.stage.Stage;
 import org.testfx.api.FxRobot;
@@ -57,21 +49,20 @@ public class JsonIODialogNGTest {
 
     @BeforeClass
     public static void setUpClass() throws Exception {
-        FxToolkit.registerPrimaryStage();
-        FxToolkit.showStage();
     }
 
     @AfterClass
     public static void tearDownClass() throws Exception {
-        FxToolkit.hideStage();
     }
 
     @BeforeMethod
     public void setUpMethod() throws Exception {
+        FxToolkit.registerPrimaryStage();
     }
 
     @AfterMethod
     public void tearDownMethod() throws Exception {
+        FxToolkit.cleanupStages();
     }
     
     @Test

--- a/CoreUtilities/test/unit/src/au/gov/asd/tac/constellation/utilities/genericjsonio/JsonIODialogNGTest.java
+++ b/CoreUtilities/test/unit/src/au/gov/asd/tac/constellation/utilities/genericjsonio/JsonIODialogNGTest.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2010-2021 Australian Signals Directorate
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package au.gov.asd.tac.constellation.utilities.genericjsonio;
+
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.Future;
+import javafx.scene.Node;
+import javafx.scene.control.Button;
+import javafx.scene.input.MouseButton;
+import javafx.stage.Modality;
+import javafx.stage.Window;
+import org.testfx.api.FxRobot;
+import org.testfx.api.FxToolkit;
+import org.testfx.util.WaitForAsyncUtils;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+/**
+ *
+ * @author formalhaunt
+ */
+public class JsonIODialogNGTest {
+    
+    public JsonIODialogNGTest() {
+    }
+
+    @BeforeClass
+    public static void setUpClass() throws Exception {
+        FxToolkit.registerPrimaryStage();
+        FxToolkit.showStage();
+    }
+
+    @AfterClass
+    public static void tearDownClass() throws Exception {
+        FxToolkit.hideStage();
+    }
+
+    @BeforeMethod
+    public void setUpMethod() throws Exception {
+    }
+
+    @AfterMethod
+    public void tearDownMethod() throws Exception {
+    }
+    
+    @Test
+    public void getSelection_ok_pressed() {
+        
+    }
+    
+    @Test
+    public void getPreferenceFileName_ok_pressed() {
+        final Future<Optional<String>> future = WaitForAsyncUtils.asyncFx(
+                () -> JsonIODialog.getPreferenceFileName());
+        
+        final FxRobot robot = new FxRobot();
+        
+        final Window dialog = getDialog(robot);
+        
+        final String input = "myPreferenceFile";
+        
+        final Node textField = robot.rootNode(dialog.getScene()).lookup(".text-field");
+        robot.clickOn(textField);
+        robot.write(input);
+        
+        final Set<Node> buttons = robot.rootNode(dialog.getScene()).lookupAll(".button");
+        
+        final Optional<Button> okButton = findButton(buttons, "OK");
+        
+        robot.clickOn(okButton.get(), MouseButton.PRIMARY);
+        
+        final Optional<String> result = WaitForAsyncUtils.waitFor(future);
+        
+        assertEquals(input, result.get());
+    }
+    
+    @Test
+    public void getPreferenceFileName_cancel_pressed() {
+        final Future<Optional<String>> future = WaitForAsyncUtils.asyncFx(
+                () -> JsonIODialog.getPreferenceFileName());
+        
+        FxRobot robot = new FxRobot();
+        
+        final Window dialog = getDialog(robot);
+        
+        final Node textField = robot.rootNode(dialog.getScene()).lookup(".text-field");
+        robot.clickOn(textField);
+        robot.write("myPreferenceFile");
+        
+        final Set<Node> buttons = robot.rootNode(dialog.getScene()).lookupAll(".button");
+        
+        final Optional<Button> cancelButton = findButton(buttons, "Cancel");
+        
+        robot.clickOn(cancelButton.get(), MouseButton.PRIMARY);
+        
+        final Optional<String> result = WaitForAsyncUtils.waitFor(future);
+        
+        assertFalse(result.isPresent());
+    }
+    
+    private Optional<Button> findButton(final Set<Node> buttons,
+                                        final String expectedText) {
+        return buttons.stream()
+                .map(node -> (Button) node)
+                .filter(button -> expectedText.equals(button.getText()))
+                .findFirst();
+    }
+    
+    private Window getDialog(final FxRobot robot) {
+        Window dialog = null;
+        while(dialog == null) {
+            dialog = robot.robotContext().getWindowFinder().listWindows().stream()
+                    .filter(window -> window instanceof javafx.stage.Stage)
+                    .map(window -> (javafx.stage.Stage) window)
+                    .filter(stage -> stage.getModality() == Modality.APPLICATION_MODAL)
+                    .findFirst()
+                    .orElse(null);
+            
+            Thread.yield();
+        }
+        
+        return dialog;
+    }
+    
+}

--- a/CoreUtilities/test/unit/src/au/gov/asd/tac/constellation/utilities/genericjsonio/JsonIONGTest.java
+++ b/CoreUtilities/test/unit/src/au/gov/asd/tac/constellation/utilities/genericjsonio/JsonIONGTest.java
@@ -296,11 +296,9 @@ public class JsonIONGTest {
                 MockedStatic<JsonIODialog> jsonIoDialogMockedStatic = Mockito.mockStatic(JsonIODialog.class);
                 MockedStatic<DialogDisplayer> dialogDisplayerMockedStatic = Mockito.mockStatic(DialogDisplayer.class);
             ) {
-            
-            outputFile.delete();
-            
+            final File preferenceDirectory = new File(System.getProperty("java.io.tmpdir") + "/samplefile");
             jsonIoMockedStatic.when(() -> JsonIO.getPrefereceFileDirectory(SUB_DIRECTORY))
-                    .thenReturn(new File(System.getProperty("java.io.tmpdir") + "/samplefile"));
+                    .thenReturn(preferenceDirectory);
             
             jsonIoMockedStatic.when(() -> JsonIO
                     .saveJsonPreferences(any(Optional.class), any(ObjectMapper.class), any(), any(Optional.class)))
@@ -320,7 +318,7 @@ public class JsonIONGTest {
             final ArgumentCaptor<NotifyDescriptor> captor = ArgumentCaptor.forClass(NotifyDescriptor.class);
             verify(dialogDisplayer).notify(captor.capture());
             assertEquals(captor.getValue().getMessage(), "Can't create preference directory '"
-                    + System.getProperty("java.io.tmpdir") + "samplefile'.");
+                    + preferenceDirectory + "'.");
             assertEquals(captor.getValue().getMessageType(), NotifyDescriptor.ERROR_MESSAGE);
         } finally {
             Files.deleteIfExists(outputFile.toPath());
@@ -336,9 +334,6 @@ public class JsonIONGTest {
                 MockedStatic<JsonIO> jsonIoMockedStatic = Mockito.mockStatic(JsonIO.class);
                 MockedStatic<JsonIODialog> jsonIoDialogMockedStatic = Mockito.mockStatic(JsonIODialog.class);
             ) {
-            // Ensure there is not old test data lying around
-            outputFile.delete();
-            
             setupStaticMocksForSavePreference(jsonIoMockedStatic, jsonIoDialogMockedStatic, Optional.empty());
             
             JsonIO.saveJsonPreferences(SUB_DIRECTORY, new ObjectMapper(), new Object(), FILE_PREFIX);

--- a/CoreUtilities/test/unit/src/au/gov/asd/tac/constellation/utilities/genericjsonio/JsonIONGTest.java
+++ b/CoreUtilities/test/unit/src/au/gov/asd/tac/constellation/utilities/genericjsonio/JsonIONGTest.java
@@ -1,0 +1,339 @@
+/*
+ * Copyright 2010-2021 Australian Signals Directorate
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package au.gov.asd.tac.constellation.utilities.genericjsonio;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Function;
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.testfx.api.FxToolkit;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+/**
+ *
+ * @author formalhaunt
+ */
+public class JsonIONGTest {
+    public JsonIONGTest() {
+    }
+
+    @BeforeClass
+    public static void setUpClass() throws Exception {
+        FxToolkit.registerPrimaryStage();
+        FxToolkit.showStage();
+    }
+
+    @AfterClass
+    public static void tearDownClass() throws Exception {
+        FxToolkit.hideStage();
+    }
+
+    @BeforeMethod
+    public void setUpMethod() throws Exception {
+    }
+
+    @AfterMethod
+    public void tearDownMethod() throws Exception {
+    }
+    
+    @Test
+    public void loadJsonPreferences_get_pojo() throws URISyntaxException {
+        
+        try (
+                MockedStatic<JsonIO> jsonIoMockedStatic = Mockito.mockStatic(JsonIO.class);
+                MockedStatic<JsonIODialog> jsonIoDialogMockedStatic = Mockito.mockStatic(JsonIODialog.class);
+            ) {
+            
+            final Optional<String> subDirectory = Optional.of("test");
+            final Optional<String> filePrefix = Optional.of("my-");
+            
+            jsonIoDialogMockedStatic.when(() -> JsonIODialog.getSelection(List.of("preferences"), subDirectory, filePrefix))
+                    .thenReturn(Optional.of("preferences"));
+            
+            jsonIoMockedStatic.when(() -> JsonIO.getPrefereceFileDirectory(subDirectory))
+                    .thenReturn(new File(JsonIONGTest.class.getResource("resources").toURI()));
+            
+            jsonIoMockedStatic.when(() -> JsonIO
+                    .loadJsonPreferences(subDirectory, filePrefix, MyPreferences.class))
+                    .thenCallRealMethod();
+            
+            jsonIoMockedStatic.when(() -> JsonIO
+                    .loadJsonPreferences(eq(subDirectory), eq(filePrefix), any(Function.class)))
+                    .thenCallRealMethod();
+            
+            final MyPreferences loadedPreferences = JsonIO
+                    .loadJsonPreferences(subDirectory, filePrefix, MyPreferences.class);
+            
+            final MyPreferences expectedPreferences = new MyPreferences();
+            expectedPreferences.setName("Joe Bloggs");
+            expectedPreferences.setVolume(5);
+            
+            assertEquals(loadedPreferences, expectedPreferences);
+        }
+    }
+    
+    @Test
+    public void loadJsonPreferences_get_tree() throws URISyntaxException {
+        
+        try (
+                MockedStatic<JsonIO> jsonIoMockedStatic = Mockito.mockStatic(JsonIO.class);
+                MockedStatic<JsonIODialog> jsonIoDialogMockedStatic = Mockito.mockStatic(JsonIODialog.class);
+            ) {
+            
+            final Optional<String> subDirectory = Optional.of("test");
+            final Optional<String> filePrefix = Optional.empty();
+            
+            jsonIoDialogMockedStatic.when(() -> JsonIODialog.getSelection(List.of("my-preferences"), subDirectory, filePrefix))
+                    .thenReturn(Optional.of("my-preferences"));
+            
+            jsonIoMockedStatic.when(() -> JsonIO.getPrefereceFileDirectory(subDirectory))
+                    .thenReturn(new File(JsonIONGTest.class.getResource("resources").toURI()));
+            
+            jsonIoMockedStatic.when(() -> JsonIO
+                    .loadJsonPreferences(subDirectory, filePrefix))
+                    .thenCallRealMethod();
+            
+            jsonIoMockedStatic.when(() -> JsonIO
+                    .loadJsonPreferences(eq(subDirectory), eq(filePrefix), any(Function.class)))
+                    .thenCallRealMethod();
+            
+            final JsonNode loadedPreferences = JsonIO
+                    .loadJsonPreferences(subDirectory, filePrefix);
+            
+            final JsonNode expectedJsonNode = new ObjectMapper()
+                    .createObjectNode()
+                    .put("name", "Joe Bloggs")
+                    .put("volume", 5);
+            
+            assertEquals(loadedPreferences, expectedJsonNode);
+            
+        }
+    }
+    
+    @Test
+    public void saveJsonPreferences() throws URISyntaxException, FileNotFoundException, IOException {
+        
+        try (
+                MockedStatic<JsonIO> jsonIoMockedStatic = Mockito.mockStatic(JsonIO.class);
+                MockedStatic<JsonIODialog> jsonIoDialogMockedStatic = Mockito.mockStatic(JsonIODialog.class);
+            ) {
+            
+            final File outputFile = new File(System.getProperty("java.io.tmpdir") + "/my-preferences.json");
+            
+            // Ensure there is not old test data lying around
+            outputFile.delete();
+            
+            final Optional<String> subDirectory = Optional.of("test");
+            final Optional<String> filePrefix = Optional.of("my-");
+            
+            jsonIoDialogMockedStatic.when(JsonIODialog::getPreferenceFileName).thenReturn(Optional.of("preferences"));
+            
+            jsonIoMockedStatic.when(() -> JsonIO.getPrefereceFileDirectory(subDirectory))
+                    .thenReturn(new File(System.getProperty("java.io.tmpdir")));
+            
+            jsonIoMockedStatic.when(() -> JsonIO
+                    .saveJsonPreferences(eq(subDirectory), any(ObjectMapper.class), any(Object.class), eq(filePrefix)))
+                    .thenCallRealMethod();
+            
+            final MyPreferences myPreferences = new MyPreferences();
+            myPreferences.setName("Joe Bloggs");
+            myPreferences.setVolume(5);
+            
+            JsonIO.saveJsonPreferences(subDirectory, new ObjectMapper(), myPreferences, filePrefix);
+                       
+            final String output = IOUtils.toString(
+                    new FileInputStream(outputFile), StandardCharsets.UTF_8);
+            
+            final String expectedOutput = IOUtils.toString(
+                    new FileInputStream(new File(JsonIONGTest.class.getResource("resources/my-preferences.json").toURI())), StandardCharsets.UTF_8);
+            
+            // Clean up
+            outputFile.delete();
+            
+            assertEquals(output, expectedOutput);
+        }
+    }
+    
+    @Test
+    public void saveJsonPreferences_pref_dir_not_a_dir() throws URISyntaxException, FileNotFoundException, IOException {
+        
+        try (
+                MockedStatic<JsonIO> jsonIoMockedStatic = Mockito.mockStatic(JsonIO.class);
+                MockedStatic<JsonIODialog> jsonIoDialogMockedStatic = Mockito.mockStatic(JsonIODialog.class);
+            ) {
+            
+            final File outputFile = new File(System.getProperty("java.io.tmpdir") + "/my-preferences.json");
+            outputFile.delete();
+            
+            final Optional<String> subDirectory = Optional.of("test");
+            final Optional<String> filePrefix = Optional.of("my-");
+            
+            jsonIoMockedStatic.when(() -> JsonIO.getPrefereceFileDirectory(subDirectory))
+                    .thenReturn(new File(System.getProperty("java.io.tmpdir") + "/samplefile"));
+            
+            jsonIoMockedStatic.when(() -> JsonIO
+                    .saveJsonPreferences(eq(subDirectory), any(ObjectMapper.class), any(Object.class), eq(filePrefix)))
+                    .thenCallRealMethod();
+            
+            JsonIO.saveJsonPreferences(subDirectory, null, null, filePrefix);
+                       
+            jsonIoDialogMockedStatic.verifyNoInteractions();
+        }
+    }
+    
+    @Test
+    public void saveJsonPreferences_user_cancels() throws URISyntaxException, FileNotFoundException, IOException {
+        
+        try (
+                MockedStatic<JsonIO> jsonIoMockedStatic = Mockito.mockStatic(JsonIO.class);
+                MockedStatic<JsonIODialog> jsonIoDialogMockedStatic = Mockito.mockStatic(JsonIODialog.class);
+            ) {
+            
+            final File outputFile = new File(System.getProperty("java.io.tmpdir") + "/my-preferences.json");
+            
+            // Ensure there is not old test data lying around
+            outputFile.delete();
+            
+            final Optional<String> subDirectory = Optional.of("test");
+            final Optional<String> filePrefix = Optional.of("my-");
+            
+            jsonIoDialogMockedStatic.when(JsonIODialog::getPreferenceFileName).thenReturn(Optional.empty());
+            
+            jsonIoMockedStatic.when(() -> JsonIO.getPrefereceFileDirectory(subDirectory))
+                    .thenReturn(new File(System.getProperty("java.io.tmpdir")));
+            
+            jsonIoMockedStatic.when(() -> JsonIO
+                    .saveJsonPreferences(eq(subDirectory), any(ObjectMapper.class), any(Object.class), eq(filePrefix)))
+                    .thenCallRealMethod();
+            
+            JsonIO.saveJsonPreferences(subDirectory, null, null, filePrefix);
+            
+            assertFalse(outputFile.exists());
+            
+            // Clean up
+            outputFile.delete();
+            
+            
+        }
+    }
+    
+    @Test
+    public void deleteJsonPreferences() throws URISyntaxException, FileNotFoundException, IOException {
+        
+        try (MockedStatic<JsonIO> jsonIoMockedStatic = Mockito.mockStatic(JsonIO.class)) {
+            
+            final File outputFile = new File(System.getProperty("java.io.tmpdir") + "/my-preferences.json");
+            
+            // Ensure there is not old test data lying around
+            outputFile.delete();
+            
+            outputFile.createNewFile();
+            
+            assertTrue(outputFile.exists());
+            
+            final Optional<String> subDirectory = Optional.of("test");
+            final Optional<String> filePrefix = Optional.of("my-");
+            
+            jsonIoMockedStatic.when(() -> JsonIO.getPrefereceFileDirectory(subDirectory))
+                    .thenReturn(new File(System.getProperty("java.io.tmpdir")));
+            
+            jsonIoMockedStatic.when(() -> JsonIO
+                    .deleteJsonPreference(eq("preferences"), eq(subDirectory), eq(filePrefix)))
+                    .thenCallRealMethod();
+            
+            JsonIO.deleteJsonPreference("preferences", subDirectory, filePrefix);
+            
+            assertFalse(outputFile.exists());
+        }
+    }
+    
+    static class MyPreferences {
+        private String name;
+        private int volume;
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        public int getVolume() {
+            return volume;
+        }
+
+        public void setVolume(int volume) {
+            this.volume = volume;
+        }
+        
+        @Override
+        public boolean equals(final Object o) {
+            if (this == o) {
+                return true;
+            }
+
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+
+            final MyPreferences rhs = (MyPreferences) o;
+
+            return new EqualsBuilder()
+                    .append(getName(), rhs.getName())
+                    .append(getVolume(), rhs.getVolume())
+                    .isEquals();
+        }
+
+        @Override
+        public int hashCode() {
+            return new HashCodeBuilder()
+                    .append(getName())
+                    .append(getVolume())
+                    .toHashCode();
+        }
+
+        @Override
+        public String toString() {
+            return new ToStringBuilder(this)
+                    .append("name", getName())
+                    .append("volume", getVolume())
+                    .toString();
+        }
+    }
+}

--- a/CoreUtilities/test/unit/src/au/gov/asd/tac/constellation/utilities/genericjsonio/JsonIONGTest.java
+++ b/CoreUtilities/test/unit/src/au/gov/asd/tac/constellation/utilities/genericjsonio/JsonIONGTest.java
@@ -54,21 +54,20 @@ public class JsonIONGTest {
 
     @BeforeClass
     public static void setUpClass() throws Exception {
-        FxToolkit.registerPrimaryStage();
-        FxToolkit.showStage();
     }
 
     @AfterClass
     public static void tearDownClass() throws Exception {
-        FxToolkit.hideStage();
     }
 
     @BeforeMethod
     public void setUpMethod() throws Exception {
+        FxToolkit.registerPrimaryStage();
     }
 
     @AfterMethod
     public void tearDownMethod() throws Exception {
+        FxToolkit.cleanupStages();
     }
     
     @Test

--- a/CoreUtilities/test/unit/src/au/gov/asd/tac/constellation/utilities/genericjsonio/resources/my-preferences.json
+++ b/CoreUtilities/test/unit/src/au/gov/asd/tac/constellation/utilities/genericjsonio/resources/my-preferences.json
@@ -1,0 +1,4 @@
+{
+  "name" : "Joe Bloggs",
+  "volume" : 5
+}

--- a/docker/netbeans-runner/Dockerfile
+++ b/docker/netbeans-runner/Dockerfile
@@ -16,6 +16,7 @@ RUN apt-get -y update \
     libx11-dev \
     fontconfig \
     ttf-dejavu \
+    libpangoft2-1.0-0 \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
### Description of the Change

Created unit tests for the JSON IO package in the utilities module. Refactored the code to make use of `Optional` where conditional parameters were being returned and provided. Improved comments and simplified some of the code where possible.

Overloaded the load preferences method to allow callers to provide an expected class. This will cause the code to map the loaded JSON into that object rather than returning a JSON Tree. The old methods are still there and this is backwards compatible. I have marked the JSON Tree methods as deprecated. I have also modified the save preferences to take a `Object` rather than a JSON Tree. Now either a JSON Tree or a preference object can be passed and it will be serialized.

The aim of this is a pre-cursor to try and clean up the IO classes that then use those JSON trees. The code is quite complex and results in multiple loops making it very difficult to comprehend what is happening. By serializing and de-serializing the JSON from and into Java POJOs it should become much less complex code. 

### Alternate Designs


### Why Should This Be In Core?

Improves test coverage. Everything is backwards compatible and will help improve code readability in future PRs.

### Benefits

* Improves test coverage
* Simplifies usage of the API

### Possible Drawbacks

N/A

### Verification Process

All unit tests passing and code coverage increased on Sonar.

### Applicable Issues

