### PR TITLE
Attribute bar disappearing on collapse

### DIFF
--- a/CoreImportExportPlugins/src/au/gov/asd/tac/constellation/plugins/importexport/RunPane.java
+++ b/CoreImportExportPlugins/src/au/gov/asd/tac/constellation/plugins/importexport/RunPane.java
@@ -121,7 +121,7 @@ public final class RunPane extends BorderPane implements KeyListener {
         public AttributeBox(final String label, final AttributeList attributeList) {
             final BorderPane borderPane = new BorderPane();
             borderPane.setTop(attributeList);
-
+            
             setMaxHeight(USE_PREF_SIZE);
             setMaxWidth(Double.MAX_VALUE);
             setCenter(borderPane);
@@ -163,12 +163,12 @@ public final class RunPane extends BorderPane implements KeyListener {
         final VBox configBox = new VBox();
         VBox.setVgrow(configBox, Priority.ALWAYS);
 
-        final ScrollPane configScroll = new ScrollPane();
-        configScroll.setMaxWidth(Double.MAX_VALUE);
-        configScroll.setPrefHeight(SCROLLPANE_HEIGHT);
-        configScroll.setHbarPolicy(ScrollPane.ScrollBarPolicy.NEVER);
-        configScroll.setVbarPolicy(ScrollPane.ScrollBarPolicy.AS_NEEDED);
-        setCenter(configBox);
+        final ScrollPane scrollPane = new ScrollPane();
+        scrollPane.setContent(configBox);
+        scrollPane.setFitToWidth(true);
+        scrollPane.setVbarPolicy(ScrollPane.ScrollBarPolicy.AS_NEEDED);
+        
+        setCenter(scrollPane);
 
         filterField = new TextField();
         filterField.setFocusTraversable(false);
@@ -235,7 +235,7 @@ public final class RunPane extends BorderPane implements KeyListener {
         // A scroll pane to hold the attribute boxes
         final ScrollPane attributeScrollPane = new ScrollPane();
         attributeScrollPane.setHbarPolicy(ScrollPane.ScrollBarPolicy.NEVER);
-        attributeScrollPane.setVbarPolicy(ScrollPane.ScrollBarPolicy.ALWAYS);
+        attributeScrollPane.setVbarPolicy(ScrollPane.ScrollBarPolicy.AS_NEEDED);
         attributeScrollPane.setMaxWidth(Double.MAX_VALUE);
         attributeScrollPane.setContent(attributePane);
         attributeScrollPane.setPrefViewportWidth(SCROLLPANE_VIEW_WIDTH);

--- a/CoreImportExportPlugins/src/au/gov/asd/tac/constellation/plugins/importexport/RunPane.java
+++ b/CoreImportExportPlugins/src/au/gov/asd/tac/constellation/plugins/importexport/RunPane.java
@@ -74,7 +74,7 @@ public final class RunPane extends BorderPane implements KeyListener {
     private static final int SCROLLPANE_HEIGHT = 450;
     private static final int SCROLLPANE_VIEW_WIDTH = 400;
     private static final int SCROLLPANE_VIEW_HEIGHT = 900;
-    private static final int SAMPLEVIEW_HEIGHT = 450;
+    private static final int SAMPLEVIEW_HEIGHT = 250;
     private static final int SAMPLEVIEW_MIN_HEIGHT = 130;
     private static final int ATTRIBUTEPANE_PREF_WIDTH = 300;
     private static final int ATTRIBUTEPANE_MIN_WIDTH = 100;
@@ -121,7 +121,7 @@ public final class RunPane extends BorderPane implements KeyListener {
         public AttributeBox(final String label, final AttributeList attributeList) {
             final BorderPane borderPane = new BorderPane();
             borderPane.setTop(attributeList);
-            
+
             setMaxHeight(USE_PREF_SIZE);
             setMaxWidth(Double.MAX_VALUE);
             setCenter(borderPane);
@@ -167,7 +167,6 @@ public final class RunPane extends BorderPane implements KeyListener {
         scrollPane.setContent(configBox);
         scrollPane.setFitToWidth(true);
         scrollPane.setVbarPolicy(ScrollPane.ScrollBarPolicy.AS_NEEDED);
-        
         setCenter(scrollPane);
 
         filterField = new TextField();


### PR DESCRIPTION
<!--

### Requirements

* Filling out the template is required. Any pull request that does not include
enough information to be reviewed in a timely manner may be closed at the
maintainers' discretion.
* Follow the check list items defined by https://github.com/constellation-app/constellation/blob/master/CONTRIBUTING.md#pull-requests
* All new code requires unit tests to ensure they work as expected and will
continue to work as new code is added in the future (regression testing).
* Make sure your branch name is prefixed by `feature`, `bugfix`, `hotfix` or `release`
* Have you read Constellation's Code of Conduct? By filing an issue, you are
expected to comply with it, including treating everyone with respect:
https://github.com/constellation-app/constellation/blob/master/CODE_OF_CONDUCT.md

-->

### Description of the Change

- Added a scroll bar to the content within the run tabs. 
- Changed attribute scroll bar to be as needed instead of always.
- Changed height of sample view to be smaller to remove large blank space

This change was needed for users with small screens/monitors that would experience the attribute collapsible pane disappearing once collapsed. The new change adds a scroll bar that stops the collapsible pane from completely disappearing after being collapsed. The user will be able to see the bar after being collapsed by scrolling to the bottom of the Import From File screen.

![image](https://user-images.githubusercontent.com/88649439/132430500-b4e5612e-a627-472a-93f7-954c1d7d5fad.png)

![image](https://user-images.githubusercontent.com/88649439/132430525-dafd467b-f032-48f4-ae3e-e71ed68acde1.png)


<!--

We must be able to understand the design of your change from this description.
If we can't get a good idea of what the code will be doing from the description
here, the pull request may be closed at the maintainers' discretion. Keep in
mind that the maintainer reviewing this PR may not be familiar with or have
worked with the code here recently, so please walk us through the concepts.

-->

### Alternate Designs

<!--

Explain what other alternates were considered and why the proposed version was
selected.

-->

### Why Should This Be In Core?

Allows users with small monitors to use the import file feature with more ease.
Small monitor uses can also now properly see the attributes when the tab is expanded.

<!--

Explain why this functionality should be in Constellation Core as opposed to a
different module suite. Note that this question is more applicable when adding
new functionality. If this change is a minor update to an existing file then it
is understood that this change has to be to this module suite and a response
and therefore a response to this question is not required.

-->

### Benefits

UX benefits.

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks

The sample height section is slightly smaller so users can not see as many rows as data as they originally could. (I'd like feedback on this one, but my logic was it removed a lot of blank space it was displaying after being placed in a scroll pane - this meant the user had to scroll a lot to get to the attributes. I also figured the important aspect of the table data was the column headings not the data itself.)

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process

- I ensured the views interactive aspects still worked as intended.
- I ensured the attribute bar was still present after being minimized. 

<!--

What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (e.g. buttons you clicked, text you typed,
commands you ran, etc.), and describe the results you observed.

-->

### Applicable Issues

#1255

<!-- Link any applicable issues here -->
