### PR TITLE
updated logging surrounding loading of autosave files

### DIFF
--- a/CoreGraphFile/src/au/gov/asd/tac/constellation/graph/file/save/AutosaveUtilities.java
+++ b/CoreGraphFile/src/au/gov/asd/tac/constellation/graph/file/save/AutosaveUtilities.java
@@ -175,19 +175,19 @@ public final class AutosaveUtilities {
      */
     public static void copyFile(final File autosave, final File to) throws IOException {
         final File toBak = new File(to.getPath() + ".bak");
-        LOGGER.log(Level.INFO, String.format("Processing request to open autosave file: %s", autosave.toString()));
+        LOGGER.log(Level.INFO, "Processing request to open autosave file: {0}", autosave.toString());
         if (toBak.exists()) {
             final boolean toBakIsDeleted = toBak.delete();
             if (!toBakIsDeleted) {
-                LOGGER.log(Level.WARNING, String.format("Unable to remove old backup file: %s", toBak.toString()));
+                LOGGER.log(Level.WARNING, "Unable to remove old backup file: {0}", toBak.toString());
             }
         }
 
         if (to.exists()) {
             final boolean toRenamed = to.renameTo(toBak);
-             LOGGER.log(Level.INFO, String.format("Backing up %s to %s", to.toString(), toBak.toString()));
+                LOGGER.log(Level.INFO, "Backing up {0} to {1}", new Object[]{to.toString(), toBak.toString()});
             if (!toRenamed) {
-                LOGGER.log(Level.WARNING, String.format("Unable to backup file: %s", to.toString()));
+                LOGGER.log(Level.WARNING, "Unable to backup file: {0}", to.toString());
             }
         }
 
@@ -204,7 +204,7 @@ public final class AutosaveUtilities {
                 }
             }
         }
-        LOGGER.log(Level.INFO, String.format("Replacing %s with autosave file prior to opening", to.toString()));
+        LOGGER.log(Level.INFO, "Replacing {0} with autosave file prior to opening", to.toString());
     }
 
     /**

--- a/CoreGraphFile/src/au/gov/asd/tac/constellation/graph/file/save/AutosaveUtilities.java
+++ b/CoreGraphFile/src/au/gov/asd/tac/constellation/graph/file/save/AutosaveUtilities.java
@@ -83,7 +83,8 @@ public final class AutosaveUtilities {
     }
 
     /**
-     * Delete the autosave files belonging to the specified graph id.
+     * Delete the 
+     * files belonging to the specified graph id.
      * <p>
      * This is typically for when the VisualTopComponent is closing and the
      * graph has not been modified.
@@ -167,28 +168,30 @@ public final class AutosaveUtilities {
      * The destination file is renamed to file.bak, the source file is copied,
      * the .bak file is deleted.
      *
-     * @param from The source file.
+     * @param autosave The autosave source file.
      * @param to The destination file.
      *
      * @throws IOException When an error happens.
      */
