### PR TITLE
Compare graph warning when only one graph is opened

### DIFF
--- a/CoreFunctionality/src/au/gov/asd/tac/constellation/functionality/compare/CompareGraphAction.java
+++ b/CoreFunctionality/src/au/gov/asd/tac/constellation/functionality/compare/CompareGraphAction.java
@@ -22,6 +22,7 @@ import au.gov.asd.tac.constellation.plugins.PluginExecution;
 import au.gov.asd.tac.constellation.utilities.gui.NotifyDisplayer;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
+import javafx.application.Platform;
 import javafx.scene.control.Alert;
 import org.openide.awt.ActionID;
 import org.openide.awt.ActionReference;
@@ -50,7 +51,9 @@ public final class CompareGraphAction implements ActionListener {
                 .interactively(true)
                 .executeLater(context.getGraph());
         } else {
-            NotifyDisplayer.displayAlert("Compare Graph", "Warning", "Two or more graphs need to be open before comparing.", Alert.AlertType.WARNING);
+            Platform.runLater(()-> {
+                NotifyDisplayer.displayAlert("Compare Graph", "Warning", "Two or more graphs need to be open before comparing.", Alert.AlertType.WARNING);
+            });
         }
     }
 }

--- a/CoreFunctionality/src/au/gov/asd/tac/constellation/functionality/compare/CompareGraphAction.java
+++ b/CoreFunctionality/src/au/gov/asd/tac/constellation/functionality/compare/CompareGraphAction.java
@@ -16,10 +16,13 @@
 package au.gov.asd.tac.constellation.functionality.compare;
 
 import au.gov.asd.tac.constellation.functionality.CorePluginRegistry;
+import au.gov.asd.tac.constellation.graph.manager.GraphManager;
 import au.gov.asd.tac.constellation.graph.node.GraphNode;
 import au.gov.asd.tac.constellation.plugins.PluginExecution;
+import au.gov.asd.tac.constellation.utilities.gui.NotifyDisplayer;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
+import javafx.scene.control.Alert;
 import org.openide.awt.ActionID;
 import org.openide.awt.ActionReference;
 import org.openide.awt.ActionRegistration;
@@ -41,8 +44,13 @@ public final class CompareGraphAction implements ActionListener {
 
     @Override
     public void actionPerformed(final ActionEvent e) {
-        PluginExecution.withPlugin(CorePluginRegistry.COMPARE_GRAPH)
+        // Check current graphs opened
+        if(GraphManager.getDefault().getAllGraphs().size() > 1){
+            PluginExecution.withPlugin(CorePluginRegistry.COMPARE_GRAPH)
                 .interactively(true)
                 .executeLater(context.getGraph());
+        } else {
+            NotifyDisplayer.displayAlert("Compare Graph", "Warning", "Two or more graphs need to be open before comparing.", Alert.AlertType.WARNING);
+        }
     }
 }

--- a/CoreFunctionality/src/au/gov/asd/tac/constellation/functionality/compare/CompareGraphAction.java
+++ b/CoreFunctionality/src/au/gov/asd/tac/constellation/functionality/compare/CompareGraphAction.java
@@ -46,14 +46,13 @@ public final class CompareGraphAction implements ActionListener {
     @Override
     public void actionPerformed(final ActionEvent e) {
         // Check current graphs opened
-        if(GraphManager.getDefault().getAllGraphs().size() > 1){
+        if (GraphManager.getDefault().getAllGraphs().size() > 1) {
             PluginExecution.withPlugin(CorePluginRegistry.COMPARE_GRAPH)
                 .interactively(true)
                 .executeLater(context.getGraph());
         } else {
-            Platform.runLater(()-> {
-                NotifyDisplayer.displayAlert("Compare Graph", "Warning", "Two or more graphs need to be open before comparing.", Alert.AlertType.WARNING);
-            });
+            Platform.runLater(() -> NotifyDisplayer.displayAlert("Compare Graph", "Warning", 
+                    "Two or more graphs need to be open before comparing.", Alert.AlertType.WARNING));
         }
     }
 }


### PR DESCRIPTION
<!--

### Requirements

* Filling out the template is required. Any pull request that does not include
enough information to be reviewed in a timely manner may be closed at the
maintainers' discretion.
* All new code requires unit tests to ensure they work as expected and will
continue to work as new code is added in the future (regression testing).
* Make sure your branch name is prefixed by `feature`, `bugfix` or `release`
* Have you read Constellation's Code of Conduct? By filing an issue, you are
expected to comply with it, including treating everyone with respect:
https://github.com/constellation-app/constellation/blob/master/CODE_OF_CONDUCT.md

-->

### Prerequisites

- [ ] Reviewed the [checklist](CHECKLIST.md)

- [ ] Reviewed feedback from the "Sonar Cloud" bot. Note that you have to wait
    for the "CI / Unit Tests") to complete first. Failed Unit tests can be 
    debugged by adding the label "verbose logging" to the GitHub PR.

### Description of the Change

This feature adds a notification to the user when only one graph is present and an attempt is made to compare graphs.
This below image shows the notification that pops up when the compare graph is clicked and one graph exists only. This will not happen if two graphs are present. This will also not be possible to open two graphs, then compare graph, and close one graph. The compare graph is modal and therefore this shouldn't happen.

![image](https://user-images.githubusercontent.com/58677759/156478999-27201f47-bb95-48b6-9636-27506e145306.png)

<!--

We must be able to understand the design of your change from this description.
If we can't get a good idea of what the code will be doing from the description
here, the pull request may be closed at the maintainers' discretion. Keep in
mind that the maintainer reviewing this PR may not be familiar with or have
worked with the code here recently, so please walk us through the concepts.

-->

### Alternate Designs
I looked to add custom logic to the context handler, but this is not accessible within our code it seems. 
This seemed like a good way to go about it because the user should have no need to compare with one graph open. This will descriptively let them know that to compare you need more than one graph.
<!--

Explain what other alternates were considered and why the proposed version was
selected.

-->

### Why Should This Be In Core?
Usability
<!--

Explain why this functionality should be in Constellation Core as opposed to a
different module suite. Note that this question is more applicable when adding
new functionality. If this change is a minor update to an existing file then it
is understood that this change has to be to this module suite and a response
and therefore a response to this question is not required.

-->

### Benefits
Usability
<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks
None realised
<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process
Opened no graphs, one graph, and many. 
Tried closing the graph once compare graph was opened. Modal so could not be done.
<!--

What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (e.g. buttons you clicked, text you typed,
commands you ran, etc.), and describe the results you observed.

-->

### Applicable Issues
#1647 
<!-- Link any applicable issues here -->
