### PR TITLE
Added the processing of newline delimited JSON (ndJSON) to JSONImport…

### DIFF
--- a/CoreImportExportPlugins/src/au/gov/asd/tac/constellation/plugins/importexport/delimited/parser/JSONImportFileParser.java
+++ b/CoreImportExportPlugins/src/au/gov/asd/tac/constellation/plugins/importexport/delimited/parser/JSONImportFileParser.java
@@ -404,14 +404,18 @@ public class JSONImportFileParser extends ImportFileParser {
             }
             // Maps newline delimited JSON to valid JSON in the format 
             // {"results": [<ndjson>]}
-            if (counter > 1){  // Newline Delimited JSON (ndJSON)
-                // Changes the ndJSON to valid JSON
-                final ObjectMapper newJSON = new ObjectMapper();
-                final ObjectNode rootNode = newJSON.createObjectNode();
-                rootNode.set("results", childNode);
-                root = rootNode;
-            } else {
-                root = node;
+            switch(counter){
+                case(0):
+                    throw new IOException(WARN_NO_VALID_LIST);
+                case(1):
+                    root = node;
+                    break;
+                default:
+                    // Changes the ndJSON to valid JSON
+                    final ObjectMapper newJSON = new ObjectMapper();
+                    final ObjectNode rootNode = newJSON.createObjectNode();
+                    rootNode.set("results", childNode);
+                    root = rootNode;                         
             }
             lookForChildArrays(root, "", 0);
 


### PR DESCRIPTION
### Description of the Change
Added the ability to parse newline delimited JSON files where multiple valid JSON objects are stored within one file, used heavily in streaming data.  Previously the JSON parser read the first entry of the file then stopped, the new implementation is a small change that will read all of the objects and add them to a valid JSON object in the format {"results": [<each ndJSON object>]}.  Normal JSON files will be unchanged.  This PR will address the first part of ticket #1318.

Example ndJSON:
![image](https://user-images.githubusercontent.com/63685177/136294409-b587a0df-6747-4fec-b278-0e7dbe81a8a9.png)

Example ndJSON after processing (with additional formatting):
![image](https://user-images.githubusercontent.com/63685177/136294510-adde6cdb-d553-4ab7-a402-d04f4cce4711.png)

### Alternate Designs

None considered.

### Why Should This Be In Core?

ndJSON is a rather common format and the change to allow parsing will add minimal overhead and complexity to core.  

### Benefits

ndJSON is now processed seamlessly with the Json parser.

### Possible Drawbacks

None

### Verification Process
Steps to verify:
- Open the file delimiter pane - File > Import > From File...
- Download a ndJSON dataset e.g. https://www.kaggle.com/cmenca/new-york-times-hardcover-fiction-best-sellers
- Add the file to the file importer
- You will now see the data in the preview bar
The resulting JSON will be processed like a normal JSON file.
![image](https://user-images.githubusercontent.com/63685177/136295174-0978ccca-28fa-48d1-a244-31e33efff588.png)

### Applicable Issues

#1318 
