### PR TITLE
fix backbone plugin treating self-loops as links

### DIFF
--- a/CoreVisualGraph/src/au/gov/asd/tac/constellation/graph/visual/plugins/select/structure/SelectBackbonePlugin.java
+++ b/CoreVisualGraph/src/au/gov/asd/tac/constellation/graph/visual/plugins/select/structure/SelectBackbonePlugin.java
@@ -62,7 +62,9 @@ public class SelectBackbonePlugin extends SimpleEditPlugin {
         // identify all transactions whose both nodes are selected
         for (int position = 0; position < graph.getTransactionCount(); position++) {
             final int txId = graph.getTransaction(position);
-            if (selected_nodes.contains(graph.getTransactionDestinationVertex(txId)) && selected_nodes.contains(graph.getTransactionSourceVertex(txId))) {
+            final int destVert = graph.getTransactionDestinationVertex(txId);
+            final int srcVert = graph.getTransactionSourceVertex(txId);
+            if (selected_nodes.contains(destVert) && selected_nodes.contains(srcVert) && srcVert != destVert) {
                 graph.setBooleanValue(selectedTransactionAttrId, txId, true);
             }
 


### PR DESCRIPTION
<!--

### Requirements

* Filling out the template is required. Any pull request that does not include
enough information to be reviewed in a timely manner may be closed at the
maintainers' discretion.
* All new code requires unit tests to ensure they work as expected and will
continue to work as new code is added in the future (regression testing).
* Make sure your branch name is prefixed by `feature`, `bugfix` or `release`
* Have you read Constellation's Code of Conduct? By filing an issue, you are
expected to comply with it, including treating everyone with respect:
https://github.com/constellation-app/constellation/blob/master/CODE_OF_CONDUCT.md

-->

### Prerequisites

- [ ] Reviewed the [checklist](CHECKLIST.md)

- [ ] Reviewed feedback from the "Sonar Cloud" bot. Note that you have to wait
    for the "CI / Unit Tests") to complete first.

### Description of the Change

Remove self-loops when calculating the backbone.  In the current implementation nodes that have self nodes are included in the backbone without any external links as observed in #1340.  The new implementation simply checks that their neighbors aren't self-loops.  

Before:
![image](https://user-images.githubusercontent.com/63685177/138103593-b4651921-4263-48b7-a8bb-61e168b68265.png)


After:
![image](https://user-images.githubusercontent.com/63685177/138103547-0c5b5499-eba5-4c6c-b2ff-bafb166d551d.png)


### Alternate Designs

None considered.

### Why Should This Be In Core?

This behavior is more in line with user expectations and doesn't allow singletons in the backbone.

### Benefits

It is a more accurate representation of the backbone.  

### Possible Drawbacks

The additional check to identify the neighbors aren't self-loops has some overhead.  The change introduced an average of 6.4% delay to computing the backbone when computing on a small world generated graph with the following:
Nodes: 10000
Nearest Neighbors to attach: 2
Rewiring probability: 0.5
Link: 14141
Edges: 38328
Transactions: 369411

### Verification Process

- Create a new graph
- Add some nodes that have self loops as well as nodes that have more than 1 link (not including self-loops)
- Run the backbone plugin
- The nodes that have more than 1 link should be selected and the nodes that just have self loops shouldn't be selected on the graph.

### Applicable Issues

#1340 
