### PR TITLE
:bug: Fix setRotationMatrix to set the right values for a 3x3 matrix, and increase test coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
 -   Removed unused `localized` parameter from the signature of the `locate()`
     method in `ConstellationInstalledFileLocator`.
 
+-   Fixed `setRotationMatrix` in `Matrix44d` as it was previously placing 
+    rotation values in the wrong value positions.
+
 ## Changes in August 2021
 
 -   Added `updateTagsFiltersAvailable`, `updateSelectedTagsCombo`,

--- a/CoreUtilities/src/au/gov/asd/tac/constellation/utilities/graphics/Matrix44d.java
+++ b/CoreUtilities/src/au/gov/asd/tac/constellation/utilities/graphics/Matrix44d.java
@@ -50,20 +50,14 @@ public final class Matrix44d {
     }
 
     public void getRotationMatrix(final Matrix33d dst) {
-//        memcpy(dst, src, sizeof(float)*3); // X column
-//        memcpy(dst+3, src+4, sizeof(float)*3); // Y column
-//        memcpy(dst+6, src+8, sizeof(float)*3); // Z column
         System.arraycopy(a, 0, dst.getA(), 0, 3); // X column
         System.arraycopy(a, 4, dst.getA(), 3, 3); // Y column
         System.arraycopy(a, 8, dst.getA(), 6, 3); // Z column
     }
 
     public void setRotationMatrix(final Matrix33d src) {
-//        memcpy(dst, src, sizeof(float)*4);
-//        memcpy(dst+4, src+4, sizeof(float)*4);
-//        memcpy(dst+8, src+8, sizeof(float)*4);
-        System.arraycopy(src.getA(), 0, a, 0, 4);
-        System.arraycopy(src.getA(), 4, a, 4, 4);
-        System.arraycopy(src.getA(), 8, a, 8, 4);
+        System.arraycopy(src.getA(), 0, a, 0, 3);
+        System.arraycopy(src.getA(), 3, a, 4, 3);
+        System.arraycopy(src.getA(), 6, a, 8, 3);
     }
 }

--- a/CoreUtilities/test/unit/src/au/gov/asd/tac/constellation/utilities/graphics/Matrix44dNGTest.java
+++ b/CoreUtilities/test/unit/src/au/gov/asd/tac/constellation/utilities/graphics/Matrix44dNGTest.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2010-2021 Australian Signals Directorate
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package au.gov.asd.tac.constellation.utilities.graphics;
+
+import java.util.Arrays;
+import static org.testng.Assert.assertEquals;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+/**
+ * @author groombridge34a
+ */
+public class Matrix44dNGTest {
+    
+    private static final double D[] = { 
+        101.1D, 102.2D, 103.3D, 104.4D,
+        111.1D, 112.2D, 113.3D, 114.4D,
+        121.1D, 122.2D, 123.3D, 124.4D,
+        131.1D, 132.2D, 133.3D, 134.4D};
+    private static final Matrix44d M1 = new Matrix44d();
+    
+    @BeforeClass
+    public void before() {
+        M1.setA(D);
+    }
+    
+    /**
+     * Can create a new Matrix44d.
+     */
+    @Test
+    public void testConstructor() {
+        final Matrix44d m = new Matrix44d();
+        double a[] = m.getA();
+        for (int i = 0; i < a.length; i++) {
+            assertEquals(a[i], 0D);
+        }
+    }
+    
+    /**
+     * Can get the array of values inside the matrix.
+     */
+    @Test
+    public void testGetA() {
+        final double a[] = M1.getA();
+        for (int i = 0; i < a.length; i++) {
+            assertEquals(a[i], D[i]);
+        }
+    }
+    
+    /**
+     * Can set the array of values inside the matrix.
+     */
+    @Test
+    public void testSetA() {
+        final Matrix44d m = new Matrix44d();
+        m.setA(Arrays.copyOf(D, D.length));
+        for (int i = 0; i < D.length; i++) {
+            assertEquals(m.getA()[i], D[i]);
+        }
+    }
+    
+    /**
+     * Can set a matrix to the identity matrix values.
+     */
+    @Test
+    public void testIdentity() {        
+        final double junk[] = new double[Matrix44d.LENGTH];
+        for (int i = 0; i < Matrix44d.LENGTH; i++) {
+            junk[i] = 1089.1451D;
+        }
+        final Matrix44d m = new Matrix44d();
+        m.setA(junk);
+        
+        m.identity();
+        final double a[] = m.getA();
+        for (int i = 0; i < a.length; i++) {
+            if (i == 0 || i == 5 || i == 10 || i == 15) {
+                assertEquals(a[i], 1D);
+            } else {
+                assertEquals(a[i], 0D);
+            }
+        }
+    }
+    
+    /**
+     * Can get a 3x3 rotation matrix version of a matrix.
+     */
+    @Test
+    public void testGetRotationMatrix33d() {
+        final Matrix33d expected = new Matrix33d();
+        expected.setA(new double[]{
+            D[0], D[1], D[2], D[4], D[5], D[6], D[8], D[9], D[10]
+        });
+
+        final Matrix33d m33 = new Matrix33d();
+        m33.setA(new double[]{1D, 2D, 3D, 4D, 5D, 6D, 7D, 8D, 9D});
+
+        M1.getRotationMatrix(m33);
+        for (int i = 0; i < expected.getA().length; i++) {
+            assertEquals(m33.getA()[i], expected.getA()[i]);
+        }
+    }
+    
+    /**
+     * Can inject a 3x3 rotation matrix into a 4x4 matrix.
+     */
+    @Test
+    public void testSetRotationMatrix() {
+        final Matrix44d expected = new Matrix44d();
+        final double[] d33 = {
+            311D, 312D, 313D,
+            321D, 322D, 323D,
+            331D, 332D, 323D};
+        expected.setA(new double[]{
+            d33[0], d33[1], d33[2], 104.4D,
+            d33[3], d33[4], d33[5], 114.4D,
+            d33[6], d33[7], d33[8], 124.4D,
+            131.1D, 132.2D, 133.3D, 134.4D
+        });
+        
+        final Matrix33d m33 = new Matrix33d();
+        m33.setA(Arrays.copyOf(d33, d33.length));
+
+        final Matrix44d m44 = new Matrix44d();
+        m44.setA(Arrays.copyOf(D, D.length));
+        m44.setRotationMatrix(m33);
+        for (int i = 0; i < expected.getA().length; i++) {
+            assertEquals(expected.getA()[i], m44.getA()[i]);
+        }
+    }
+}


### PR DESCRIPTION
### Description of the Change

`setRotationMatrix` is intended to set the top-left nine values of the 4x4 matrix to the values of the input 3x3 matrix. Incorrect values were used in the `System.arraycopy` calls to retrieve values from the source 3x3 matrix. This is especially obvious with the 3rd copy, which attempts to copy 4 values from a 9-element array, starting at the 8th element.

While I was here I also improved unit test coverage of the class.

### Alternate Designs

None - simple bugfix.

### Why Should This Be In Core?

Reliance on this incorrect method could result in strange bugs when users move their viewpoint around Constellation views.

### Benefits

Improved correctness in a core utility method.

### Possible Drawbacks

Any plugins relying on this behaviour will no longer work as expected. Updated the change log to account for this.

### Verification Process

Created unit tests and ensured they run correctly.