### PR TITLE
Removed Found Count Text When No Search Is Made

### DIFF
--- a/CoreConversationView/src/au/gov/asd/tac/constellation/views/conversationview/ConversationBox.java
+++ b/CoreConversationView/src/au/gov/asd/tac/constellation/views/conversationview/ConversationBox.java
@@ -72,6 +72,7 @@ import javafx.scene.layout.RowConstraints;
 import javafx.scene.layout.StackPane;
 import javafx.scene.layout.VBox;
 import javafx.scene.text.Font;
+import org.apache.commons.lang3.StringUtils;
 import org.controlsfx.control.CheckComboBox;
 import org.netbeans.api.javahelp.Help;
 import org.openide.util.HelpCtx;
@@ -258,8 +259,6 @@ public final class ConversationBox extends StackPane {
             highlightRegions();
             refreshCountUI(false);
         });
-        foundLabel.setText(FOUND_TEXT + foundCount);
-        foundLabel.setStyle(foundCount > 0 ? FOUND_PASS_COLOUR : FOUND_FAIL_COLOUR);
         foundLabel.setPadding(new Insets(4, 8, 4, 8));
         searchVBox.getChildren().addAll(searchTextField, foundLabel);
 
@@ -278,7 +277,7 @@ public final class ConversationBox extends StackPane {
             foundCount = 0;
         }
 
-        foundLabel.setText(FOUND_TEXT + foundCount);
+        foundLabel.setText(StringUtils.isBlank(searchTextField.getText())? "" : FOUND_TEXT + foundCount);
         foundLabel.setStyle(foundCount > 0 ? FOUND_PASS_COLOUR : FOUND_FAIL_COLOUR);
     }
 

--- a/CoreConversationView/src/au/gov/asd/tac/constellation/views/conversationview/ConversationBox.java
+++ b/CoreConversationView/src/au/gov/asd/tac/constellation/views/conversationview/ConversationBox.java
@@ -277,7 +277,7 @@ public final class ConversationBox extends StackPane {
             foundCount = 0;
         }
 
-        foundLabel.setText(StringUtils.isBlank(searchTextField.getText())? "" : FOUND_TEXT + foundCount);
+        foundLabel.setText(StringUtils.isBlank(searchTextField.getText()) ? "" : FOUND_TEXT + foundCount);
         foundLabel.setStyle(foundCount > 0 ? FOUND_PASS_COLOUR : FOUND_FAIL_COLOUR);
     }
 


### PR DESCRIPTION
<!--

### Requirements

* Filling out the template is required. Any pull request that does not include
enough information to be reviewed in a timely manner may be closed at the
maintainers' discretion.
* Follow the check list items defined by https://github.com/constellation-app/constellation/blob/master/CONTRIBUTING.md#pull-requests
* All new code requires unit tests to ensure they work as expected and will
continue to work as new code is added in the future (regression testing).
* Make sure your branch name is prefixed by `feature`, `bugfix`, `hotfix` or `release`
* Have you read Constellation's Code of Conduct? By filing an issue, you are
expected to comply with it, including treating everyone with respect:
https://github.com/constellation-app/constellation/blob/master/CODE_OF_CONDUCT.md

-->

### Description of the Change

Updated the conversation search to change the found text to the empty string when there is no search text. 

### Alternate Designs

<!--

Explain what other alternates were considered and why the proposed version was
selected.

-->

### Why Should This Be In Core?

Showing a search count doesn't make much sense if no search has been made

### Benefits

Better UX

### Possible Drawbacks

My solution assumes users aren't searching for a string of whitespace characters. Maybe someone will be mad but I'm assuming 99% of users won't be

### Verification Process

Conducted various permutations of opening a graph before and after Conversation view was open with and without search text already present. Then conducted some searches on a graph that had content to verify the found text appeared in its various forms when I start typing and disappeared once I cleared the search.

### Applicable Issues

#1168 
