### PR TITLE
Add icons to right click popup context menu

### DIFF
--- a/CoreInteractiveGraph/src/au/gov/asd/tac/constellation/graph/interaction/plugins/zoom/ResetViewContextMenu.java
+++ b/CoreInteractiveGraph/src/au/gov/asd/tac/constellation/graph/interaction/plugins/zoom/ResetViewContextMenu.java
@@ -22,9 +22,12 @@ import au.gov.asd.tac.constellation.graph.interaction.InteractiveGraphPluginRegi
 import au.gov.asd.tac.constellation.graph.visual.contextmenu.ContextMenuProvider;
 import au.gov.asd.tac.constellation.plugins.PluginExecution;
 import au.gov.asd.tac.constellation.utilities.graphics.Vector3f;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import javax.swing.ImageIcon;
+import org.openide.util.ImageUtilities;
 import org.openide.util.lookup.ServiceProvider;
 
 /**
@@ -35,15 +38,30 @@ import org.openide.util.lookup.ServiceProvider;
 @ServiceProvider(service = ContextMenuProvider.class, position = 10000)
 public class ResetViewContextMenu implements ContextMenuProvider {
 
+    private static final String RESET_VIEW = "Reset View";
+    private static final String X_AXIS = "X Axis";
+    private static final String NEGATIVE_X_AXIS = "-X Axis";
+    private static final String Y_AXIS = "Y Axis";
+    private static final String NEGATIVE_Y_AXIS = "-Y Axis";
+    private static final String Z_AXIS = "Z Axis";
+    private static final String NEGATIVE_Z_AXIS = "-Z Axis";
+
+    private static final String X_AXIS_ICON = "au/gov/asd/tac/constellation/graph/interaction/plugins/zoom/resources/axis_x.png";
+    private static final String NEGATIVE_X_AXIS_ICON = "au/gov/asd/tac/constellation/graph/interaction/plugins/zoom/resources/axis_x_negative.png";
+    private static final String Y_AXIS_ICON = "au/gov/asd/tac/constellation/graph/interaction/plugins/zoom/resources/axis_y.png";
+    private static final String NEGATIVE_Y_AXIS_ICON = "au/gov/asd/tac/constellation/graph/interaction/plugins/zoom/resources/axis_y_negative.png";
+    private static final String Z_AXIS_ICON = "au/gov/asd/tac/constellation/graph/interaction/plugins/zoom/resources/axis_z.png";
+    private static final String NEGATIVE_Z_AXIS_ICON = "au/gov/asd/tac/constellation/graph/interaction/plugins/zoom/resources/axis_z_negative.png";
+
     @Override
     public List<String> getMenuPath(final GraphElementType elementType) {
-        return Collections.emptyList();
+        return Arrays.asList(RESET_VIEW);
     }
 
     @Override
     public List<String> getItems(final GraphReadMethods graph, final GraphElementType elementType, final int entity) {
         if (elementType == GraphElementType.GRAPH) {
-            return Arrays.asList("Reset View");
+            return Arrays.asList(X_AXIS, NEGATIVE_X_AXIS, Y_AXIS, NEGATIVE_Y_AXIS, Z_AXIS, NEGATIVE_Z_AXIS);
         } else {
             return Collections.emptyList();
         }
@@ -51,7 +69,68 @@ public class ResetViewContextMenu implements ContextMenuProvider {
 
     @Override
     public void selectItem(final String item, final Graph graph, final GraphElementType elementType, final int element, final Vector3f unprojected) {
-        PluginExecution.withPlugin(InteractiveGraphPluginRegistry.RESET_VIEW)
-                .executeLater(graph);
+        if (RESET_VIEW.equals(item)) {
+            PluginExecution.withPlugin(InteractiveGraphPluginRegistry.RESET_VIEW).executeLater(graph);
+        } else if (X_AXIS.equals(item)) {
+            PluginExecution.withPlugin(InteractiveGraphPluginRegistry.RESET_VIEW)
+                    .withParameter(ResetViewPlugin.AXIS_PARAMETER_ID, "x")
+                    .withParameter(ResetViewPlugin.NEGATIVE_PARAMETER_ID, false)
+                    .withParameter(ResetViewPlugin.SIGNIFICANT_PARAMETER_ID, true)
+                    .executeLater(graph);
+        } else if (Y_AXIS.equals(item)) {
+            PluginExecution.withPlugin(InteractiveGraphPluginRegistry.RESET_VIEW)
+                    .withParameter(ResetViewPlugin.AXIS_PARAMETER_ID, "y")
+                    .withParameter(ResetViewPlugin.NEGATIVE_PARAMETER_ID, false)
+                    .withParameter(ResetViewPlugin.SIGNIFICANT_PARAMETER_ID, true)
+                    .executeLater(graph);
+        } else if (Z_AXIS.equals(item)) {
+            PluginExecution.withPlugin(InteractiveGraphPluginRegistry.RESET_VIEW)
+                    .withParameter(ResetViewPlugin.AXIS_PARAMETER_ID, "z")
+                    .withParameter(ResetViewPlugin.NEGATIVE_PARAMETER_ID, false)
+                    .withParameter(ResetViewPlugin.SIGNIFICANT_PARAMETER_ID, true)
+                    .executeLater(graph);
+        } else if (NEGATIVE_X_AXIS.equals(item)) {
+            PluginExecution.withPlugin(InteractiveGraphPluginRegistry.RESET_VIEW)
+                    .withParameter(ResetViewPlugin.AXIS_PARAMETER_ID, "x")
+                    .withParameter(ResetViewPlugin.NEGATIVE_PARAMETER_ID, true)
+                    .withParameter(ResetViewPlugin.SIGNIFICANT_PARAMETER_ID, true)
+                    .executeLater(graph);
+        } else if (NEGATIVE_Y_AXIS.equals(item)) {
+            PluginExecution.withPlugin(InteractiveGraphPluginRegistry.RESET_VIEW)
+                    .withParameter(ResetViewPlugin.AXIS_PARAMETER_ID, "y")
+                    .withParameter(ResetViewPlugin.NEGATIVE_PARAMETER_ID, true)
+                    .withParameter(ResetViewPlugin.SIGNIFICANT_PARAMETER_ID, true)
+                    .executeLater(graph);
+        } else if (NEGATIVE_Z_AXIS.equals(item)) {
+            PluginExecution.withPlugin(InteractiveGraphPluginRegistry.RESET_VIEW)
+                    .withParameter(ResetViewPlugin.AXIS_PARAMETER_ID, "z")
+                    .withParameter(ResetViewPlugin.NEGATIVE_PARAMETER_ID, true)
+                    .withParameter(ResetViewPlugin.SIGNIFICANT_PARAMETER_ID, true)
+                    .executeLater(graph);
+        }
+    }
+
+    /**
+     * Produce the list of icons for the reset view menu
+     *
+     * @param graph the graph that has been right-clicked on.
+     * @param elementType the type of element that has been right-clicked on.
+     * @param elementId the id of the element that has been right-clicked on.
+     * @return list of reset view icons
+     */
+    @Override
+    public List<ImageIcon> getIcons(final GraphReadMethods graph, final GraphElementType elementType, final int elementId) {
+        if (elementType == GraphElementType.GRAPH) {
+            final List<ImageIcon> icons = new ArrayList<>();
+            icons.add(ImageUtilities.loadImageIcon(X_AXIS_ICON, false));
+            icons.add(ImageUtilities.loadImageIcon(NEGATIVE_X_AXIS_ICON, false));
+            icons.add(ImageUtilities.loadImageIcon(Y_AXIS_ICON, false));
+            icons.add(ImageUtilities.loadImageIcon(NEGATIVE_Y_AXIS_ICON, false));
+            icons.add(ImageUtilities.loadImageIcon(Z_AXIS_ICON, false));
+            icons.add(ImageUtilities.loadImageIcon(NEGATIVE_Z_AXIS_ICON, false));
+            return icons;
+        } else {
+            return Collections.emptyList();
+        }
     }
 }

