### PR TITLE
Hashmod - Allow transactions to have attributes from the CSV

### DIFF
--- a/CoreGraphUtilities/src/au/gov/asd/tac/constellation/graph/utilities/hashmod/Hashmod.java
+++ b/CoreGraphUtilities/src/au/gov/asd/tac/constellation/graph/utilities/hashmod/Hashmod.java
@@ -106,7 +106,7 @@ public class Hashmod {
             for (int i = 1; i < data.size(); i++) {
                 final String[] row = getCSVRow(i);
                 if (row[0] != null) {
-                    keys.put(row[0].toUpperCase(), 0);
+                    keys.put(row[0].toUpperCase(), i);
                 }
             }
         }
@@ -143,7 +143,7 @@ public class Hashmod {
     }
 
     private String getColumnOfTransaction(int transactionCol, String regex) {
-        final Pattern cardNamePattern = Pattern.compile(regex);
+        final Pattern transactionPattern = Pattern.compile(regex);
 
         final String[] headers = getCSVFileHeaders();
         if (headers != null) {
@@ -151,7 +151,7 @@ public class Hashmod {
             for (int i = getNumberCSVDataColumns(); i < headers.length; i++) {
                 if (headers[i].matches(HEADER_MATCH_STRING)) {
                     if (numTransactions == transactionCol) {
-                        Matcher matchPattern = cardNamePattern.matcher(headers[i]);
+                        Matcher matchPattern = transactionPattern.matcher(headers[i]);
                         if (matchPattern.find()) {
                             return matchPattern.group(1);
                         }
@@ -168,7 +168,16 @@ public class Hashmod {
     }
 
     public String getSecondColumnOfTransaction(int transactionCol) {
-        return getColumnOfTransaction(transactionCol, ".*?\\.\\.\\.([^\"]+)");
+        return getColumnOfTransaction(transactionCol, ".*?\\.\\.\\.([^\"]+?)(;;;.*|$)");
+    }
+
+    public String getTransactionAttribute(String attributeFromCSV) {
+        final Pattern transactionPattern = Pattern.compile("^.*;;;([^\"]+)");
+        Matcher matchPattern = transactionPattern.matcher(attributeFromCSV);
+        if (matchPattern.find()) {
+            return matchPattern.group(1);
+        }
+        return "";
     }
 
     public String getCSVHeader(final int col) {
@@ -199,6 +208,19 @@ public class Hashmod {
             }
         }
         return null;
+    }
+
+    public String getValueFromKeyAndIndex(final String key, final int value, final int index) {
+        if (CollectionUtils.isNotEmpty(data)) {
+            final String[] row = getCSVRow(index);
+            if (row[0].equalsIgnoreCase(key)) {
+
+                if (row.length > value) {
+                    return row[value];
+                }
+            }
+        }
+        return getValueFromKey(key, value);
     }
 
     public Boolean doesKeyExist(final String key) {

--- a/CoreGraphUtilities/src/au/gov/asd/tac/constellation/graph/utilities/hashmod/Hashmod.java
+++ b/CoreGraphUtilities/src/au/gov/asd/tac/constellation/graph/utilities/hashmod/Hashmod.java
@@ -173,7 +173,7 @@ public class Hashmod {
 
     public String getTransactionAttribute(String attributeFromCSV) {
         final Pattern transactionPattern = Pattern.compile("^.*;;;([^\"]+)");
-        Matcher matchPattern = transactionPattern.matcher(attributeFromCSV);
+        final Matcher matchPattern = transactionPattern.matcher(attributeFromCSV);
         if (matchPattern.find()) {
             return matchPattern.group(1);
         }

--- a/CoreGraphUtilities/src/au/gov/asd/tac/constellation/graph/utilities/hashmod/HashmodAction.java
+++ b/CoreGraphUtilities/src/au/gov/asd/tac/constellation/graph/utilities/hashmod/HashmodAction.java
@@ -135,8 +135,8 @@ public final class HashmodAction implements ActionListener {
                     }
                 }
 
-                if (createTransactions && !hashmod.getTransactionAttribute(nextAttr).equalsIgnoreCase("")) {
-                    String transactionAttributeName = hashmod.getTransactionAttribute(nextAttr);
+                if (createTransactions && StringUtils.isNotBlank(hashmod.getTransactionAttribute(nextAttr))) {
+                    final String transactionAttributeName = hashmod.getTransactionAttribute(nextAttr);
                     final int newTransactionAttribute = wg.addAttribute(GraphElementType.TRANSACTION, newAttributeType, transactionAttributeName, transactionAttributeName, "", null);
                     if (newTransactionAttribute != Graph.NOT_FOUND) {
                         transactionAttributeValues[transAttrCount] = newTransactionAttribute;
@@ -196,7 +196,7 @@ public final class HashmodAction implements ActionListener {
         if (createVertices) {
             numberSuccessful = 0;
             for (final Entry<String, Integer> entry : keys.entrySet()) {
-                int newVertexId = wg.addVertex();
+                final int newVertexId = wg.addVertex();
 
                 for (i = 0; i < attrCount; i++) {
                     wg.setStringValue(attributeValues[i], newVertexId, hashmod.getValueFromKeyAndIndex(entry.getKey(), csvValues[i], entry.getValue()));
@@ -248,11 +248,10 @@ public final class HashmodAction implements ActionListener {
 
                             String attr2Value = wg.getObjectValue(transaction2Attribute, vx2Id);
                             if (attr1Value.equals(attr2Value) && vxId != vx2Id) {
-                                int newTransactionId = wg.addTransaction(vxId, vx2Id, false);
-
+                                final int newTransactionId = wg.addTransaction(vxId, vx2Id, false);
 
                                 for (i = 0; i < transAttrCount; i++) {
-                                    String theVal = wg.getStringValue(fromNodeValues [i], vxId);
+                                    final String theVal = wg.getStringValue(fromNodeValues [i], vxId);
                                     wg.setStringValue(transactionAttributeValues[i], newTransactionId, theVal);
                                 }
 

--- a/CoreGraphUtilities/src/au/gov/asd/tac/constellation/graph/utilities/hashmod/HashmodAction.java
+++ b/CoreGraphUtilities/src/au/gov/asd/tac/constellation/graph/utilities/hashmod/HashmodAction.java
@@ -76,19 +76,19 @@ public final class HashmodAction implements ActionListener {
                 final boolean createAttributes = hashmodPanel.getCreateAttributes();
                 final Hashmod[] chainedHashmods = hashmodPanel.getChainedHashmods();
                 final int numChainedHashmods = hashmodPanel.numChainedHashmods();
-                final Boolean createNonMatchingKeysVertexes = hashmodPanel.getCreateVertexes();
+                final Boolean createVertices = hashmodPanel.getCreateVertexes();
                 final Boolean createTransactions = hashmodPanel.getCreateTransactions();
                 hashmodPanel.setAttributeNames(hashmod1.getCSVKey(), hashmod1.getCSVHeader(1), hashmod1.getCSVHeader(2));
 
                 PluginExecution.withPlugin(
-                        new AddHashmodPlugin(isChainedHashmods, createAttributes, createNonMatchingKeysVertexes,
+                        new AddHashmodPlugin(isChainedHashmods, createAttributes, createVertices,
                                 createTransactions, chainedHashmods, numChainedHashmods, hashmod1)).executeLater(graph);
             }
         });
         DialogDisplayer.getDefault().notify(dialog);
     }
 
-    private static void run(final GraphWriteMethods wg, final PluginInteraction interaction, final Hashmod hashmod, final Boolean createAllKeys, final Boolean createTransactions, final Boolean setPrimary, final Boolean createAttributes) throws InterruptedException {
+    private static void run(final GraphWriteMethods wg, final PluginInteraction interaction, final Hashmod hashmod, final Boolean createVertices, final Boolean createTransactions, final Boolean setPrimary, final Boolean createAttributes) throws InterruptedException {
 
         if (wg != null && hashmod != null) {
             if (hashmod.getNumberCSVDataColumns() < 2) {
@@ -101,16 +101,22 @@ public final class HashmodAction implements ActionListener {
 
         final int[] attributeValues = new int[hashmod.getNumberCSVDataColumns() + 1];
         final int[] csvValues = new int[hashmod.getNumberCSVDataColumns() + 1];
+        final int[] transactionAttributeValues = new int[hashmod.getNumberCSVTransactionColumns() + 1];
+        final int[] fromNodeValues = new int[hashmod.getNumberCSVTransactionColumns() + 1];
+        final int[] transactionCSVValues = new int[hashmod.getNumberCSVTransactionColumns() + 1];
         String nextAttr;
         int i = 0;
         int attrCount = 0;
+        int transAttrCount = 0;
         while ((nextAttr = hashmod.getCSVHeader(i)) != null) {
             final int nextAttribute = wg.getSchema().getFactory().ensureAttribute(wg, GraphElementType.VERTEX, nextAttr);
             if (nextAttribute != Graph.NOT_FOUND) {
                 attributeValues[attrCount] = nextAttribute;
                 csvValues[attrCount] = i;
                 attrCount++;
-            } else if (createAttributes && StringUtils.isNotBlank(nextAttr)) {
+            }
+
+            if ((createAttributes || createTransactions) && StringUtils.isNotBlank(nextAttr)) {
                 final String[] attributeName = nextAttr.split("\\.");
                 String newAttributeType = StringAttributeDescription.ATTRIBUTE_NAME;
 
@@ -120,14 +126,25 @@ public final class HashmodAction implements ActionListener {
                     }
                 }
 
-                final int newAttribute = wg.addAttribute(GraphElementType.VERTEX, newAttributeType, nextAttr, nextAttr, "", null);
-                if (newAttribute != Graph.NOT_FOUND) {
-                    attributeValues[attrCount] = newAttribute;
-                    csvValues[attrCount] = i;
-                    attrCount++;
+                if (createAttributes) {
+                    final int newAttribute = wg.addAttribute(GraphElementType.VERTEX, newAttributeType, nextAttr, nextAttr, "", null);
+                    if (newAttribute != Graph.NOT_FOUND) {
+                        attributeValues[attrCount] = newAttribute;
+                        csvValues[attrCount] = i;
+                        attrCount++;
+                    }
                 }
-            } else {
-                // Do nothing
+
+                if (createTransactions && !hashmod.getTransactionAttribute(nextAttr).equalsIgnoreCase("")) {
+                    String transactionAttributeName = hashmod.getTransactionAttribute(nextAttr);
+                    final int newTransactionAttribute = wg.addAttribute(GraphElementType.TRANSACTION, newAttributeType, transactionAttributeName, transactionAttributeName, "", null);
+                    if (newTransactionAttribute != Graph.NOT_FOUND) {
+                        transactionAttributeValues[transAttrCount] = newTransactionAttribute;
+                        transactionCSVValues[transAttrCount] = i;
+                        fromNodeValues[transAttrCount] = wg.getAttribute(GraphElementType.VERTEX, transactionAttributeName);
+                        transAttrCount++;
+                    }
+                }
             }
             i++;
         }
@@ -144,7 +161,7 @@ public final class HashmodAction implements ActionListener {
 
         final int[] vxOrder = new int[vxCount];
         int vxPos = 0;
-        if (vxCount > 0) {
+        if (vxCount > 0 && createVertices) {
             final BitSet vertices = HashmodUtilities.vertexBits(wg);
             for (int vxId = vertices.nextSetBit(0); vxId >= 0; vxId = vertices.nextSetBit(vxId + 1)) {
                 if (Thread.interrupted()) {
@@ -164,10 +181,10 @@ public final class HashmodAction implements ActionListener {
                 if (keys.containsKey(keyValue.toUpperCase())) {
                     numberSuccessful++;
                     for (i = 1; i < attrCount; i++) {
-                        wg.setStringValue(attributeValues[i], j, hashmod.getValueFromKey(keyValue, csvValues[i]));
+                        wg.setStringValue(attributeValues[i], j, hashmod.getValueFromKeyAndIndex(keyValue, csvValues[i], keys.get(keyValue.toUpperCase())));
                     }
 
-                    if (createAllKeys) {
+                    if (createVertices) {
                         keys.put(keyValue, 1);
                     }
                 }
@@ -176,17 +193,15 @@ public final class HashmodAction implements ActionListener {
             interaction.notify(PluginNotificationLevel.WARNING, "Successfully updated " + numberSuccessful + "/" + vxPos + " nodes");
         }
 
-        if (createAllKeys) {
+        if (createVertices) {
             numberSuccessful = 0;
             for (final Entry<String, Integer> entry : keys.entrySet()) {
-                if (entry.getValue() == 0) {
-                    int newVertex = wg.addVertex();
+                int newVertexId = wg.addVertex();
 
-                    for (i = 0; i < attrCount; i++) {
-                        wg.setStringValue(attributeValues[i], newVertex, hashmod.getValueFromKey(entry.getKey(), csvValues[i]));
-                    }
-                    numberSuccessful++;
+                for (i = 0; i < attrCount; i++) {
+                    wg.setStringValue(attributeValues[i], newVertexId, hashmod.getValueFromKeyAndIndex(entry.getKey(), csvValues[i], entry.getValue()));
                 }
+                numberSuccessful++;
             }
 
             if (setPrimary) {
@@ -233,7 +248,15 @@ public final class HashmodAction implements ActionListener {
 
                             String attr2Value = wg.getObjectValue(transaction2Attribute, vx2Id);
                             if (attr1Value.equals(attr2Value) && vxId != vx2Id) {
-                                wg.addTransaction(vxId, vx2Id, false);
+                                int newTransactionId = wg.addTransaction(vxId, vx2Id, false);
+
+
+                                for (i = 0; i < transAttrCount; i++) {
+                                    String theVal = wg.getStringValue(fromNodeValues [i], vxId);
+                                    wg.setStringValue(transactionAttributeValues[i], newTransactionId, theVal);
+                                }
+
+                                numberSuccessful++;
                             }
                         }
                     }
@@ -252,18 +275,18 @@ public final class HashmodAction implements ActionListener {
 
         final boolean isChainedHashmods;
         final boolean createAttributes;
-        final boolean createNonMatchingKeysVertexes;
+        final boolean createVertices;
         final boolean createTransactions;
         final Hashmod[] chainedHashmods;
         final int numChainedHashmods;
         final Hashmod hashmod1;
 
-        public AddHashmodPlugin(final boolean isChainedHashmods, final boolean createAttributes, final boolean createNonMatchingKeysVertexes,
+        public AddHashmodPlugin(final boolean isChainedHashmods, final boolean createAttributes, final boolean createVertices,
                 final boolean createTransactions, final Hashmod[] chainedHashmods, final int numChainedHashmods, final Hashmod hashmod1) {
 
             this.isChainedHashmods = isChainedHashmods;
             this.createAttributes = createAttributes;
-            this.createNonMatchingKeysVertexes = createNonMatchingKeysVertexes;
+            this.createVertices = createVertices;
             this.createTransactions = createTransactions;
             this.chainedHashmods = chainedHashmods;
             this.numChainedHashmods = numChainedHashmods;
@@ -278,7 +301,7 @@ public final class HashmodAction implements ActionListener {
         @Override
         public void edit(final GraphWriteMethods wg, final PluginInteraction interaction, final PluginParameters parameters) throws InterruptedException {
             if (hashmod1 != null) {
-                HashmodAction.run(wg, interaction, hashmod1, createNonMatchingKeysVertexes, createTransactions, true, createAttributes);
+                HashmodAction.run(wg, interaction, hashmod1, createVertices, createTransactions, true, createAttributes);
             }
             if (isChainedHashmods && numChainedHashmods >= 2) {
                 for (int i = 1; i < numChainedHashmods; i++) {

--- a/CoreWhatsNewView/src/au/gov/asd/tac/constellation/views/whatsnew/whatsnew.txt
+++ b/CoreWhatsNewView/src/au/gov/asd/tac/constellation/views/whatsnew/whatsnew.txt
@@ -1,6 +1,11 @@
 == 3030-12-31 Getting Started
 <p>If you're new to Constellation, read the <a href="" helpId="au.gov.asd.tac.constellation.functionality.gettingstarted">getting started guide</a>.</p>
 
+== 2021-09-28 Hashmod Improvements
+<p>Significant speed up in ingesting CSV files with a header line in as separate vertices and you can now specify
+(via a header field with format 'COLUMN1...COLUMN2;;;COLUMN3') that any transactions that hashmod creates via 
+matching COLUMN1 and COLUMN2 values will also gain the COLUMN3 attribute from one of the vertices it connects.</p>
+
 == 2021-09-17 Anaglyphic Display
 <p>The anaglyphic 3D display now allows different colors to be selected for left and right eyes.</p>
 


### PR DESCRIPTION
### Description of the Change

Allow transaction to inherit attributes from a node.  Also significantly speeds up ingest of data from a CSV file

### Alternate Designs

Nil considered

### Why Should This Be In Core?

Already in core

### Benefits

Ingesting csv files is a lot quicker with the hashmod ingester now as it doesn't have to traverse the entire key chain each time.
Allows transactions to have an attribute from a vertex added to it.

### Possible Drawbacks

Nil known.

### Verification Process

Integration testing was done for new and larger csv files (one with 48K rows - when this same one took minutes previously, it took seconds to ingest with the changes)

### Applicable Issues

#1363 