### PR TITLE
Data access view preferences load bug for batch plugins

### DIFF
--- a/CoreDataAccessView/src/au/gov/asd/tac/constellation/views/dataaccess/io/ParameterIOUtilities.java
+++ b/CoreDataAccessView/src/au/gov/asd/tac/constellation/views/dataaccess/io/ParameterIOUtilities.java
@@ -52,6 +52,7 @@ import org.openide.util.Exceptions;
  * @author algol
  */
 public class ParameterIOUtilities {
+
     private static final String DATA_ACCESS_DIR = "DataAccessView";
 
     /**
@@ -133,12 +134,12 @@ public class ParameterIOUtilities {
     }
 
     /**
-     * Saves the global and plugin parameters from the passed tabs that belong to
-     * the {@link DataAccessPane}. The parameters will be saved to a JSON file as
-     * an array with each element representing one tab.
+     * Saves the global and plugin parameters from the passed tabs that belong
+     * to the {@link DataAccessPane}. The parameters will be saved to a JSON
+     * file as an array with each element representing one tab.
      *
      * @param tabs the tabs to extract the global and plugin parameters from
-     * @see JsonIO#saveJsonPreferences(Optional, ObjectMapper, Object) 
+     * @see JsonIO#saveJsonPreferences(Optional, ObjectMapper, Object)
      */
     public static void saveParameters(final TabPane tabs) {
         final List<DataAccessUserPreferences> dataAccessUserPreferenceses = new ArrayList<>();
@@ -173,20 +174,22 @@ public class ParameterIOUtilities {
     }
 
     /**
-     * Loads global and plugin parameters from a JSON file into the passed {@link DataAccessPane}.
-     * If the JSON is loaded then all existing tabs will be removed and then new tabs added
-     * for each entry in the loaded JSON array.
-     * 
+     * Loads global and plugin parameters from a JSON file into the passed
+     * {@link DataAccessPane}. If the JSON is loaded then all existing tabs will
+     * be removed and then new tabs added for each entry in the loaded JSON
+     * array.
+     *
      * @param dataAccessPane the pane to load the JSON parameter file into
-     * @see JsonIO#loadJsonPreferences(Optional, TypeReference) 
+     * @see JsonIO#loadJsonPreferences(Optional, TypeReference)
      */
     public static void loadParameters(final DataAccessPane dataAccessPane) {
         final List<DataAccessUserPreferences> loadedParameters = JsonIO
                 .loadJsonPreferences(
                         Optional.of(DATA_ACCESS_DIR),
-                        new TypeReference<List<DataAccessUserPreferences>>() {}
+                        new TypeReference<List<DataAccessUserPreferences>>() {
+                }
                 );
-        
+
         if (loadedParameters != null) {
             dataAccessPane.removeTabs();
 
@@ -205,24 +208,21 @@ public class ParameterIOUtilities {
 
                 // Groups all the parameters in to the plugin groups. Common parameters
                 // are based on the plugin name that is before the first '.' in the key values
-                final Map<String, Map<String, String>> ppmap = loadedParameter.toPerPluginParamMap();
-
                 pluginPane.getDataAccessPanes().stream()
                         // Plugins are disabled by defult. Only load and enable from
                         // the JSON if the JSON contains data for this plugin and it's
                         // enabled.
-                        .filter(pane -> loadedParameter.getPluginParameters().containsKey(getEnabledPluginKey(pane)) 
-                                && Boolean.valueOf(loadedParameter.getPluginParameters().get(getEnabledPluginKey(pane))))
+                        .filter(pane -> loadedParameter.getPluginParameters().containsKey(getEnabledPluginKey(pane))
+                        && Boolean.valueOf(loadedParameter.getPluginParameters().get(getEnabledPluginKey(pane))))
                         .forEach(pane -> pane.setParameterValues(
-                                ppmap.get(pane.getPlugin().getClass().getSimpleName())
-                        ));
+                        loadedParameter.getPluginParameters()));
             });
         }
     }