-    public static void copyFile(final File from, final File to) throws IOException {
+    public static void copyFile(final File autosave, final File to) throws IOException {
         final File toBak = new File(to.getPath() + ".bak");
+        LOGGER.log(Level.INFO, String.format("Processing request to open autosave file: %s", autosave.toString()));
         if (toBak.exists()) {
             final boolean toBakIsDeleted = toBak.delete();
             if (!toBakIsDeleted) {
-                //TODO: Handle case where file not successfully deleted
+                LOGGER.log(Level.WARNING, String.format("Unable to remove old backup file: %s", toBak.toString()));
             }
         }
 
         if (to.exists()) {
             final boolean toRenamed = to.renameTo(toBak);
+             LOGGER.log(Level.INFO, String.format("Backing up %s to %s", to.toString(), toBak.toString()));
             if (!toRenamed) {
-                //TODO: Handle case where file not successfully renamed
+                LOGGER.log(Level.WARNING, String.format("Unable to backup file: %s", to.toString()));
             }
         }
 
-        try (InputStream in = new FileInputStream(from)) {
+        try (InputStream in = new FileInputStream(autosave)) {
             try (final OutputStream out = new FileOutputStream(to)) {
                 final int bufsiz = 1024 * 1024;
                 final byte[] buf = new byte[bufsiz];
@@ -197,11 +200,11 @@ public final class AutosaveUtilities {
                     if (len == -1) {
                         break;
                     }
-
                     out.write(buf, 0, len);
                 }
             }
         }
+        LOGGER.log(Level.INFO, String.format("Replacing %s with autosave file prior to opening", to.toString()));
     }
 
     /**

--- a/CoreGraphFile/src/au/gov/asd/tac/constellation/graph/file/save/AutosaveUtilities.java
+++ b/CoreGraphFile/src/au/gov/asd/tac/constellation/graph/file/save/AutosaveUtilities.java
@@ -175,19 +175,19 @@ public final class AutosaveUtilities {
      */
     public static void copyFile(final File autosave, final File to) throws IOException {
         final File toBak = new File(to.getPath() + ".bak");
-        LOGGER.log(Level.INFO, "Processing request to open autosave file: {0}", autosave.toString());
+        LOGGER.log(Level.INFO, "Processing request to open autosave file: {0}", autosave);
         if (toBak.exists()) {
             final boolean toBakIsDeleted = toBak.delete();
             if (!toBakIsDeleted) {
-                LOGGER.log(Level.WARNING, "Unable to remove old backup file: {0}", toBak.toString());
+                LOGGER.log(Level.WARNING, "Unable to remove old backup file: {0}", toBak);
             }
         }
 
         if (to.exists()) {
             final boolean toRenamed = to.renameTo(toBak);
-                LOGGER.log(Level.INFO, "Backing up {0} to {1}", new Object[]{to.toString(), toBak.toString()});
+            LOGGER.log(Level.INFO, "Backing up {0} to {1}", new Object[]{to, toBak});
             if (!toRenamed) {
-                LOGGER.log(Level.WARNING, "Unable to backup file: {0}", to.toString());
+                LOGGER.log(Level.WARNING, "Unable to backup file: {0}", to);
             }
         }
 
@@ -204,7 +204,7 @@ public final class AutosaveUtilities {
                 }
             }
         }
-        LOGGER.log(Level.INFO, "Replacing {0} with autosave file prior to opening", to.toString());
+        LOGGER.log(Level.INFO, "Replacing {0} with autosave file prior to opening", to);
     }
 
     /**

--- a/CoreInteractiveGraph/src/au/gov/asd/tac/constellation/graph/interaction/gui/VisualGraphOpener.java
+++ b/CoreInteractiveGraph/src/au/gov/asd/tac/constellation/graph/interaction/gui/VisualGraphOpener.java
@@ -181,7 +181,7 @@ public final class VisualGraphOpener extends GraphOpener {
                 HandleIoProgress ioProgressHandler = new HandleIoProgress(String.format("Reading %s...", graphFile.getName()));
                 try {
                     final long t0 = System.currentTimeMillis();
-                    LOGGER.log(Level.INFO, "Attempting to open {0}", graphFile.toString());
+                    LOGGER.log(Level.INFO, "Attempting to open {0}", graphFile);
                     graph = new GraphJsonReader().readGraphZip(graphFile, ioProgressHandler);
                     time = System.currentTimeMillis() - t0;
                 } catch (final GraphParseException | IOException | RuntimeException ex) {
@@ -203,7 +203,7 @@ public final class VisualGraphOpener extends GraphOpener {
                             // Try to load backup file that was located, if it loads then clear previous exception, if not the
                             // original exception is kept to be handled in the done method
                             final long t0 = System.currentTimeMillis();
-                            LOGGER.log(Level.WARNING, "Unable to open requested file, attempting to open backup {0}", backupFile.toString());
+                            LOGGER.log(Level.WARNING, "Unable to open requested file, attempting to open backup {0}", backupFile);
                             graph = new GraphJsonReader().readGraphZip(backupFile, ioProgressHandler);
                             time = System.currentTimeMillis() - t0;
                             gex = null;
@@ -211,12 +211,12 @@ public final class VisualGraphOpener extends GraphOpener {
                             // Backup file successfully loaded, copy it over top of corrupt actual file - theres no reason to keep the corrupted file.
                             // Don't do a move, rather perform the move in two stages, a copy, then a delete to ensure there
                             // is always going to be a valid file somewhere as only the copy or the delete can fail in a given run.
-                            LOGGER.log(Level.INFO, "Successfully opened backup file: {0}, replacing star file", backupFile.toString());
+                            LOGGER.log(Level.INFO, "Successfully opened backup file: {0}, replacing star file", backupFile);
                             FileUtils.copyFile(new File(backupFile.toString()), new File(graphFile.toString()));
                         }
                     }
                 } catch (final GraphParseException | IOException | RuntimeException ex) {
-                    LOGGER.log(Level.WARNING, "Unable to open requested file ({0}) or any associated backup", graphFile.toString());
+                    LOGGER.log(Level.WARNING, "Unable to open requested file ({0}) or any associated backup", graphFile);
                     gex = ex;
                     // Clear previous progress message and reset to indicate we are trying to use backup.
                     ioProgressHandler.finish();

--- a/CoreInteractiveGraph/src/au/gov/asd/tac/constellation/graph/interaction/gui/VisualGraphOpener.java
+++ b/CoreInteractiveGraph/src/au/gov/asd/tac/constellation/graph/interaction/gui/VisualGraphOpener.java
@@ -211,6 +211,7 @@ public final class VisualGraphOpener extends GraphOpener {
                             // Backup file successfully loaded, copy it over top of corrupt actual file - theres no reason to keep the corrupted file.
                             // Don't do a move, rather perform the move in two stages, a copy, then a delete to ensure there
                             // is always going to be a valid file somewhere as only the copy or the delete can fail in a given run.
+                            LOGGER.log(Level.INFO, String.format("Successfully opened backup file: %s, replacing star file", backupFile.toString()));
                             FileUtils.copyFile(new File(backupFile.toString()), new File(graphFile.toString()));
                         }
                     }

--- a/CoreInteractiveGraph/src/au/gov/asd/tac/constellation/graph/interaction/gui/VisualGraphOpener.java
+++ b/CoreInteractiveGraph/src/au/gov/asd/tac/constellation/graph/interaction/gui/VisualGraphOpener.java
@@ -181,7 +181,7 @@ public final class VisualGraphOpener extends GraphOpener {
                 HandleIoProgress ioProgressHandler = new HandleIoProgress(String.format("Reading %s...", graphFile.getName()));
                 try {
                     final long t0 = System.currentTimeMillis();
-                    LOGGER.log(Level.INFO, String.format("Attempting to open %s", graphFile.toString()));
+                    LOGGER.log(Level.INFO, "Attempting to open {0}", graphFile.toString());
                     graph = new GraphJsonReader().readGraphZip(graphFile, ioProgressHandler);
                     time = System.currentTimeMillis() - t0;
                 } catch (final GraphParseException | IOException | RuntimeException ex) {
@@ -203,7 +203,7 @@ public final class VisualGraphOpener extends GraphOpener {
                             // Try to load backup file that was located, if it loads then clear previous exception, if not the
                             // original exception is kept to be handled in the done method
                             final long t0 = System.currentTimeMillis();
-                            LOGGER.log(Level.WARNING, String.format("Unable to open requested file, attempting to open backup %s", backupFile.toString()));
+                            LOGGER.log(Level.WARNING, "Unable to open requested file, attempting to open backup {0}", backupFile.toString());
                             graph = new GraphJsonReader().readGraphZip(backupFile, ioProgressHandler);
                             time = System.currentTimeMillis() - t0;
                             gex = null;
@@ -211,12 +211,12 @@ public final class VisualGraphOpener extends GraphOpener {
                             // Backup file successfully loaded, copy it over top of corrupt actual file - theres no reason to keep the corrupted file.
                             // Don't do a move, rather perform the move in two stages, a copy, then a delete to ensure there
                             // is always going to be a valid file somewhere as only the copy or the delete can fail in a given run.
-                            LOGGER.log(Level.INFO, String.format("Successfully opened backup file: %s, replacing star file", backupFile.toString()));
+                            LOGGER.log(Level.INFO, "Successfully opened backup file: {0}, replacing star file", backupFile.toString());
                             FileUtils.copyFile(new File(backupFile.toString()), new File(graphFile.toString()));
                         }
                     }
                 } catch (final GraphParseException | IOException | RuntimeException ex) {
-                    LOGGER.log(Level.WARNING, String.format("Unable to open requested file or any associated backup", graphFile.toString()));
+                    LOGGER.log(Level.WARNING, "Unable to open requested file ({0}) or any associated backup", graphFile.toString());
                     gex = ex;
                     // Clear previous progress message and reset to indicate we are trying to use backup.
                     ioProgressHandler.finish();


### PR DESCRIPTION
### Description of the Change
Changed log messages provided during loading of files to give a more detailed picture of what is happening when user opts to use an autosave file. This is aimed at demostrating via logs how original file (and any .bak files) are replace by autosave restore process.
### Alternate Designs
nil
### Why Should This Be In Core?
Reduce user confusion if viewing logs. Actual load process doesnt change.
### Benefits
Reduce user confusion if viewing logs. Actual load process doesnt change.
### Possible Drawbacks
None known.
### Verification Process
Replicate steps documnted in https://github.com/constellation-app/constellation/issues/1091 - Steps to reproduce and view generate dlog messages.
### Applicable Issues

