### PR TITLE
RESTApi Swagger showing the response message when the requests with image MIME type fail

### DIFF
--- a/CoreWebServer/src/au/gov/asd/tac/constellation/webserver/api/SwaggerServlet.java
+++ b/CoreWebServer/src/au/gov/asd/tac/constellation/webserver/api/SwaggerServlet.java
@@ -157,13 +157,11 @@ public class SwaggerServlet extends ConstellationHttpServlet {
                     final ObjectNode responses = httpMethod.putObject("responses");
                     final ObjectNode success = responses.putObject("200");
                     success.put(DESCRIPTION, rs.getDescription());
-                    final ObjectNode content = success.putObject("content");
-                    final ObjectNode mime = content.putObject(rs.getMimeType());
-                    final ObjectNode schema = mime.putObject(SCHEMA);
-                    if (rs.getMimeType().equals(RestServiceUtilities.IMAGE_PNG)) {
-                        schema.put("type", "string");
-                        schema.put("format", "binary");
-                    } else if (rs.getMimeType().equals(RestServiceUtilities.APPLICATION_JSON)) {
+
+                    if (rs.getMimeType().equals(RestServiceUtilities.APPLICATION_JSON)) {
+                        final ObjectNode content = success.putObject("content");
+                        final ObjectNode mime = content.putObject(rs.getMimeType());
+                        final ObjectNode schema = mime.putObject(SCHEMA);
                         // Make a wild guess about the response.
                         if (serviceKey.name.toLowerCase(Locale.ENGLISH).startsWith("list")) {
                             schema.put("type", "array");


### PR DESCRIPTION


<!--

### Requirements

* Filling out the template is required. Any pull request that does not include
enough information to be reviewed in a timely manner may be closed at the
maintainers' discretion.
* All new code requires unit tests to ensure they work as expected and will
continue to work as new code is added in the future (regression testing).
* Make sure your branch name is prefixed by `feature`, `bugfix` or `release`
* Have you read Constellation's Code of Conduct? By filing an issue, you are
expected to comply with it, including treating everyone with respect:
https://github.com/constellation-app/constellation/blob/master/CODE_OF_CONDUCT.md

-->

### Prerequisites

- [x] Reviewed the [checklist](CHECKLIST.md)

- [x] Reviewed feedback from the "Sonar Cloud" bot. Note that you have to wait
    for the "CI / Unit Tests") to complete first. Failed Unit tests can be 
    debugged by adding the label "verbose logging" to the GitHub PR.

### Description of the Change
Following endpoints which were not showing the response message because of missing Response body has been fixed. They now display the message in html format in the response body.
Get_graph_image
Get_icon
![image](https://user-images.githubusercontent.com/64826928/154896552-3be7c753-baf7-4a3c-99ed-f4d3a340f28d.png)

<!--

We must be able to understand the design of your change from this description.
If we can't get a good idea of what the code will be doing from the description
here, the pull request may be closed at the maintainers' discretion. Keep in
mind that the maintainer reviewing this PR may not be familiar with or have
worked with the code here recently, so please walk us through the concepts.

-->

### Alternate Designs
The best option is to display the message in JSON format, similar to other end points.
<!--

Explain what other alternates were considered and why the proposed version was
selected.

-->

### Why Should This Be In Core?
Better UX
<!--

Explain why this functionality should be in Constellation Core as opposed to a
different module suite. Note that this question is more applicable when adding
new functionality. If this change is a minor update to an existing file then it
is understood that this change has to be to this module suite and a response
and therefore a response to this question is not required.

-->

### Benefits
User can now see details of what went wrong rather than just an error code.
<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process
Open swagger and run the above endpoints with incorrect constellation secret, and correct constellation secret with incorrect icon name.
The response body should appear with a clear error message.
<!--

What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (e.g. buttons you clicked, text you typed,
commands you ran, etc.), and describe the results you observed.

-->

### Applicable Issues
https://github.com/constellation-app/constellation/issues/656
<!-- Link any applicable issues here -->
