### PR TITLE
Map view various fixes

### DIFF
--- a/CoreImportExportPlugins/src/au/gov/asd/tac/constellation/plugins/importexport/geospatial/AbstractGeoExportPlugin.java
+++ b/CoreImportExportPlugins/src/au/gov/asd/tac/constellation/plugins/importexport/geospatial/AbstractGeoExportPlugin.java
@@ -50,6 +50,7 @@ import au.gov.asd.tac.constellation.plugins.templates.SimpleReadPlugin;
 import au.gov.asd.tac.constellation.utilities.datastructure.Tuple;
 import au.gov.asd.tac.constellation.utilities.geospatial.Shape;
 import au.gov.asd.tac.constellation.utilities.geospatial.Shape.GeometryType;
+import au.gov.asd.tac.constellation.utilities.gui.NotifyDisplayer;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -61,6 +62,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import javafx.stage.FileChooser.ExtensionFilter;
 import org.apache.commons.lang3.StringUtils;
+import org.openide.NotifyDescriptor;
 
 /**
  * Abstract geo export plugin.
@@ -208,6 +210,14 @@ public abstract class AbstractGeoExportPlugin extends SimpleReadPlugin {
 
     @Override
     public void read(final GraphReadMethods graph, final PluginInteraction interaction, final PluginParameters parameters) throws InterruptedException, PluginException {
+        if (parameters.getStringValue(OUTPUT_PARAMETER_ID) == null) {
+            NotifyDisplayer.display("Invalid output file provided, cannot be empty", NotifyDescriptor.ERROR_MESSAGE);
+            return;
+        }
+        if (parameters.getSingleChoice(ELEMENT_TYPE_PARAMETER_ID) == null) {
+            NotifyDisplayer.display("Invalid element type provided, cannot be empty", NotifyDescriptor.ERROR_MESSAGE);
+            return;
+        }
         final File output = new File(parameters.getStringValue(OUTPUT_PARAMETER_ID));
         final GraphElementType elementType = (GraphElementType) ((ElementTypeParameterValue) parameters.getSingleChoice(ELEMENT_TYPE_PARAMETER_ID)).getObjectValue();
         final List<GraphAttribute> graphAttributes = parameters.getMultiChoiceValue(ATTRIBUTES_PARAMETER_ID).getChoicesData().stream()

--- a/CoreMapView/nbproject/project.xml
+++ b/CoreMapView/nbproject/project.xml
@@ -120,6 +120,14 @@
                     </run-dependency>
                 </dependency>
                 <dependency>
+                    <code-name-base>org.openide.dialogs</code-name-base>
+                    <build-prerequisite/>
+                    <compile-dependency/>
+                    <run-dependency>
+                        <specification-version>7.50</specification-version>
+                    </run-dependency>
+                </dependency>
+                <dependency>
                     <code-name-base>org.openide.modules</code-name-base>
                     <build-prerequisite/>
                     <compile-dependency/>

--- a/CoreMapView/src/au/gov/asd/tac/constellation/views/mapview/MapViewTopComponent.java
+++ b/CoreMapView/src/au/gov/asd/tac/constellation/views/mapview/MapViewTopComponent.java
@@ -382,7 +382,7 @@ public final class MapViewTopComponent extends SwingTopComponent<Component> {
         switch (geoType) {
             case GEO_TYPE_COORDINATE:
                 final String[] coordinate = location.split("[,\\s]+");
-                if (!(coordinate.length == 2 || coordinate.length == 3)) {
+                if (coordinate.length != 2 && coordinate.length != 3) {
                     NotifyDisplayer.display("Invalid coordinate syntax provided, should be comma or space separated", NotifyDescriptor.ERROR_MESSAGE);
                     return;
                 }
@@ -401,15 +401,15 @@ public final class MapViewTopComponent extends SwingTopComponent<Component> {
                     NotifyDisplayer.display("Invalid coordinate data provided, latitude and longitude should be numbers", NotifyDescriptor.ERROR_MESSAGE);
                     return;
                 }
-                if (!(latitude > -90F && latitude < 90F)) {
+                if (latitude <= -90F || latitude >= 90F) {
                     NotifyDisplayer.display("Invalid coordinate data provided, latitude should be in the range [-90. 90]", NotifyDescriptor.ERROR_MESSAGE);
                     return;
                 }
-                if (!(longitude > -180F && longitude < 180F)) {
+                if (longitude <= -180F || longitude >= 180F) {
                     NotifyDisplayer.display("Invalid coordinate data provided, longitude should be in the range [-180, 180]", NotifyDescriptor.ERROR_MESSAGE);
                     return;
                 }
-                if (!(radius >= 0F)) {
+                if (radius < 0F) {
                     NotifyDisplayer.display("Invalid coordinate data provided, radius should be greater than or equal to 0", NotifyDescriptor.ERROR_MESSAGE);
                     return;
                 }

--- a/CoreMapView/src/au/gov/asd/tac/constellation/views/mapview/MapViewTopComponent.java
+++ b/CoreMapView/src/au/gov/asd/tac/constellation/views/mapview/MapViewTopComponent.java
@@ -43,6 +43,7 @@ import au.gov.asd.tac.constellation.utilities.geospatial.Mgrs;
 import au.gov.asd.tac.constellation.utilities.gui.JDropDownMenu;
 import au.gov.asd.tac.constellation.utilities.gui.JMultiChoiceComboBoxMenu;
 import au.gov.asd.tac.constellation.utilities.gui.JSingleChoiceComboBoxMenu;
+import au.gov.asd.tac.constellation.utilities.gui.NotifyDisplayer;
 import au.gov.asd.tac.constellation.utilities.icon.AnalyticIconProvider;
 import au.gov.asd.tac.constellation.utilities.icon.UserInterfaceIconProvider;
 import au.gov.asd.tac.constellation.views.SwingTopComponent;
@@ -80,6 +81,7 @@ import javax.swing.JToolBar;
 import javax.swing.ScrollPaneConstants;
 import javax.swing.SwingConstants;
 import javax.swing.SwingUtilities;
+import org.openide.NotifyDescriptor;
 import org.openide.awt.ActionID;
 import org.openide.awt.ActionReference;
 import org.openide.awt.ActionReferences;
@@ -208,30 +210,34 @@ public final class MapViewTopComponent extends SwingTopComponent<Component> {
         final List<String> zoomActions = Arrays.asList(ZOOM_ALL, ZOOM_SELECTION, ZOOM_LOCATION);
         this.zoomMenu = new JDropDownMenu<>(UserInterfaceIconProvider.ZOOM_IN.buildIcon(16, ConstellationColor.AZURE.getJavaColor()), zoomActions);
         zoomMenu.addActionListener(event -> {
-            final String zoomAction = (String) event.getSource();
-            switch (zoomAction) {
-                case ZOOM_ALL:
-                    renderer.zoomToMarkers(markerState);
-                    break;
-                case ZOOM_SELECTION:
-                    final MarkerState selectedOnlyState = new MarkerState();
-                    selectedOnlyState.setShowSelectedOnly(true);
-                    renderer.zoomToMarkers(selectedOnlyState);
-                    break;
-                case ZOOM_LOCATION:
-                    final PluginParameters zoomParameters = createParameters();
-                    final PluginParametersSwingDialog dialog = new PluginParametersSwingDialog(ZOOM_LOCATION, zoomParameters);
-                    dialog.showAndWait();
-                    if (PluginParametersDialog.OK.equals(dialog.getResult())) {
-                        @SuppressWarnings("unchecked") //the plugin that comes from PARAMETER_TYPE is of type SingleChoiceParameter
-                        final PluginParameter<SingleChoiceParameterValue> parameterType = (PluginParameter<SingleChoiceParameterValue>) zoomParameters.getParameters().get(PARAMETER_TYPE);
-                        final String geoType = SingleChoiceParameterType.getChoice(parameterType);
-                        final String location = zoomParameters.getStringValue(PARAMETER_LOCATION);
-                        zoomLocationBasedOnGeoType(geoType, location);
-                    }
-                    break;
-                default:
-                    break;
+            if (currentGraph != null) {
+                final String zoomAction = (String) event.getSource();
+                switch (zoomAction) {
+                    case ZOOM_ALL:
+                        renderer.zoomToMarkers(markerState);
+                        break;
+                    case ZOOM_SELECTION:
+                        final MarkerState selectedOnlyState = new MarkerState();
+                        selectedOnlyState.setShowSelectedOnly(true);
+                        renderer.zoomToMarkers(selectedOnlyState);
+                        break;
+                    case ZOOM_LOCATION:
+                        final PluginParameters zoomParameters = createParameters();
+                        final PluginParametersSwingDialog dialog = new PluginParametersSwingDialog(ZOOM_LOCATION, zoomParameters);
+                        dialog.showAndWait();
+                        if (PluginParametersDialog.OK.equals(dialog.getResult())) {
+                            @SuppressWarnings("unchecked") //the plugin that comes from PARAMETER_TYPE is of type SingleChoiceParameter
+                            final PluginParameter<SingleChoiceParameterValue> parameterType = (PluginParameter<SingleChoiceParameterValue>) zoomParameters.getParameters().get(PARAMETER_TYPE);
+                            final String geoType = SingleChoiceParameterType.getChoice(parameterType);
+                            final String location = zoomParameters.getStringValue(PARAMETER_LOCATION);
+                            zoomLocationBasedOnGeoType(geoType, location);
+                        }
+                        break;
+                    default:
+                        break;
+                }
+            } else {
+                NotifyDisplayer.display("Zoom options require a graph to be open!", NotifyDescriptor.INFORMATION_MESSAGE);
             }
         });
         zoomMenu.setToolTipText("Zoom based on markers or locations in the Map View");
@@ -292,11 +298,16 @@ public final class MapViewTopComponent extends SwingTopComponent<Component> {
         final List<MapExporterWrapper> exporterWrappers = exporters.stream().map(MapExporterWrapper::new).collect(Collectors.toList());
         this.exportMenu = new JDropDownMenu<>(UserInterfaceIconProvider.DOWNLOAD.buildIcon(16, ConstellationColor.AZURE.getJavaColor()), exporterWrappers);
         exportMenu.addActionListener(event -> {
-            final MapExporterWrapper exporterWrapper = (MapExporterWrapper) event.getSource();
-            PluginExecution
-                    .withPlugin(exporterWrapper.getExporter().getPluginReference())
-                    .interactively(true)
-                    .executeLater(currentGraph);
+            if (currentGraph != null) {
+                final MapExporterWrapper exporterWrapper = (MapExporterWrapper) event.getSource();
+                PluginExecution
+                        .withPlugin(exporterWrapper.getExporter().getPluginReference())
+                        .interactively(true)
+                        .executeLater(currentGraph);
+            } else {
+                NotifyDisplayer.display("Export options require a graph to be open!", NotifyDescriptor.INFORMATION_MESSAGE);
+            }
+
         });
         exportMenu.setToolTipText("Export from the Map View");
         toolBar.add(exportMenu);
@@ -371,8 +382,10 @@ public final class MapViewTopComponent extends SwingTopComponent<Component> {
         switch (geoType) {
             case GEO_TYPE_COORDINATE:
                 final String[] coordinate = location.split("[,\\s]+");
-                assert coordinate.length == 2 || coordinate.length == 3 : "Invalid coordinate syntax provided, should be comma or space separated";
-
+                if (!(coordinate.length == 2 || coordinate.length == 3)) {
+                    NotifyDisplayer.display("Invalid coordinate syntax provided, should be comma or space separated", NotifyDescriptor.ERROR_MESSAGE);
+                    return;
+                }
                 final float latitude;
                 final float longitude;
                 final float radius;
@@ -385,11 +398,22 @@ public final class MapViewTopComponent extends SwingTopComponent<Component> {
                         radius = 0;
                     }
                 } catch (final NumberFormatException ex) {
-                    throw new AssertionError("Invalid coordinate data provided, latitude and longitude should be numbers");
+                    NotifyDisplayer.display("Invalid coordinate data provided, latitude and longitude should be numbers", NotifyDescriptor.ERROR_MESSAGE);
+                    return;
                 }
-                assert latitude > -90F && latitude < 90F : "Invalid coordinate data provided, latitude should be in the range [-90. 90]";
-                assert longitude > -180F && longitude < 180F : "Invalid coordinate data provided, longitude should be in the range [-180, 180]";
-                assert radius >= 0F : "Invalid coordinate data provided, radius should be greater than or equal to 0";
+                if (!(latitude > -90F && latitude < 90F)) {
+                    NotifyDisplayer.display("Invalid coordinate data provided, latitude should be in the range [-90. 90]", NotifyDescriptor.ERROR_MESSAGE);
+                    return;
+                }
+                if (!(longitude > -180F && longitude < 180F)) {
+                    NotifyDisplayer.display("Invalid coordinate data provided, longitude should be in the range [-180, 180]", NotifyDescriptor.ERROR_MESSAGE);
+                    return;
+                }
+                if (!(radius >= 0F)) {
+                    NotifyDisplayer.display("Invalid coordinate data provided, radius should be greater than or equal to 0", NotifyDescriptor.ERROR_MESSAGE);
+                    return;
+                }
+
                 final Location coordinateLocation = new Location(latitude, longitude);
                 if (radius > 0) {
                     final float radiusDD = (float) Distance.Haversine.kilometersToDecimalDegrees(radius);


### PR DESCRIPTION
<!--

### Requirements

* Filling out the template is required. Any pull request that does not include
enough information to be reviewed in a timely manner may be closed at the
maintainers' discretion.
* All new code requires unit tests to ensure they work as expected and will
continue to work as new code is added in the future (regression testing).
* Make sure your branch name is prefixed by `feature`, `bugfix` or `release`
* Have you read Constellation's Code of Conduct? By filing an issue, you are
expected to comply with it, including treating everyone with respect:
https://github.com/constellation-app/constellation/blob/master/CODE_OF_CONDUCT.md

-->

### Prerequisites

- [ ] Reviewed the [checklist](CHECKLIST.md)

- [ ] Reviewed feedback from the "Sonar Cloud" bot. Note that you have to wait
    for the "CI / Unit Tests") to complete first. Failed Unit tests can be 
    debugged by adding the label "verbose logging" to the GitHub PR.

### Description of the Change
This change adds validation to the dialogs involved with exporting and zooming.
A graph has to exist before the export menu dialog will pop up. If the export menu button is pressed without a graph, a dialog is presented to notify the user that a graph must be present to export from.

similarly with the zoom to ... menu, there must be a graph present to zoom to a location, so there is relevant error handling around that.

The main issue was to do with there not being a graph present or the inputs being blank.

![image](https://user-images.githubusercontent.com/58677759/149442553-cfab05c6-0852-4208-a01e-a0ebd8b57f3f.png)

<!--

We must be able to understand the design of your change from this description.
If we can't get a good idea of what the code will be doing from the description
here, the pull request may be closed at the maintainers' discretion. Keep in
mind that the maintainer reviewing this PR may not be familiar with or have
worked with the code here recently, so please walk us through the concepts.

-->

### Alternate Designs
I tried to disable the export menu when a graph was not present. this did not work as the jdropdownbox did not disable for some reason, and it didnt seem right to do it for both dialogs. I then tried to swap out the pane with one that effectively did nothing and disabled the view when a graph was not present. This didn't work because the glcanvas couldn't be dyamically swapped out even when repainting (from what I figured).
<!--

Explain what other alternates were considered and why the proposed version was
selected.

-->

### Why Should This Be In Core?
Gives extra information when an error occurs.
Reduces the amount of exceptions to the user.
<!--

Explain why this functionality should be in Constellation Core as opposed to a
different module suite. Note that this question is more applicable when adding
new functionality. If this change is a minor update to an existing file then it
is understood that this change has to be to this module suite and a response
and therefore a response to this question is not required.

-->

### Benefits
as above
<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process

<!--

What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (e.g. buttons you clicked, text you typed,
commands you ran, etc.), and describe the results you observed.

-->

### Applicable Issues
#1572
<!-- Link any applicable issues here -->