-    
+
     /**
-     * Generates the JSON 'enabled' property name for the plugin associated to the
-     * passed {@link DataSourceTitledPane}.
+     * Generates the JSON 'enabled' property name for the plugin associated to
+     * the passed {@link DataSourceTitledPane}.
      *
      * @param pane the pane that contains the plugin
      * @return the generated property name

--- a/CoreDataAccessView/src/au/gov/asd/tac/constellation/views/dataaccess/panes/DataSourceTitledPane.java
+++ b/CoreDataAccessView/src/au/gov/asd/tac/constellation/views/dataaccess/panes/DataSourceTitledPane.java
@@ -89,6 +89,9 @@ public class DataSourceTitledPane extends TitledPane implements PluginParameters
 
     private static final Image HELP_ICON = UserInterfaceIconProvider.HELP.buildImage(16, ConstellationColor.BLUEBERRY.getJavaColor());
 
+    private static int pluginCount = 0;
+    private static boolean preferenceLoad = false;
+
     public DataSourceTitledPane(final DataAccessPlugin plugin, final ImageView dataSourceIcon, final PluginParametersPaneListener top, final Set<String> globalParamLabels) {
         this.plugin = plugin;
         this.top = top;
@@ -102,6 +105,8 @@ public class DataSourceTitledPane extends TitledPane implements PluginParameters
         enabled.setDisable(true);
 
         final boolean isExpanded = DataAccessPreferences.isExpanded(plugin.getName(), false);
+
+        resetPreferenceVariables();
 
         createParameters(isExpanded, null);
 
@@ -155,9 +160,12 @@ public class DataSourceTitledPane extends TitledPane implements PluginParameters
                 }
 
                 try {
-                    dataSourceParameters = DefaultPluginParameters.getDefaultParameters(plugin);
-                    if (dataSourceParameters != null) {
-                        dataSourceParameters = dataSourceParameters.copy();
+                    // Only copy the default parameters first time within a preference PLUGINS_OBJECT
+                    if (!preferenceLoad || pluginCount == 1) {
+                        dataSourceParameters = DefaultPluginParameters.getDefaultParameters(plugin);
+                        if (dataSourceParameters != null) {
+                            dataSourceParameters = dataSourceParameters.copy();
+                        }
                     }
 
                     if (perPluginParamMap != null && dataSourceParameters != null) {
@@ -198,9 +206,15 @@ public class DataSourceTitledPane extends TitledPane implements PluginParameters
                     }
 
                     displayParameters(isExpanded);
+                    resetPreferenceVariables();
                 });
             }
         });
+    }
+
+    private void resetPreferenceVariables() {
+        preferenceLoad = false;
+        pluginCount = 0;
     }
 
     /**
@@ -347,6 +361,8 @@ public class DataSourceTitledPane extends TitledPane implements PluginParameters
      * @param perPluginParamMap the parameter values.
      */
     public void setParameterValues(final Map<String, String> perPluginParamMap) {
+        pluginCount++;
+        preferenceLoad = true;
         createParameters(true, perPluginParamMap);
     }
 

--- a/CoreDataAccessView/src/au/gov/asd/tac/constellation/views/dataaccess/plugins/experimental/TestParametersBatched.java
+++ b/CoreDataAccessView/src/au/gov/asd/tac/constellation/views/dataaccess/plugins/experimental/TestParametersBatched.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2010-2021 Australian Signals Directorate
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package au.gov.asd.tac.constellation.views.dataaccess.plugins.experimental;
+
+import au.gov.asd.tac.constellation.plugins.Plugin;
+import au.gov.asd.tac.constellation.plugins.PluginInfo;
+import au.gov.asd.tac.constellation.plugins.PluginType;
+import au.gov.asd.tac.constellation.views.dataaccess.DataAccessPlugin;
+import au.gov.asd.tac.constellation.views.dataaccess.DataAccessPluginCoreType;
+import au.gov.asd.tac.constellation.views.dataaccess.templates.WorkflowQueryPlugin;
+import java.util.ArrayList;
+import java.util.List;
+import org.openide.util.NbBundle.Messages;
+import org.openide.util.lookup.ServiceProvider;
+import org.openide.util.lookup.ServiceProviders;
+
+/**
+ * A data access plugin that tests the various types of parameters (including
+ * the global parameters).
+ * <p>
+ * Each of the parameter types should have a matching GUI input.
+ *
+ * @author mimosa
+ */
+@ServiceProviders({
+    @ServiceProvider(service = DataAccessPlugin.class),
+    @ServiceProvider(service = Plugin.class)
+})
+@Messages("TestParametersBatched=Test Parameters Batch")
+@PluginInfo(pluginType = PluginType.UPDATE, tags = {"DEVELOPER", "MODIFY"})
+public class TestParametersBatched extends WorkflowQueryPlugin implements DataAccessPlugin {
+
+    public TestParametersBatched() {
+    }
+
+    @Override
+    public String getType() {
+        return DataAccessPluginCoreType.DEVELOPER;
+    }
+
+    @Override
+    public int getPosition() {
+        return Integer.MAX_VALUE - 10;
+    }
+
+    @Override
+    public String getDescription() {
+        return "Test the various input UIs";
+    }
+
+    @Override
+    public List<String> getWorkflow() {
+        final List<String> batchPlugin = new ArrayList<>();
+        batchPlugin.add("TestParameters");
+        return batchPlugin;
+    }
+
+    @Override
+    public String getErrorHandlingPlugin() {
+        return "SelectAll";
+    }
+}