--- a/CoreInteractiveGraph/test/unit/src/au/gov/asd/tac/constellation/graph/interaction/plugins/zoom/ResetViewContextMenuNGTest.java
+++ b/CoreInteractiveGraph/test/unit/src/au/gov/asd/tac/constellation/graph/interaction/plugins/zoom/ResetViewContextMenuNGTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2010-2021 Australian Signals Directorate
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package au.gov.asd.tac.constellation.graph.interaction.plugins.zoom;
+
+import au.gov.asd.tac.constellation.graph.GraphElementType;
+import au.gov.asd.tac.constellation.graph.StoreGraph;
+import au.gov.asd.tac.constellation.plugins.PluginException;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+/**
+ * ResetViewContextMenu Tests. Simulate the user right clicking on different objects
+ * in the graph.  Should only get a non empty response when GRAPH is simulated
+ *
+ * @author CrucisGamma
+ */
+public class ResetViewContextMenuNGTest {
+
+    private StoreGraph graph;
+
+    public ResetViewContextMenuNGTest() {
+    }
+
+    @BeforeClass
+    public static void setUpClass() throws Exception {
+    }
+
+    @AfterClass
+    public static void tearDownClass() throws Exception {
+    }
+
+    @BeforeMethod
+    public void setUpMethod() throws Exception {
+    }
+
+    @AfterMethod
+    public void tearDownMethod() throws Exception {
+    }
+
+    private void generateData() throws InterruptedException {
+        graph = new StoreGraph();
+    }
+
+    @Test
+    public void simulateResetContextMenuTest() throws InterruptedException, PluginException {
+        generateData();
+
+        final ResetViewContextMenu menu = new ResetViewContextMenu();
+
+        assertEquals(graph.getVertexCount(), 0);
+        assertEquals(graph.getTransactionCount(), 0);
+
+        assertFalse(menu.getItems(graph, GraphElementType.GRAPH, 0).isEmpty());
+        assertTrue(menu.getItems(graph, GraphElementType.EDGE, 0).isEmpty());
+        assertTrue(menu.getItems(graph, GraphElementType.LINK, 0).isEmpty());
+        assertTrue(menu.getItems(graph, GraphElementType.META, 0).isEmpty());
+        assertTrue(menu.getItems(graph, GraphElementType.TRANSACTION, 0).isEmpty());
+
+        assertFalse(menu.getIcons(graph, GraphElementType.GRAPH, 0).isEmpty());
+        assertTrue(menu.getIcons(graph, GraphElementType.EDGE, 0).isEmpty());
+        assertTrue(menu.getIcons(graph, GraphElementType.LINK, 0).isEmpty());
+        assertTrue(menu.getIcons(graph, GraphElementType.META, 0).isEmpty());
+        assertTrue(menu.getIcons(graph, GraphElementType.TRANSACTION, 0).isEmpty());
+    }
+}

