### PR TITLE
Switched 'Ok' buttons to 'OK' for consistency across application

### DIFF
--- a/CoreAttributeEditorView/src/au/gov/asd/tac/constellation/views/attributeeditor/AttributeEditorDialog.java
+++ b/CoreAttributeEditorView/src/au/gov/asd/tac/constellation/views/attributeeditor/AttributeEditorDialog.java
@@ -54,7 +54,7 @@ public class AttributeEditorDialog extends ConstellationDialog {
         errorLabel = new Label("");
         errorLabel.setId("error");
 
-        okButton = new Button("Ok");
+        okButton = new Button("OK");
         cancelButton = new Button("Cancel");
         defaultButton = new Button("Restore Default");
 

--- a/CoreImportExportPlugins/src/au/gov/asd/tac/constellation/plugins/importexport/AttributeNode.java
+++ b/CoreImportExportPlugins/src/au/gov/asd/tac/constellation/plugins/importexport/AttributeNode.java
@@ -154,7 +154,7 @@ public final class AttributeNode extends Label implements Comparable<AttributeNo
             final Window parent = attributeList.importController.getStage().getParentWindow();
             final PluginParametersDialog dialog = new PluginParametersDialog(
                     parent, at.getLabel() + " Parameters",
-                    parameters, "Ok", "Cancel");
+                    parameters, "OK", "Cancel");
 
             dialog.showAndWait();
             if (PluginParametersDialog.OK.equalsIgnoreCase(dialog.getResult())) {

--- a/CoreImportExportPlugins/src/au/gov/asd/tac/constellation/plugins/importexport/DefaultAttributeValueDialog.java
+++ b/CoreImportExportPlugins/src/au/gov/asd/tac/constellation/plugins/importexport/DefaultAttributeValueDialog.java
@@ -94,7 +94,7 @@ public class DefaultAttributeValueDialog extends Stage {
         buttonPane.setHgap(GAP);
         root.setBottom(buttonPane);
 
-        final Button okButton = new Button("Ok");
+        final Button okButton = new Button("OK");
         okButton.setOnAction((ActionEvent event) -> {
             defaultValue = labelText.getText();
             DefaultAttributeValueDialog.this.hide();

--- a/CoreImportExportPlugins/src/au/gov/asd/tac/constellation/plugins/importexport/NewAttributeDialog.java
+++ b/CoreImportExportPlugins/src/au/gov/asd/tac/constellation/plugins/importexport/NewAttributeDialog.java
@@ -118,7 +118,7 @@ public class NewAttributeDialog extends Stage {
         buttonPane.setHgap(GRIDPANE_GAP);
         root.setBottom(buttonPane);
 
-        final Button okButton = new Button("Ok");
+        final Button okButton = new Button("OK");
         okButton.setOnAction((ActionEvent event) -> {
             attribute = new NewAttribute(elementType, typeBox.getSelectionModel().getSelectedItem(),
                     labelText.getText(), descriptionText.getText());

--- a/CoreNamedSelectionView/src/au/gov/asd/tac/constellation/views/namedselection/NamedSelectionManager.java
+++ b/CoreNamedSelectionView/src/au/gov/asd/tac/constellation/views/namedselection/NamedSelectionManager.java
@@ -901,7 +901,7 @@ public class NamedSelectionManager implements LookupListener, GraphChangeListene
         final NamedSelectionAllAllocPanel panel = new NamedSelectionAllAllocPanel();
         final DialogDescriptor dd = new DialogDescriptor(panel, Bundle.AllAllocated());
 
-        dd.setOptions(new Object[]{"Ok"});
+        dd.setOptions(new Object[]{"OK"});
         DialogDisplayer.getDefault().notify(dd);
     }
 
@@ -916,7 +916,7 @@ public class NamedSelectionManager implements LookupListener, GraphChangeListene
         final NamedSelectionProtectedPanel panel = new NamedSelectionProtectedPanel(name);
         final DialogDescriptor dd = new DialogDescriptor(panel, Bundle.ProtectedSelection());
 
-        dd.setOptions(new Object[]{"Ok"});
+        dd.setOptions(new Object[]{"OK"});
         DialogDisplayer.getDefault().notify(dd);
     }
 

--- a/CoreNamedSelectionView/src/au/gov/asd/tac/constellation/views/namedselection/NamedSelectionTopComponent.java
+++ b/CoreNamedSelectionView/src/au/gov/asd/tac/constellation/views/namedselection/NamedSelectionTopComponent.java
@@ -967,7 +967,7 @@ public final class NamedSelectionTopComponent extends SwingTopComponent<JPanel> 
     private void notifyProtected(final String name) {
         final NamedSelectionProtectedPanel panel = new NamedSelectionProtectedPanel(name);
         final DialogDescriptor dd = new DialogDescriptor(panel, Bundle.ProtectedSelection());
-        dd.setOptions(new Object[]{"Ok"});
+        dd.setOptions(new Object[]{"OK"});
         DialogDisplayer.getDefault().notify(dd);
     }
 

--- a/CorePluginFramework/src/au/gov/asd/tac/constellation/plugins/PluginInteraction.java
+++ b/CorePluginFramework/src/au/gov/asd/tac/constellation/plugins/PluginInteraction.java
@@ -87,7 +87,7 @@ public interface PluginInteraction {
      *
      * @param promptName the name of the dialog box.
      * @param parameters the parameters to be displayed and edited.
-     * @return true if the user selected "Ok" or false if the user selected
+     * @return true if the user selected "OK" or false if the user selected
      * "Cancel".
      */
     boolean prompt(final String promptName, final PluginParameters parameters);

--- a/CorePluginFramework/src/au/gov/asd/tac/constellation/plugins/gui/PluginParametersSwingDialog.java
+++ b/CorePluginFramework/src/au/gov/asd/tac/constellation/plugins/gui/PluginParametersSwingDialog.java
@@ -148,7 +148,7 @@ public class PluginParametersSwingDialog {
     }
 
     public void showAndWaitNoFocus() {
-        //Having 'No' button as initial value means focus is off of 'Ok' and 'Cancel' buttons
+        //Having 'No' button as initial value means focus is off of 'OK' and 'Cancel' buttons
         final DialogDescriptor dd = new DialogDescriptor(xp, title, true, DialogDescriptor.OK_CANCEL_OPTION, DialogDescriptor.NO_OPTION, null);
         final Object r = DialogDisplayer.getDefault().notify(dd);
         result = r == DialogDescriptor.OK_OPTION ? OK : r == DialogDescriptor.CANCEL_OPTION ? CANCEL : null;


### PR DESCRIPTION
<!--

### Requirements

* Filling out the template is required. Any pull request that does not include
enough information to be reviewed in a timely manner may be closed at the
maintainers' discretion.
* Follow the check list items defined by https://github.com/constellation-app/constellation/blob/master/CONTRIBUTING.md#pull-requests
* All new code requires unit tests to ensure they work as expected and will
continue to work as new code is added in the future (regression testing).
* Make sure your branch name is prefixed by `feature`, `bugfix`, `hotfix` or `release`
* Have you read Constellation's Code of Conduct? By filing an issue, you are
expected to comply with it, including treating everyone with respect:
https://github.com/constellation-app/constellation/blob/master/CODE_OF_CONDUCT.md

-->

### Description of the Change

Changed all the 'Ok' buttons to uppercase so that we have consistent naming across the application

### Alternate Designs

I would've preferred to switch the upper case 'OK's to camel case but since this what is used by the javafx button (which I can't fix in this application), I had to go with the other option

### Why Should This Be In Core?

Consistency across teh application is a good thing

### Benefits

Consistency

### Possible Drawbacks

OK is now always shouting at you

### Verification Process

<!--

What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (e.g. buttons you clicked, text you typed,
commands you ran, etc.), and describe the results you observed.

-->

### Applicable Issues

#1348