--- a/CoreDataAccessView/test/unit/src/au/gov/asd/tac/constellation/views/dataaccess/io/ParameterIOUtilitiesNGTest.java
+++ b/CoreDataAccessView/test/unit/src/au/gov/asd/tac/constellation/views/dataaccess/io/ParameterIOUtilitiesNGTest.java
@@ -138,96 +138,96 @@ public class ParameterIOUtilitiesNGTest {
         verify(wGraph).setObjectValue(0, 0, expectedTab);
 
     }
-    
+
     @Test
     public void saveParameters_query_present() {
         final Map<String, String> tab1GlobalParams = Map.of(
                 "param1", "tab1_param1_value",
                 "CoreGlobalParameters.query_name", "my query"
         );
-                
+
         final Map<String, String> tab2GlobalParams = Map.of(
                 "param2", "tab2_param2_value"
         );
-        
+
         saveParameters(tab1GlobalParams, tab2GlobalParams, true);
     }
-    
+
     @Test
     public void saveParameters_no_query_name() {
         final Map<String, String> tab1GlobalParams = Map.of(
                 "param1", "tab1_param1_value"
         );
-                
+
         final Map<String, String> tab2GlobalParams = Map.of(
                 "param2", "tab2_param2_value"
         );
-        
+
         saveParameters(tab1GlobalParams, tab2GlobalParams, false);
     }
-    
+
     @Test
     public void saveParameters_query_name_blank() {
         final Map<String, String> tab1GlobalParams = Map.of(
                 "param1", "tab1_param1_value",
                 "CoreGlobalParameters.query_name", ""
         );
-                
+
         final Map<String, String> tab2GlobalParams = Map.of(
                 "param2", "tab2_param2_value"
         );
-        
+
         saveParameters(tab1GlobalParams, tab2GlobalParams, false);
     }
