### PR TITLE
Improve user flow for K-truss view

### DIFF
--- a/CoreAlgorithmPlugins/src/au/gov/asd/tac/constellation/plugins/algorithms/clustering/ktruss/Bundle.properties
+++ b/CoreAlgorithmPlugins/src/au/gov/asd/tac/constellation/plugins/algorithms/clustering/ktruss/Bundle.properties
@@ -17,5 +17,6 @@ KTrussControllerTopComponent.upButton.text=>
 KTrussControllerTopComponent.upButton.toolTipText=
 KTrussControllerTopComponent.excludedElementsLabel.text=\ Excluded Elements:
 KTrussControllerTopComponent.colorNestedTrussesCheckBox.text=Colour Nested K-Trusses
-KTrussControllerTopComponent.interactiveButton.text=Interactive - Disabled
+KTrussControllerTopComponent.interactiveButton.text=Toggle Interactive: Enabled
 KTrussControllerTopComponent.reclusterButton.text=Cluster
+KTrussControllerTopComponent.interactiveButton.AccessibleContext.accessibleDescription=

--- a/CoreAlgorithmPlugins/src/au/gov/asd/tac/constellation/plugins/algorithms/clustering/ktruss/KTrussControllerTopComponent.form
+++ b/CoreAlgorithmPlugins/src/au/gov/asd/tac/constellation/plugins/algorithms/clustering/ktruss/KTrussControllerTopComponent.form
@@ -87,7 +87,7 @@
                   <Component id="nestedTrussButton" min="-2" max="-2" attributes="0"/>
                   <Component id="nestedTrussPane" min="-2" max="-2" attributes="0"/>
               </Group>
-              <EmptySpace pref="40" max="32767" attributes="0"/>
+              <EmptySpace pref="46" max="32767" attributes="0"/>
               <Group type="103" groupAlignment="3" attributes="0">
                   <Component id="reclusterButton" alignment="3" min="-2" max="-2" attributes="0"/>
                   <Component id="interactiveButton" alignment="3" min="-2" max="-2" attributes="0"/>
@@ -217,6 +217,9 @@
     </Component>
     <Component class="javax.swing.JButton" name="reclusterButton">
       <Properties>
+        <Property name="font" type="java.awt.Font" editor="org.netbeans.beaninfo.editors.FontEditor">
+          <Font name="Segoe UI" size="12" style="1"/>
+        </Property>
         <Property name="text" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
           <ResourceString bundle="au/gov/asd/tac/constellation/plugins/algorithms/clustering/ktruss/Bundle.properties" key="KTrussControllerTopComponent.reclusterButton.text" replaceFormat="org.openide.util.NbBundle.getMessage({sourceFileName}.class, &quot;{key}&quot;)"/>
         </Property>
@@ -227,11 +230,22 @@
     </Component>
     <Component class="javax.swing.JToggleButton" name="interactiveButton">
       <Properties>
-        <Property name="selected" type="boolean" value="true"/>
+        <Property name="font" type="java.awt.Font" editor="org.netbeans.beaninfo.editors.FontEditor">
+          <Font name="Segoe UI" size="12" style="1"/>
+        </Property>
         <Property name="text" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
           <ResourceString bundle="au/gov/asd/tac/constellation/plugins/algorithms/clustering/ktruss/Bundle.properties" key="KTrussControllerTopComponent.interactiveButton.text" replaceFormat="org.openide.util.NbBundle.getMessage({sourceFileName}.class, &quot;{key}&quot;)"/>
         </Property>
+        <Property name="cursor" type="java.awt.Cursor" editor="org.netbeans.modules.form.editors2.CursorEditor">
+          <Color id="Hand Cursor"/>
+        </Property>
+        <Property name="focusable" type="boolean" value="false"/>
       </Properties>
