### PR TITLE
:fire: Remove unused HttpsConnection code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Changes in October 2021
 
+-   Removed the `keepAlive` method from `HttpsConnection` as it is not the 
+    method to enable HTTP keep-alive for `HttpURLConnection`. `keepAlive` is 
+    turned on by default and is controlled using the `http.keepalive` VM
+    argument.
+
 -   Added `isRequired` in `PluginParameter` with a getter and a setter, which 
     can be used to configure the required plugin parameters to mark as `*required`
 	in the swagger.

--- a/CoreUtilities/src/au/gov/asd/tac/constellation/utilities/https/HttpsConnection.java
+++ b/CoreUtilities/src/au/gov/asd/tac/constellation/utilities/https/HttpsConnection.java
@@ -50,7 +50,6 @@ public class HttpsConnection {
     private static final String NO_CERTIFICATE_ERROR = "Failed to create a secure connection. Make sure CONSTELLATION has access to your certificate.";
 
     private final HttpURLConnection httpConnection;
-    private final boolean enableSSL;
 
     /**
      * A {@code HttpsURLConnection} with some sensible default values
@@ -66,9 +65,8 @@ public class HttpsConnection {
      */
     public HttpsConnection(final URL url, final boolean enableSSL) throws IOException {
         this.httpConnection = enableSSL ? (HttpsURLConnection) url.openConnection() : (HttpURLConnection) url.openConnection();
-        this.enableSSL = enableSSL;
 
-        if (this.enableSSL) {
+        if (enableSSL) {
             if (ConstellationSecurityManager.getCurrentSecurityContext() == null) {
                 throw new RuntimeException(NO_CERTIFICATE_ERROR);
             }
@@ -253,16 +251,6 @@ public class HttpsConnection {
      */
     public HttpsConnection withXmlContentType() {
         httpConnection.setRequestProperty(HttpsConnection.CONTENT_TYPE, HttpsConnection.APPLICATION_XML);
-        return this;
-    }
-
-    /**
-     * Set the request property to Connection Keep Alive
-     *
-     * @return HttpsConnection
-     */
-    public HttpsConnection keepAlive() {
-        httpConnection.setRequestProperty(HttpsConnection.CONNECTION, HttpsConnection.KEEP_ALIVE);
         return this;
     }
 


### PR DESCRIPTION
### Prerequisites

- [x] Reviewed the [checklist](CHECKLIST.md)

- [x] Reviewed feedback from the "Sonar Cloud" bot. Note that you have to wait
    for the "CI / Unit Tests") to complete first.

### Description of the Change

`HttpsConnection` had two areas of unused code. The first was the `enableSSL` member variable. The second was the `keepAlive` method which was intended to enable `HTTP keep-alive`. As shown in the [Mics HTTP URL stream protocol handler VM properties](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/net/doc-files/net-properties.html#MiscHTTP) `keep-alive` is controlled by the `http.keepalive` VM property with defaults to `true`.

### Alternate Designs

None.

### Why Should This Be In Core?

It is a class used by many things, and already in the Core.

### Benefits

Reducing complexity by removing unnecessary code.

### Possible Drawbacks

None.

### Verification Process

Confirmed that the `keepAlive` method in `HttpsConnection` does nothing by creating a test harness that executes the method then inspects the set of `requestProperties`. The method attempts to add a `requestProperty` but silently fails - no new property is added and the size of the collection remains the same.

### Applicable Issues

None.