-    
+
     @Test
     public void loadParameters() throws IOException {
         final DataAccessPane dataAccessPane = mock(DataAccessPane.class);
-        
+
         final QueryPhasePane tab1 = mock(QueryPhasePane.class);
         final QueryPhasePane tab2 = mock(QueryPhasePane.class);
         when(dataAccessPane.newTab()).thenReturn(tab1).thenReturn(tab2);
-        
-        final GlobalParametersPane globalParametersPane1 = mock(GlobalParametersPane.class); 
-        final GlobalParametersPane globalParametersPane2 = mock(GlobalParametersPane.class); 
+
+        final GlobalParametersPane globalParametersPane1 = mock(GlobalParametersPane.class);
+        final GlobalParametersPane globalParametersPane2 = mock(GlobalParametersPane.class);
         when(tab1.getGlobalParametersPane()).thenReturn(globalParametersPane1);
         when(tab2.getGlobalParametersPane()).thenReturn(globalParametersPane2);
-        
+
         // By adding the settings bit here, it forces mockito to generate two different
         // classes. Otherwise they would be two different objects but have the same class name
         final Plugin plugin1 = mock(Plugin.class, withSettings().extraInterfaces(Comparable.class));
         final Plugin plugin2 = mock(Plugin.class, withSettings().extraInterfaces(Serializable.class));
-        
+
         final DataSourceTitledPane dataSourceTitledPane1 = mock(DataSourceTitledPane.class);
         when(dataSourceTitledPane1.getPlugin()).thenReturn(plugin1);
 
         final DataSourceTitledPane dataSourceTitledPane2 = mock(DataSourceTitledPane.class);
         when(dataSourceTitledPane2.getPlugin()).thenReturn(plugin2);
-        
+
         when(tab1.getDataAccessPanes()).thenReturn(List.of(dataSourceTitledPane1, dataSourceTitledPane2));
         when(tab2.getDataAccessPanes()).thenReturn(List.of());
-        
+
         final PluginParameter pluginParameter1 = mock(PluginParameter.class);
         when(pluginParameter1.getId()).thenReturn("param1");
-        
+
         final PluginParameter pluginParameter2 = mock(PluginParameter.class);
         when(pluginParameter2.getId()).thenReturn("param2");
-        
+
         final PluginParameter pluginParameter3 = mock(PluginParameter.class);
         when(pluginParameter3.getId()).thenReturn("param3");
-        
+
         final PluginParameter pluginParameter4 = mock(PluginParameter.class);
         when(pluginParameter4.getId()).thenReturn("param4");
-        
+
         final PluginParameters globalPluginParameters1 = new PluginParameters();
         globalPluginParameters1.addParameter(pluginParameter1);
         globalPluginParameters1.addParameter(pluginParameter2);
         globalPluginParameters1.addParameter(pluginParameter3);
-        
+
         final PluginParameters globalPluginParameters2 = new PluginParameters();
         globalPluginParameters2.addParameter(pluginParameter3);
         globalPluginParameters2.addParameter(pluginParameter4);
-        
+
         when(globalParametersPane1.getParams()).thenReturn(globalPluginParameters1);
         when(globalParametersPane2.getParams()).thenReturn(globalPluginParameters2);
 
@@ -237,7 +237,7 @@ public class ParameterIOUtilitiesNGTest {
                     new FileInputStream(getClass().getResource("resources/preferences.json").getPath()),
                     StandardCharsets.UTF_8
             );
-            
+
             // We do not know the mockito plugin names ahead of time so substitute them in now
             final StringSubstitutor substitutor = new StringSubstitutor(
                     Map.of(
@@ -246,74 +246,80 @@ public class ParameterIOUtilitiesNGTest {
                     )
             );
             final List<DataAccessUserPreferences> preferences = objectMapper.readValue(
-                    substitutor.replace(json), new TypeReference<List<DataAccessUserPreferences>>() {});
+                    substitutor.replace(json), new TypeReference<List<DataAccessUserPreferences>>() {
+            });
 
             jsonIOStaticMock.when(() -> JsonIO.loadJsonPreferences(eq(Optional.of("DataAccessView")), any(TypeReference.class)))
                     .thenReturn(preferences);
 
             ParameterIOUtilities.loadParameters(dataAccessPane);
         }
-        
+
         verify(dataAccessPane, times(2)).newTab();
-        
+
         // tab1 global parameters
         verify(pluginParameter1).setStringValue("tab1_param1_value");
         verify(pluginParameter3).setStringValue(null);
-        
-        // tab1 plugin parameters - only plugin1 because plugin2 is disabled
+
+        // tab1 plugin parameters
         verify(dataSourceTitledPane1).setParameterValues(Map.of(
-                plugin1.getClass().getSimpleName()+ "." + "__is_enabled__", "true",
-                plugin1.getClass().getSimpleName()+ "." + "param1", "plugin1_param1_value"
+                plugin1.getClass().getSimpleName() + "." + "__is_enabled__", "true",
+                plugin1.getClass().getSimpleName() + "." + "param1", "plugin1_param1_value",
+                plugin2.getClass().getSimpleName() + "." + "__is_enabled__", "false",
+                plugin2.getClass().getSimpleName() + "." + "param1", "plugin2_param1_value",
+                "OTHER_PLUGIN1.param1", "other1_param1_value",
+                "OTHER_PLUGIN1.__is_enabled__", "true"
         ));
-        
+
         // tab2 global parameters
         verify(pluginParameter4).setStringValue("tab2_param4_value");
-        
+
         // tab2 plugin parameters
         verify(dataSourceTitledPane2, times(0)).setParameterValues(anyMap());
     }