+      <AccessibilityProperties>
+        <Property name="AccessibleContext.accessibleDescription" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
+          <ResourceString bundle="au/gov/asd/tac/constellation/plugins/algorithms/clustering/ktruss/Bundle.properties" key="KTrussControllerTopComponent.interactiveButton.AccessibleContext.accessibleDescription" replaceFormat="org.openide.util.NbBundle.getMessage({sourceFileName}.class, &quot;{key}&quot;)"/>
+        </Property>
+      </AccessibilityProperties>
       <Events>
         <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="interactiveButtonActionPerformed"/>
       </Events>

--- a/CoreAlgorithmPlugins/src/au/gov/asd/tac/constellation/plugins/algorithms/clustering/ktruss/KTrussControllerTopComponent.java
+++ b/CoreAlgorithmPlugins/src/au/gov/asd/tac/constellation/plugins/algorithms/clustering/ktruss/KTrussControllerTopComponent.java
@@ -87,8 +87,8 @@ import org.openide.windows.TopComponent;
 })
 public final class KTrussControllerTopComponent extends TopComponent implements LookupListener, GraphChangeListener, ComponentListener {
 
-    private static final String INTERACTIVE_DISABLED = "Interactive - Disabled";
-    private static final String INTERACTIVE_ENABLED = "Interactive - Enabled";
+    private static final String TOGGLE_DISABLED = "Toggle Interactive: Disabled";
+    private static final String TOGGLE_ENABLED = "Toggle Interactive: Enabled";
 
     private final Lookup.Result<GraphNode> result;
     private GraphNode graphNode;
@@ -114,6 +114,7 @@ public final class KTrussControllerTopComponent extends TopComponent implements 
         isAdjusting = false;
         nestedTrussesHeight = 500;
         nestedPanelIsVisible = false;
+        updateInteractiveButton(interactiveButton.getText() == TOGGLE_ENABLED ? true : false);
     }
 
     /**
@@ -205,6 +206,7 @@ public final class KTrussControllerTopComponent extends TopComponent implements 
             }
         });
 
+        reclusterButton.setFont(new java.awt.Font("Segoe UI", 1, 12)); // NOI18N
         org.openide.awt.Mnemonics.setLocalizedText(reclusterButton, org.openide.util.NbBundle.getMessage(KTrussControllerTopComponent.class, "KTrussControllerTopComponent.reclusterButton.text")); // NOI18N
         reclusterButton.addActionListener(new java.awt.event.ActionListener() {
             public void actionPerformed(java.awt.event.ActionEvent evt) {
@@ -212,8 +214,10 @@ public final class KTrussControllerTopComponent extends TopComponent implements 
             }
         });
 
-        interactiveButton.setSelected(true);
+        interactiveButton.setFont(new java.awt.Font("Segoe UI", 1, 12)); // NOI18N
         org.openide.awt.Mnemonics.setLocalizedText(interactiveButton, org.openide.util.NbBundle.getMessage(KTrussControllerTopComponent.class, "KTrussControllerTopComponent.interactiveButton.text")); // NOI18N
+        interactiveButton.setCursor(new java.awt.Cursor(java.awt.Cursor.HAND_CURSOR));
+        interactiveButton.setFocusable(false);
         interactiveButton.addActionListener(new java.awt.event.ActionListener() {
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 interactiveButtonActionPerformed(evt);
@@ -278,7 +282,7 @@ public final class KTrussControllerTopComponent extends TopComponent implements 
                 .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
                     .addComponent(nestedTrussButton)
                     .addComponent(nestedTrussPane, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
-                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED, 40, Short.MAX_VALUE)
+                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED, 46, Short.MAX_VALUE)
                 .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
                     .addComponent(reclusterButton)
                     .addComponent(interactiveButton)
@@ -294,6 +298,7 @@ public final class KTrussControllerTopComponent extends TopComponent implements 
 
         hiddenRadioButton.getAccessibleContext().setAccessibleName(org.openide.util.NbBundle.getMessage(KTrussControllerTopComponent.class, "KTrussControllerTopComponent.hiddenRadioButton.AccessibleContext.accessibleName")); // NOI18N
         dimmedRadioButton.getAccessibleContext().setAccessibleName(org.openide.util.NbBundle.getMessage(KTrussControllerTopComponent.class, "KTrussControllerTopComponent.dimmedRadioButton.AccessibleContext.accessibleName")); // NOI18N
+        interactiveButton.getAccessibleContext().setAccessibleDescription(org.openide.util.NbBundle.getMessage(KTrussControllerTopComponent.class, "KTrussControllerTopComponent.interactiveButton.AccessibleContext.accessibleDescription")); // NOI18N
     }// </editor-fold>//GEN-END:initComponents
 
     private void stepSliderStateChanged(javax.swing.event.ChangeEvent evt) {//GEN-FIRST:event_stepSliderStateChanged
@@ -367,7 +372,7 @@ public final class KTrussControllerTopComponent extends TopComponent implements 
     private void updateInteractivity() {
         state.setInteractive(!state.getInteractive());
         if (!state.getInteractive()) {
-            interactiveButton.setText(INTERACTIVE_DISABLED);
+            updateInteractiveButton(true);
             if (state.getNestedTrussesVisible()) {
                 hideNestedTrussesPanel();
             }
@@ -376,7 +381,7 @@ public final class KTrussControllerTopComponent extends TopComponent implements 
                 PluginExecution.withPlugin(uncolor).interactively(true).executeLater(graph);
             }
         } else {
-            interactiveButton.setText(INTERACTIVE_ENABLED);
+            updateInteractiveButton(false);
             if (state.getNestedTrussesVisible()) {
                 showNestedTrussesPanel();
             }
@@ -558,10 +563,10 @@ public final class KTrussControllerTopComponent extends TopComponent implements 
                 if (state != null) {
                     colorNestedTrussesCheckBox.setSelected(state.getNestedTrussesColored());
                     interactiveButton.setSelected(state.getInteractive());
-                    interactiveButton.setText(state.getInteractive() ? INTERACTIVE_ENABLED : INTERACTIVE_DISABLED);
+                    updateInteractiveButton(!state.getInteractive());
                 } else {
                     interactiveButton.setSelected(false);
-                    interactiveButton.setText(INTERACTIVE_DISABLED);
+                    updateInteractiveButton(true);
                     colorNestedTrussesCheckBox.setSelected(false);
                 }
             } finally {
@@ -708,11 +713,11 @@ public final class KTrussControllerTopComponent extends TopComponent implements 
             if (state != null) {
                 // Interactive button should only be available if state is available
                 interactiveButton.setEnabled(true);
-                interactiveButton.setText(INTERACTIVE_ENABLED);
+                updateInteractiveButton(false);
             } else {
                 reclusterButton.setEnabled(true);
                 interactiveButton.setEnabled(false);
-                interactiveButton.setText(INTERACTIVE_DISABLED);
+                updateInteractiveButton(true);
             }
         }
 
@@ -730,7 +735,8 @@ public final class KTrussControllerTopComponent extends TopComponent implements 
         // This is used to revert the graph display when the component is closed and was previously
         // set to interactive.
         final boolean interactive = state.getInteractive();
-        interactiveButton.setText(interactive ? INTERACTIVE_ENABLED : INTERACTIVE_DISABLED);
+        updateInteractiveButton(!interactive);
+
         if (!interactive) {
             final RemoveOverlayColors removeColors = new RemoveOverlayColors();
             PluginExecution.withPlugin(removeColors).interactively(true).executeLater(graph);
@@ -1030,5 +1036,15 @@ public final class KTrussControllerTopComponent extends TopComponent implements 
             KTruss.run(graph, new KTruss.KTrussPluginResultHandler(graph, isInteractiveButtonSelected));
         }
 
+    }
+
+    public void updateInteractiveButton(boolean disableButton) {
+        if (disableButton) {
+            interactiveButton.setText(TOGGLE_DISABLED);
+            interactiveButton.setSelected(false);
+        } else {
+            interactiveButton.setText(TOGGLE_ENABLED);
+            interactiveButton.setSelected(false);
+        }
     }
 }

--- a/CoreAlgorithmPlugins/src/au/gov/asd/tac/constellation/plugins/algorithms/clustering/ktruss/KTrussControllerTopComponent.java
+++ b/CoreAlgorithmPlugins/src/au/gov/asd/tac/constellation/plugins/algorithms/clustering/ktruss/KTrussControllerTopComponent.java
@@ -114,9 +114,8 @@ public final class KTrussControllerTopComponent extends TopComponent implements 
         isAdjusting = false;
         nestedTrussesHeight = 500;
         nestedPanelIsVisible = false;
-        updateInteractiveButton(interactiveButton.getText() == TOGGLE_ENABLED ? true : false);
+        updateInteractiveButton(interactiveButton.getText().equals(TOGGLE_DISABLED));
     }
-
     /**
      * This method is called from within the constructor to initialize the form.
      * WARNING: Do NOT modify this code. The content of this method is always


### PR DESCRIPTION
<!--

### Requirements

* Filling out the template is required. Any pull request that does not include
enough information to be reviewed in a timely manner may be closed at the
maintainers' discretion.
* Follow the check list items defined by https://github.com/constellation-app/constellation/blob/master/CONTRIBUTING.md#pull-requests
* All new code requires unit tests to ensure they work as expected and will
continue to work as new code is added in the future (regression testing).
* Make sure your branch name is prefixed by `feature`, `bugfix`, `hotfix` or `release`
* Have you read Constellation's Code of Conduct? By filing an issue, you are
expected to comply with it, including treating everyone with respect:
https://github.com/constellation-app/constellation/blob/master/CODE_OF_CONDUCT.md

-->

### Description of the Change

I have done a few small things that should hopefully help.
- Moved updating the buttons into functions so changing button properties can be easily added or modified later on.
- Made the cluster button and the interactive button have bold text. This should hopefully direct the user a bit more to press then 1st then 2nd respectively.
- Changed the text of the interactive button to state "Toggle Interactive: Enabled" or "Toggle Interactive: Disabled" 
    - this just read a bit cleaner to me. It states what the button does and states the current mode its in.
    - This was changed from "Interactive - disabled" and "Interactive - enabled"

![ktrussInteractionButtonBoldWhiteFinal](https://user-images.githubusercontent.com/88649439/134595050-56a603e5-6c0a-40a4-9e36-36621ff8469f.gif)

I was unable to automate the process of pressing cluster automatically enabling the interactive mode due to the inflexible design of the view. This should hopefully just help guide the user where to go next.
<!--

We must be able to understand the design of your change from this description.
If we can't get a good idea of what the code will be doing from the description
here, the pull request may be closed at the maintainers' discretion. Keep in
mind that the maintainer reviewing this PR may not be familiar with or have
worked with the code here recently, so please walk us through the concepts.

-->

### Alternate Designs

Changing the colours of the buttons to be similar to bootstraps style. @arcturus2 Idea. https://getbootstrap.com/docs/5.1/components/buttons/
Would likely be a whole application overhaul if done.

<!--

Explain what other alternates were considered and why the proposed version was
selected.

-->

### Why Should This Be In Core?

Improve user flow.

<!--

Explain why this functionality should be in Constellation Core as opposed to a
different module suite. Note that this question is more applicable when adding
new functionality. If this change is a minor update to an existing file then it
is understood that this change has to be to this module suite and a response
and therefore a response to this question is not required.

-->

### Benefits
UI UX

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks

Should be none.

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process

All buttons work the exact way as before.
-I ensured when implementing the update button method that I replaced all existing code with the correct method(true/false).
-Toggling between the 2 states appears to work as intended.

<!--

What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (e.g. buttons you clicked, text you typed,
commands you ran, etc.), and describe the results you observed.

-->

### Applicable Issues
#1089

<!-- Link any applicable issues here -->
