### PR TITLE
Welcome Page Recent Graphs Exception

### DIFF
--- a/CoreGraphFile/src/au/gov/asd/tac/constellation/graph/file/open/RecentFilesWelcomePage.java
+++ b/CoreGraphFile/src/au/gov/asd/tac/constellation/graph/file/open/RecentFilesWelcomePage.java
@@ -66,7 +66,8 @@ public class RecentFilesWelcomePage {
             }
         }
         if (index != -1) {
-            final String path = files.get(index).getPath();
+            // the recent file action has path separated by '/' rather than '\' so mimicing that
+            final String path = files.get(index).getPath().replace('\\', '/');
 
             final FileObject fo = RecentFiles.convertPath2File(path);
             OpenFile.open(fo, -1);


### PR DESCRIPTION
<!--

### Requirements

* Filling out the template is required. Any pull request that does not include
enough information to be reviewed in a timely manner may be closed at the
maintainers' discretion.
* Follow the check list items defined by https://github.com/constellation-app/constellation/blob/master/CONTRIBUTING.md#pull-requests
* All new code requires unit tests to ensure they work as expected and will
continue to work as new code is added in the future (regression testing).
* Make sure your branch name is prefixed by `feature`, `bugfix`, `hotfix` or `release`
* Have you read Constellation's Code of Conduct? By filing an issue, you are
expected to comply with it, including treating everyone with respect:
https://github.com/constellation-app/constellation/blob/master/CODE_OF_CONDUCT.md

-->

### Description of the Change

The issue described here #1284 was not as fixed as we first thought as the exception came up again. Adding some logs to what was being loaded suggested that the open recent menu item used the '/' path separator whereas the welcome page used '\'. I reckon there is a possibility that this is the cause of the issue (though why it only happens sometimes and not always baffles me)

I've made an adjustment to the welcome page one to replace the path separator to mimic what is happening in the open recent menu item. This should hopefully fix the issue once and for all (fingers-crossed)

### Alternate Designs

<!--

Explain what other alternates were considered and why the proposed version was
selected.

-->

### Why Should This Be In Core?

Bug fix

### Benefits

Bug fix

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process

<!--

What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (e.g. buttons you clicked, text you typed,
commands you ran, etc.), and describe the results you observed.

-->

### Applicable Issues

#1284 