-    
+
     /**
      * Verifies the save parameter method saves only if the query name parameter
-     * is present in the global parameters and is not blank. This will simulate two
-     * tabs and verify the correct calls are made to serialize the data.
+     * is present in the global parameters and is not blank. This will simulate
+     * two tabs and verify the correct calls are made to serialize the data.
      *
      * @param tab1GlobalParams the global parameters to be populated in tab 1
      * @param tab2GlobalParams the global parameters to be populated in tab 2
-     * @param isSaveExpected true if a call to save the JSON is expected to be made, false otherwise
+     * @param isSaveExpected true if a call to save the JSON is expected to be
+     * made, false otherwise
      */
     public void saveParameters(final Map<String, String> tab1GlobalParams,
-                               final Map<String, String> tab2GlobalParams,
-                               final boolean isSaveExpected) {
+            final Map<String, String> tab2GlobalParams,
+            final boolean isSaveExpected) {
         final TabPane tabPane = mock(TabPane.class);
-        
+
         final Tab tab1 = mock(Tab.class);
         final Tab tab2 = mock(Tab.class);
         when(tabPane.getTabs()).thenReturn(FXCollections.observableArrayList(tab1, tab2));
-        
+
         final ScrollPane scrollPane1 = mock(ScrollPane.class);
         final ScrollPane scrollPane2 = mock(ScrollPane.class);
         when(tab1.getContent()).thenReturn(scrollPane1);
         when(tab2.getContent()).thenReturn(scrollPane2);
-        
+
         final QueryPhasePane queryPhasePane1 = mock(QueryPhasePane.class);
         final QueryPhasePane queryPhasePane2 = mock(QueryPhasePane.class);
         when(scrollPane1.getContent()).thenReturn(queryPhasePane1);
         when(scrollPane2.getContent()).thenReturn(queryPhasePane2);
-        
+
         // This will apply the correct stubbing to the created mocks. Uses the passed
         // query phase pane to determine what stubs to set.
-        final MockedConstruction.MockInitializer<DataAccessUserPreferences> mockInitializer = 
-                (mock, cntxt) -> {
+        final MockedConstruction.MockInitializer<DataAccessUserPreferences> mockInitializer
+                = (mock, cntxt) -> {
                     final QueryPhasePane pane = (QueryPhasePane) cntxt.arguments().get(0);
-                
+
                     if (pane.equals(queryPhasePane1)) {
                         when(mock.getGlobalParameters())
                                 .thenReturn(
                                         tab1GlobalParams
                                 );
                         return;
-                    } else if(pane.equals(queryPhasePane2)) {
+                    } else if (pane.equals(queryPhasePane2)) {
                         when(mock.getGlobalParameters())
                                 .thenReturn(
                                         tab2GlobalParams
@@ -323,14 +329,12 @@ public class ParameterIOUtilitiesNGTest {
 
                     throw new RuntimeException("Unknown QueryPhasePane passed to DataAccessUserPreferences constructor");
                 };
-        
+
         try (
-                final MockedStatic<JsonIO> jsonIOStaticMock = Mockito.mockStatic(JsonIO.class);
-                final MockedConstruction<DataAccessUserPreferences> mockedPrefConstruction = 
-                        Mockito.mockConstruction(DataAccessUserPreferences.class, mockInitializer);
-            ) {
+                final MockedStatic<JsonIO> jsonIOStaticMock = Mockito.mockStatic(JsonIO.class); final MockedConstruction<DataAccessUserPreferences> mockedPrefConstruction
+                = Mockito.mockConstruction(DataAccessUserPreferences.class, mockInitializer);) {
             ParameterIOUtilities.saveParameters(tabPane);
-            
+
             if (isSaveExpected) {
                 jsonIOStaticMock.verify(() -> JsonIO.saveJsonPreferences(
                         eq(Optional.of("DataAccessView")),


### PR DESCRIPTION
<!--

### Requirements

* Filling out the template is required. Any pull request that does not include
enough information to be reviewed in a timely manner may be closed at the
maintainers' discretion.
* Follow the check list items defined by https://github.com/constellation-app/constellation/blob/master/CONTRIBUTING.md#pull-requests
* All new code requires unit tests to ensure they work as expected and will
continue to work as new code is added in the future (regression testing).
* Make sure your branch name is prefixed by `feature`, `bugfix`, `hotfix` or `release`
* Have you read Constellation's Code of Conduct? By filing an issue, you are
expected to comply with it, including treating everyone with respect:
https://github.com/constellation-app/constellation/blob/master/CODE_OF_CONDUCT.md

-->

### Description of the Change

A bug has been fixed when loading data access view preferences for batch plugins in options ->load.

### Alternate Designs

<!--

Explain what other alternates were considered and why the proposed version was
selected.

-->

### Why Should This Be In Core?

Core functionality

### Benefits

Parameters will be selected correctly on load preferences.

### Possible Drawbacks

N/A

### Verification Process

Open DA view , select a batch plugin (e.g. Test Parameters Batch) and select all parameters.

Open Options -> Save to a file

Close and open DA view

Open Options -> Load and select the file

### Applicable Issues

<!-- Link any applicable issues here -->