--- a/CoreVisualGraph/src/au/gov/asd/tac/constellation/graph/visual/plugins/select/SelectionContextMenu.java
+++ b/CoreVisualGraph/src/au/gov/asd/tac/constellation/graph/visual/plugins/select/SelectionContextMenu.java
@@ -22,9 +22,13 @@ import au.gov.asd.tac.constellation.graph.visual.VisualGraphPluginRegistry;
 import au.gov.asd.tac.constellation.graph.visual.contextmenu.ContextMenuProvider;
 import au.gov.asd.tac.constellation.plugins.PluginExecution;
 import au.gov.asd.tac.constellation.utilities.graphics.Vector3f;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import javax.swing.ImageIcon;
+import org.netbeans.api.annotations.common.StaticResource;
+import org.openide.util.ImageUtilities;
 import org.openide.util.lookup.ServiceProvider;
 
 /**
@@ -35,7 +39,34 @@ import org.openide.util.lookup.ServiceProvider;
 @ServiceProvider(service = ContextMenuProvider.class, position = 800)
 public class SelectionContextMenu implements ContextMenuProvider {
 
+    private static final String SELECT_ALL = "Select All";
+    private static final String DESELECT_ALL = "Deselect All";
+    private static final String DESELECT_VERTICES = "Deselect Nodes";
+    private static final String DESELECT_TRANSACTIONS = "Deselect Transactions";
     private static final String INVERT_SELECTION = "Invert Selection";
+    private static final String SELECT_BLAZES = "Select Blazes";
+    private static final String DESELECT_BLAZES = "Deselect Blazes";
+    private static final String SELECT_DIMMED = "Select Dimmed";
+    private static final String SELECT_UNDIMMED = "Select Undimmed";
+
+    @StaticResource
+    private static final String SELECT_ALL_ICON = "au/gov/asd/tac/constellation/graph/visual/plugins/select/resources/select_all.png";
+    @StaticResource
+    private static final String DESELECT_ALL_ICON = "au/gov/asd/tac/constellation/graph/visual/plugins/select/resources/deselect_all.png";
+    @StaticResource
+    private static final String DESELECT_VERTICES_ICON = "au/gov/asd/tac/constellation/graph/visual/plugins/select/resources/deselectNodes.png";
+    @StaticResource
+    private static final String DESELECT_TRANSACTIONS_ICON = "au/gov/asd/tac/constellation/graph/visual/plugins/select/resources/deselectTransactions.png";
+    @StaticResource
+    private static final String INVERT_SELECTION_ICON = "au/gov/asd/tac/constellation/graph/visual/plugins/select/resources/invert_selection.png";
+    @StaticResource
+    private static final String SELECT_BLAZES_ICON = "au/gov/asd/tac/constellation/graph/visual/plugins/blaze/resources/selectblazes.png";
+    @StaticResource
+    private static final String DESELECT_BLAZES_ICON = "au/gov/asd/tac/constellation/graph/visual/plugins/blaze/resources/blaze.png";
+    @StaticResource
+    private static final String SELECT_DIMMED_ICON = "au/gov/asd/tac/constellation/graph/visual/plugins/dim/resources/select_dimmed.png";
+    @StaticResource
+    private static final String SELECT_UNDIMMED_ICON = "au/gov/asd/tac/constellation/graph/visual/plugins/dim/resources/select_undimmed.png";
 
     @Override
     public List<String> getMenuPath(final GraphElementType elementType) {
@@ -45,7 +76,7 @@ public class SelectionContextMenu implements ContextMenuProvider {
     @Override
     public List<String> getItems(final GraphReadMethods graph, final GraphElementType elementType, final int entity) {
         if (elementType == GraphElementType.GRAPH) {
-            return Arrays.asList();
+            return Arrays.asList(SELECT_ALL, DESELECT_ALL, DESELECT_VERTICES, DESELECT_TRANSACTIONS, INVERT_SELECTION, SELECT_BLAZES, DESELECT_BLAZES, SELECT_DIMMED, SELECT_UNDIMMED);
         } else {
             return Collections.emptyList();
         }
@@ -53,8 +84,51 @@ public class SelectionContextMenu implements ContextMenuProvider {
 
     @Override
     public void selectItem(String item, Graph graph, GraphElementType elementType, int entity, Vector3f unprojected) {
-        if (INVERT_SELECTION.equals(item)) {
+        if (SELECT_ALL.equals(item)) {
+            PluginExecution.withPlugin(VisualGraphPluginRegistry.SELECT_ALL).executeLater(graph);
+        } else if (DESELECT_ALL.equals(item)) {
+            PluginExecution.withPlugin(VisualGraphPluginRegistry.DESELECT_ALL).executeLater(graph);
+        } else if (DESELECT_VERTICES.equals(item)) {
+            PluginExecution.withPlugin(VisualGraphPluginRegistry.DESELECT_VERTICES).executeLater(graph);
+        } else if (DESELECT_TRANSACTIONS.equals(item)) {
+            PluginExecution.withPlugin(VisualGraphPluginRegistry.DESELECT_TRANSACTIONS).executeLater(graph);
+        } else if (INVERT_SELECTION.equals(item)) {
             PluginExecution.withPlugin(VisualGraphPluginRegistry.INVERT_SELECTION).executeLater(graph);
+        } else if (SELECT_BLAZES.equals(item)) {
+            PluginExecution.withPlugin(VisualGraphPluginRegistry.SELECT_BLAZES).executeLater(graph);
+        } else if (DESELECT_BLAZES.equals(item)) {
+            PluginExecution.withPlugin(VisualGraphPluginRegistry.DESELECT_BLAZES).executeLater(graph);
+        } else if (SELECT_DIMMED.equals(item)) {
+            PluginExecution.withPlugin(VisualGraphPluginRegistry.SELECT_DIMMED).executeLater(graph);
+        } else if (SELECT_UNDIMMED.equals(item)) {
+            PluginExecution.withPlugin(VisualGraphPluginRegistry.SELECT_UNDIMMED).executeLater(graph);
+        }
+    }
+
+    /**
+     * Produce the list of icons for the selection menu
+     *
+     * @param graph the graph that has been right-clicked on.
+     * @param elementType the type of element that has been right-clicked on.
+     * @param elementId the id of the element that has been right-clicked on.
+     * @return list of selection icons
+     */
+    @Override
+    public List<ImageIcon> getIcons(final GraphReadMethods graph, final GraphElementType elementType, final int elementId) {
+        if (elementType == GraphElementType.GRAPH) {
+            final List<ImageIcon> icons = new ArrayList<>();
+            icons.add(ImageUtilities.loadImageIcon(SELECT_ALL_ICON, false));
+            icons.add(ImageUtilities.loadImageIcon(DESELECT_ALL_ICON, false));
+            icons.add(ImageUtilities.loadImageIcon(DESELECT_VERTICES_ICON, false));
+            icons.add(ImageUtilities.loadImageIcon(DESELECT_TRANSACTIONS_ICON, false));
+            icons.add(ImageUtilities.loadImageIcon(INVERT_SELECTION_ICON, false));
+            icons.add(ImageUtilities.loadImageIcon(SELECT_BLAZES_ICON, false));
+            icons.add(ImageUtilities.loadImageIcon(DESELECT_BLAZES_ICON, false));
+            icons.add(ImageUtilities.loadImageIcon(SELECT_DIMMED_ICON, false));
+            icons.add(ImageUtilities.loadImageIcon(SELECT_UNDIMMED_ICON, false));
+            return icons;
+        } else {
+            return Collections.emptyList();
         }
     }
 }

