### PR TITLE
Fix to Analytic View sort

### DIFF
--- a/CoreAnalyticView/src/au/gov/asd/tac/constellation/views/analyticview/results/AnalyticResult.java
+++ b/CoreAnalyticView/src/au/gov/asd/tac/constellation/views/analyticview/results/AnalyticResult.java
@@ -20,6 +20,8 @@ import au.gov.asd.tac.constellation.views.analyticview.AnalyticViewTopComponent.
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -33,8 +35,7 @@ import java.util.stream.Collectors;
  */
 public abstract class AnalyticResult<D extends AnalyticData> {
 
-    protected final Map<IdentificationData, D> result = new HashMap<>();
-//    protected final List<D> result = new LinkedList<>();
+    protected Map<IdentificationData, D> result = new LinkedHashMap<>();
     protected final Map<String, String> metadata = new HashMap<>();
     protected boolean ignoreNullResults = false;
     protected AnalyticController analyticController = null;
@@ -78,6 +79,35 @@ public abstract class AnalyticResult<D extends AnalyticData> {
     }
 
     public final void sort() {
+        result = sortMapByValuesWithDuplicates(result);
+    }
+
+    private LinkedHashMap sortMapByValuesWithDuplicates(Map<IdentificationData, D> passedMap) {
+        List mapKeys = new ArrayList(passedMap.keySet());
+        List mapValues = new ArrayList(passedMap.values());
+        Collections.sort(mapValues);
+
+        LinkedHashMap sortedMap = new LinkedHashMap();
+
+        Iterator valueIt = mapValues.iterator();
+        while (valueIt.hasNext()) {
+            Object val = valueIt.next();
+            Iterator keyIt = mapKeys.iterator();
+
+            while (keyIt.hasNext()) {
+                Object key = keyIt.next();
+                String comp1 = passedMap.get(key).toString();
+                String comp2 = val.toString();
+
+                if (comp1.equals(comp2)) {
+                    passedMap.remove(key);
+                    mapKeys.remove(key);
+                    sortedMap.put(key, val);
+                    break;
+                }
+            }
+        }
+        return sortedMap;
     }
 
     public final List<D> get() {

--- a/CoreAnalyticView/src/au/gov/asd/tac/constellation/views/analyticview/results/AnalyticResult.java
+++ b/CoreAnalyticView/src/au/gov/asd/tac/constellation/views/analyticview/results/AnalyticResult.java
@@ -24,6 +24,7 @@ import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.stream.Collectors;
 
 /**
@@ -35,7 +36,7 @@ import java.util.stream.Collectors;
  */
 public abstract class AnalyticResult<D extends AnalyticData> {
 
-    protected Map<IdentificationData, D> result = new LinkedHashMap<>();
+    protected final Map<IdentificationData, D> result = new LinkedHashMap<>();
     protected final Map<String, String> metadata = new HashMap<>();
     protected boolean ignoreNullResults = false;
     protected AnalyticController analyticController = null;
@@ -79,35 +80,28 @@ public abstract class AnalyticResult<D extends AnalyticData> {
     }
 
     public final void sort() {
-        result = sortMapByValuesWithDuplicates(result);
-    }
 
-    private LinkedHashMap sortMapByValuesWithDuplicates(Map<IdentificationData, D> passedMap) {
-        List mapKeys = new ArrayList(passedMap.keySet());
-        List mapValues = new ArrayList(passedMap.values());
-        Collections.sort(mapValues);
+        final List<Entry<IdentificationData, D>> mapPairs = new ArrayList<>(result.entrySet());
+        final List<D> mapValues = new ArrayList<>(result.values());
+        mapValues.sort(null);
 
-        LinkedHashMap sortedMap = new LinkedHashMap();
+        result.clear();
 
-        Iterator valueIt = mapValues.iterator();
+        final Iterator<D> valueIt = mapValues.iterator();
         while (valueIt.hasNext()) {
-            Object val = valueIt.next();
-            Iterator keyIt = mapKeys.iterator();
+            final D val = valueIt.next();
 
-            while (keyIt.hasNext()) {
-                Object key = keyIt.next();
-                String comp1 = passedMap.get(key).toString();
-                String comp2 = val.toString();
+            final Iterator<Entry<IdentificationData, D>> pairIt = mapPairs.iterator();
+            while (pairIt.hasNext()) {
+                final Entry<IdentificationData, D> pair = pairIt.next();
 
-                if (comp1.equals(comp2)) {
-                    passedMap.remove(key);
-                    mapKeys.remove(key);
-                    sortedMap.put(key, val);
+                if (pair.getValue().equals(val)) {
+                    mapPairs.remove(pair);
+                    result.put(pair.getKey(), pair.getValue());
                     break;
                 }
             }
         }
-        return sortedMap;
     }
 
     public final List<D> get() {


### PR DESCRIPTION
<!--

### Requirements

* Filling out the template is required. Any pull request that does not include
enough information to be reviewed in a timely manner may be closed at the
maintainers' discretion.
* All new code requires unit tests to ensure they work as expected and will
continue to work as new code is added in the future (regression testing).
* Make sure your branch name is prefixed by `feature`, `bugfix` or `release`
* Have you read Constellation's Code of Conduct? By filing an issue, you are
expected to comply with it, including treating everyone with respect:
https://github.com/constellation-app/constellation/blob/master/CODE_OF_CONDUCT.md

-->

### Prerequisites

- [ ] Reviewed the [checklist](CHECKLIST.md)

- [ ] Reviewed feedback from the "Sonar Cloud" bot. Note that you have to wait
    for the "CI / Unit Tests") to complete first.

### Description of the Change

After the recent Analytic View refactor the default sort was disabled and the results were displayed in random order. This fix brings back the default descending order of the results. 

### Alternate Designs

<!--

Explain what other alternates were considered and why the proposed version was
selected.

-->

### Why Should This Be In Core?

Core functionality

### Benefits

The descending order is more intuitive to analyze the data. The random ordering was misleading   

### Possible Drawbacks

Possible performance issues tested, but there is no change in performance.  

### Verification Process

1. Open the Analytic View and open a graph.
2. Select any Analytic Question e.g. 'Connects The Network Best' -> 'Betweenness Centrality Alalytic' and Run the plugin.
3. Notice the results are sorted in descending order.



### Applicable Issues

<!-- Link any applicable issues here -->
