### PR TITLE
Add autoscroll for new notes being added to the notes view

### DIFF
--- a/CoreNotesView/src/au/gov/asd/tac/constellation/views/notes/NotesViewPane.java
+++ b/CoreNotesView/src/au/gov/asd/tac/constellation/views/notes/NotesViewPane.java
@@ -514,7 +514,8 @@ public class NotesViewPane extends BorderPane {
                     createNote(note);
                 });
             }
-
+            notesListScrollPane.applyCss();
+            notesListScrollPane.layout();
             // Keeps the scroll bar at the bottom?
             notesListScrollPane.setVvalue(notesListScrollPane.getVmax());
         });


### PR DESCRIPTION
<!--

### Requirements

* Filling out the template is required. Any pull request that does not include
enough information to be reviewed in a timely manner may be closed at the
maintainers' discretion.
* All new code requires unit tests to ensure they work as expected and will
continue to work as new code is added in the future (regression testing).
* Make sure your branch name is prefixed by `feature`, `bugfix` or `release`
* Have you read Constellation's Code of Conduct? By filing an issue, you are
expected to comply with it, including treating everyone with respect:
https://github.com/constellation-app/constellation/blob/master/CODE_OF_CONDUCT.md

-->

### Prerequisites

- [ ] Reviewed the [checklist](CHECKLIST.md)

- [ ] Reviewed feedback from the "Sonar Cloud" bot. Note that you have to wait
    for the "CI / Unit Tests") to complete first.

### Description of the Change

Fixed the auto scroll to new note when a new note is added.  The current implementation is setting the scroll to the bottom of the pane where the new note should be but the max value of the scroll is being calculated before the note is added so the maximum v height is set to the old value.  This small change forces a recalculation of the layout using the sequence of operations outlined in the JavaFX Node doco [https://docs.oracle.com/javase/8/javafx/api/javafx/scene/Node.html#applyCss--](url)

### Alternate Designs

None considered

### Why Should This Be In Core?

Increases usability when adding new notes in the notes viewer.

### Benefits

Increases usability when adding new notes in the notes viewer.

### Possible Drawbacks


### Verification Process

- Open a new graph or a graph that previously had notes
- Add new notes until they no longer fit into the current view
- Add one more note, the scroll bar should scroll to view the new note.

### Applicable Issues

#1444 
