### PR TITLE
Prevent exception of divide by zero in k-truss

### DIFF
--- a/CoreAlgorithmPlugins/src/au/gov/asd/tac/constellation/plugins/algorithms/clustering/ktruss/NestedKTrussDisplayPanel.java
+++ b/CoreAlgorithmPlugins/src/au/gov/asd/tac/constellation/plugins/algorithms/clustering/ktruss/NestedKTrussDisplayPanel.java
@@ -123,12 +123,18 @@ public class NestedKTrussDisplayPanel extends JPanel implements MouseInputListen
     // Returns the y position on this panel of the given rectangle.
     private int rectY(final int rectangleNum) {
         final int y = rectangles[rectangleNum][2];
+        if(totalNeededHeight == 0){
+            return y;
+        }
         return expandHeight ? (y * PREFERRED_HEIGHT) / totalNeededHeight : y;
     }
 
     // Returns the height in this panel of the given rectangle
     private int rectHeight(final int rectangleNum) {
         final int h = rectangles[rectangleNum][1];
+        if(totalNeededHeight == 0){
+            return h;
+        }
         return expandHeight ? (h * PREFERRED_HEIGHT) / totalNeededHeight : h;
     }
 
@@ -181,7 +187,7 @@ public class NestedKTrussDisplayPanel extends JPanel implements MouseInputListen
         }
         totalNeededHeight = state.getTotalVertsInTrusses() + (totalGaps * COMPONENT_VISUAL_GRAP);
         if (totalNeededHeight < PREFERRED_HEIGHT) {
-            expandHeight = true;
+            expandHeight = totalNeededHeight != 0;
         }
         final Dimension size = new Dimension(getWidth(), expandHeight ? PREFERRED_HEIGHT : totalNeededHeight);
         setSize(size);

--- a/CoreAlgorithmPlugins/src/au/gov/asd/tac/constellation/plugins/algorithms/clustering/ktruss/NestedKTrussDisplayPanel.java
+++ b/CoreAlgorithmPlugins/src/au/gov/asd/tac/constellation/plugins/algorithms/clustering/ktruss/NestedKTrussDisplayPanel.java
@@ -123,19 +123,13 @@ public class NestedKTrussDisplayPanel extends JPanel implements MouseInputListen
     // Returns the y position on this panel of the given rectangle.
     private int rectY(final int rectangleNum) {
         final int y = rectangles[rectangleNum][2];
-        if(totalNeededHeight == 0){
-            return y;
-        }
-        return expandHeight ? (y * PREFERRED_HEIGHT) / totalNeededHeight : y;
+        return (expandHeight && totalNeededHeight != 0) ? (y * PREFERRED_HEIGHT) / totalNeededHeight : y;
     }
 
     // Returns the height in this panel of the given rectangle
     private int rectHeight(final int rectangleNum) {
         final int h = rectangles[rectangleNum][1];
-        if(totalNeededHeight == 0){
-            return h;
-        }
-        return expandHeight ? (h * PREFERRED_HEIGHT) / totalNeededHeight : h;
+        return (expandHeight && totalNeededHeight != 0) ? (h * PREFERRED_HEIGHT) / totalNeededHeight : h;
     }
 
     // Calculates the relative sizes and positions of the rectangles based on the connected component information stored in the


### PR DESCRIPTION
<!--

### Requirements

* Filling out the template is required. Any pull request that does not include
enough information to be reviewed in a timely manner may be closed at the
maintainers' discretion.
* All new code requires unit tests to ensure they work as expected and will
continue to work as new code is added in the future (regression testing).
* Make sure your branch name is prefixed by `feature`, `bugfix` or `release`
* Have you read Constellation's Code of Conduct? By filing an issue, you are
expected to comply with it, including treating everyone with respect:
https://github.com/constellation-app/constellation/blob/master/CODE_OF_CONDUCT.md

-->

### Prerequisites

- [ ] Reviewed the [checklist](CHECKLIST.md)

- [ ] Reviewed feedback from the "Sonar Cloud" bot. Note that you have to wait
    for the "CI / Unit Tests") to complete first. Failed Unit tests can be 
    debugged by adding the label "verbose logging" to the GitHub PR.

### Description of the Change
Pane was resizing by diving by zero because of the `totalNeededHeight` variable. Adding a check to avoid dividing by zero seemed to prevent the exception. I have spend the last few hours trying to correct the actual problem of it being zero and checking if the current solution causes any detrimental behaviour but have not found anything.

I actually could not seem to create a graph that had nested k-trusses for testing. The pane will resize just as it did in previous versions on standard working graphs so I suspect this PR is fine.
<!--

We must be able to understand the design of your change from this description.
If we can't get a good idea of what the code will be doing from the description
here, the pull request may be closed at the maintainers' discretion. Keep in
mind that the maintainer reviewing this PR may not be familiar with or have
worked with the code here recently, so please walk us through the concepts.

-->

### Alternate Designs
Tried to find alternate solution which involved avoiding the  case of zero being the variable value but came up short.
<!--

Explain what other alternates were considered and why the proposed version was
selected.

-->

### Why Should This Be In Core?
Avoids exception to user by defensively checking variable values.
<!--

Explain why this functionality should be in Constellation Core as opposed to a
different module suite. Note that this question is more applicable when adding
new functionality. If this change is a minor update to an existing file then it
is understood that this change has to be to this module suite and a response
and therefore a response to this question is not required.

-->

### Benefits
Avoids exception to user by defensively checking variable values.
<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks
Possibly unfound drawbacks due to not being able to figure out how to trigger a nested ktruss.
<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process
Creating and manipulating the ktruss view to try and throw an exception.
Using sphere graphs to test the functionality is not affected from this change. 
Toggling the up and down arrow 'V' and '^'
<!--

What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (e.g. buttons you clicked, text you typed,
commands you ran, etc.), and describe the results you observed.

-->

### Applicable Issues
#1460 
<!-- Link any applicable issues here -->