--- a/CoreVisualGraph/test/unit/src/au/gov/asd/tac/constellation/graph/visual/plugins/select/SelectionContextMenuNGTest.java
+++ b/CoreVisualGraph/test/unit/src/au/gov/asd/tac/constellation/graph/visual/plugins/select/SelectionContextMenuNGTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2010-2021 Australian Signals Directorate
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package au.gov.asd.tac.constellation.graph.visual.plugins.select;
+
+import au.gov.asd.tac.constellation.graph.GraphElementType;
+import au.gov.asd.tac.constellation.graph.StoreGraph;
+import au.gov.asd.tac.constellation.graph.locking.DualGraph;
+import au.gov.asd.tac.constellation.plugins.PluginException;
+import static org.testng.Assert.assertEquals;
+import static org.testng.AssertJUnit.assertFalse;
+import static org.testng.AssertJUnit.assertTrue;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+/**
+ * SelectionContextMenu Tests. Simulate the user right clicking on different objects
+ * in the graph.  Should only get a non empty response when GRAPH is simulated
+ *
+ * @author CrucisGamma
+ */
+public class SelectionContextMenuNGTest {
+
+    private StoreGraph graph;
+    private DualGraph dgraph;
+
+    public SelectionContextMenuNGTest() {
+    }
+
+    @BeforeClass
+    public static void setUpClass() throws Exception {
+    }
+
+    @AfterClass
+    public static void tearDownClass() throws Exception {
+    }
+
+    @BeforeMethod
+    public void setUpMethod() throws Exception {
+    }
+
+    @AfterMethod
+    public void tearDownMethod() throws Exception {
+    }
+
+    private void generateData() throws InterruptedException {
+        graph = new StoreGraph();
+    }
+
+    @Test
+    public void simulateSelectionContextMenuTest() throws InterruptedException, PluginException {
+        generateData();
+
+        final SelectionContextMenu menu = new SelectionContextMenu();
+
+        assertEquals(graph.getVertexCount(), 0);
+        assertEquals(graph.getTransactionCount(), 0);
+
+        assertFalse(menu.getItems(graph, GraphElementType.GRAPH, 0).isEmpty());
+        assertTrue(menu.getItems(graph, GraphElementType.EDGE, 0).isEmpty());
+        assertTrue(menu.getItems(graph, GraphElementType.LINK, 0).isEmpty());
+        assertTrue(menu.getItems(graph, GraphElementType.META, 0).isEmpty());
+        assertTrue(menu.getItems(graph, GraphElementType.TRANSACTION, 0).isEmpty());
+
+        assertFalse(menu.getIcons(graph, GraphElementType.GRAPH, 0).isEmpty());
+        assertTrue(menu.getIcons(graph, GraphElementType.EDGE, 0).isEmpty());
+        assertTrue(menu.getIcons(graph, GraphElementType.LINK, 0).isEmpty());
+        assertTrue(menu.getIcons(graph, GraphElementType.META, 0).isEmpty());
+        assertTrue(menu.getIcons(graph, GraphElementType.TRANSACTION, 0).isEmpty());
+    }
+}


### PR DESCRIPTION
### Prerequisites

- [x] Reviewed the [checklist](CHECKLIST.md)

- [ ] Reviewed feedback from the "Sonar Cloud" bot. Note that you have to wait
    for the "CI / Unit Tests") to complete first.

### Description of the Change

Adds in the Selection menu (with icons) on right clicking the Graph menu and adds in the Reset menu (with icons) as well
![image](https://user-images.githubusercontent.com/62917181/138010780-b549fd8a-4c24-4acb-85c3-064209e01257.png)

### Alternate Designs

Nil.  The ordering of the selection and reset view sub menus are the same as the default menu options

### Why Should This Be In Core?

Already there

### Benefits

Enhances UX for the user

### Possible Drawbacks

Nil

### Verification Process

Ran across multiple graphs with no issues or bugs noticed.

### Applicable Issues

#1261 I see this as addressing the actual problem that that issue was looking at.
