### PR TITLE
#1608

### DIFF
--- a/CorePluginFramework/src/au/gov/asd/tac/constellation/plugins/gui/ValueInputPane.java
+++ b/CorePluginFramework/src/au/gov/asd/tac/constellation/plugins/gui/ValueInputPane.java
@@ -294,18 +294,21 @@ public class ValueInputPane extends HBox implements RecentValuesListener {
     @Override
     public void recentValuesChanged(final RecentValuesChangeEvent e) {
         if (recentValuesCombo != null && parameterId.equals(e.getId())) {
-            recentValuesCombo.getSelectionModel().selectedIndexProperty().removeListener(recentValueSelectionListener);
-            final List<String> recentValues = e.getNewValues();
-            if (recentValues != null) {
-                recentValuesCombo.setItems(FXCollections.observableList(recentValues));
-                recentValuesCombo.setDisable(false);
-            } else {
-                final List<String> empty = Collections.emptyList();
-                recentValuesCombo.setItems(FXCollections.observableList(empty));
-                recentValuesCombo.setDisable(true);
-            }
-            recentValuesCombo.setPromptText("...");
-            recentValuesCombo.getSelectionModel().selectedIndexProperty().addListener(recentValueSelectionListener);
+            //#1608: JavaFX code allows updating the UI from an JavaFX application thread.
+             Platform.runLater(() -> {             
+                recentValuesCombo.getSelectionModel().selectedIndexProperty().removeListener(recentValueSelectionListener);
+                final List<String> recentValues = e.getNewValues();
+                if (recentValues != null) {
+                    recentValuesCombo.setItems(FXCollections.observableList(recentValues));
+                    recentValuesCombo.setDisable(false);
+                } else {
+                    final List<String> empty = Collections.emptyList();
+                    recentValuesCombo.setItems(FXCollections.observableList(empty));
+                    recentValuesCombo.setDisable(true);
+                }
+                recentValuesCombo.setPromptText("...");
+                recentValuesCombo.getSelectionModel().selectedIndexProperty().addListener(recentValueSelectionListener);
+            });
         }
     }
 }

--- a/CorePluginFramework/src/au/gov/asd/tac/constellation/plugins/gui/ValueInputPane.java
+++ b/CorePluginFramework/src/au/gov/asd/tac/constellation/plugins/gui/ValueInputPane.java
@@ -294,18 +294,21 @@ public class ValueInputPane extends HBox implements RecentValuesListener {
     @Override
     public void recentValuesChanged(final RecentValuesChangeEvent e) {
         if (recentValuesCombo != null && parameterId.equals(e.getId())) {
-            recentValuesCombo.getSelectionModel().selectedIndexProperty().removeListener(recentValueSelectionListener);
-            final List<String> recentValues = e.getNewValues();
-            if (recentValues != null) {
-                recentValuesCombo.setItems(FXCollections.observableList(recentValues));
-                recentValuesCombo.setDisable(false);
-            } else {
-                final List<String> empty = Collections.emptyList();
-                recentValuesCombo.setItems(FXCollections.observableList(empty));
-                recentValuesCombo.setDisable(true);
-            }
-            recentValuesCombo.setPromptText("...");
-            recentValuesCombo.getSelectionModel().selectedIndexProperty().addListener(recentValueSelectionListener);
+            //Covering actual value change under FX Thread
+            Platform.runLater(() -> {
+                recentValuesCombo.getSelectionModel().selectedIndexProperty().removeListener(recentValueSelectionListener);
+                final List<String> recentValues = e.getNewValues();
+                if (recentValues != null) {
+                    recentValuesCombo.setItems(FXCollections.observableList(recentValues));
+                    recentValuesCombo.setDisable(false);
+                } else {
+                    final List<String> empty = Collections.emptyList();
+                    recentValuesCombo.setItems(FXCollections.observableList(empty));
+                    recentValuesCombo.setDisable(true);
+                }
+                recentValuesCombo.setPromptText("...");
+                recentValuesCombo.getSelectionModel().selectedIndexProperty().addListener(recentValueSelectionListener);
+            });            
         }
     }
 }

--- a/CorePluginFramework/src/au/gov/asd/tac/constellation/plugins/gui/ValueInputPane.java
+++ b/CorePluginFramework/src/au/gov/asd/tac/constellation/plugins/gui/ValueInputPane.java
@@ -294,7 +294,7 @@ public class ValueInputPane extends HBox implements RecentValuesListener {
     @Override
     public void recentValuesChanged(final RecentValuesChangeEvent e) {
         if (recentValuesCombo != null && parameterId.equals(e.getId())) {
-            //#1608: JavaFX code allows updating the UI from an JavaFX application thread.
+            //JavaFX code allows updating the UI from an JavaFX application thread.
              Platform.runLater(() -> {             
                 recentValuesCombo.getSelectionModel().selectedIndexProperty().removeListener(recentValueSelectionListener);
                 final List<String> recentValues = e.getNewValues();

--- a/CorePluginFramework/src/au/gov/asd/tac/constellation/plugins/gui/ValueInputPane.java
+++ b/CorePluginFramework/src/au/gov/asd/tac/constellation/plugins/gui/ValueInputPane.java
@@ -294,21 +294,18 @@ public class ValueInputPane extends HBox implements RecentValuesListener {
     @Override
     public void recentValuesChanged(final RecentValuesChangeEvent e) {
         if (recentValuesCombo != null && parameterId.equals(e.getId())) {
-            //JavaFX code allows updating the UI from an JavaFX application thread.
-             Platform.runLater(() -> {             
-                recentValuesCombo.getSelectionModel().selectedIndexProperty().removeListener(recentValueSelectionListener);
-                final List<String> recentValues = e.getNewValues();
-                if (recentValues != null) {
-                    recentValuesCombo.setItems(FXCollections.observableList(recentValues));
-                    recentValuesCombo.setDisable(false);
-                } else {
-                    final List<String> empty = Collections.emptyList();
-                    recentValuesCombo.setItems(FXCollections.observableList(empty));
-                    recentValuesCombo.setDisable(true);
-                }
-                recentValuesCombo.setPromptText("...");
-                recentValuesCombo.getSelectionModel().selectedIndexProperty().addListener(recentValueSelectionListener);
-            });
+            recentValuesCombo.getSelectionModel().selectedIndexProperty().removeListener(recentValueSelectionListener);
+            final List<String> recentValues = e.getNewValues();
+            if (recentValues != null) {            
+                recentValuesCombo.setItems(FXCollections.observableList(recentValues));
+                recentValuesCombo.setDisable(false);                
+            } else {
+                final List<String> empty = Collections.emptyList();
+                recentValuesCombo.setItems(FXCollections.observableList(empty));
+                recentValuesCombo.setDisable(true);
+            }
+            recentValuesCombo.setPromptText("...");
+            recentValuesCombo.getSelectionModel().selectedIndexProperty().addListener(recentValueSelectionListener);
         }
     }
 }

--- a/CorePluginFramework/src/au/gov/asd/tac/constellation/plugins/gui/ValueInputPane.java
+++ b/CorePluginFramework/src/au/gov/asd/tac/constellation/plugins/gui/ValueInputPane.java
@@ -296,9 +296,9 @@ public class ValueInputPane extends HBox implements RecentValuesListener {
         if (recentValuesCombo != null && parameterId.equals(e.getId())) {
             recentValuesCombo.getSelectionModel().selectedIndexProperty().removeListener(recentValueSelectionListener);
             final List<String> recentValues = e.getNewValues();
-            if (recentValues != null) {            
+            if (recentValues != null) {
                 recentValuesCombo.setItems(FXCollections.observableList(recentValues));
-                recentValuesCombo.setDisable(false);                
+                recentValuesCombo.setDisable(false);
             } else {
                 final List<String> empty = Collections.emptyList();
                 recentValuesCombo.setItems(FXCollections.observableList(empty));

--- a/CorePluginFramework/src/au/gov/asd/tac/constellation/plugins/parameters/RecentParameterValues.java
+++ b/CorePluginFramework/src/au/gov/asd/tac/constellation/plugins/parameters/RecentParameterValues.java
@@ -108,10 +108,11 @@ public class RecentParameterValues {
      */
     public static void fireChangeEvent(RecentValuesChangeEvent e) {
         synchronized (LISTENERS) {
-            for (RecentValuesListener listener : LISTENERS) {
-                //JavaFX code allows updating the UI from an JavaFX application thread.            
-                Platform.runLater(() -> listener.recentValuesChanged(e));
-            }
+            Platform.runLater(() -> {
+                for (final RecentValuesListener listener : LISTENERS) {
+                  listener.recentValuesChanged(e);
+                }
+            });               
         }
     }
 

--- a/CorePluginFramework/src/au/gov/asd/tac/constellation/plugins/parameters/RecentParameterValues.java
+++ b/CorePluginFramework/src/au/gov/asd/tac/constellation/plugins/parameters/RecentParameterValues.java
@@ -108,11 +108,10 @@ public class RecentParameterValues {
      */
     public static void fireChangeEvent(RecentValuesChangeEvent e) {
         synchronized (LISTENERS) {
-            Platform.runLater(() -> {
-                for (final RecentValuesListener listener : LISTENERS) {
-                  listener.recentValuesChanged(e);
-                }
-            });               
+            for (RecentValuesListener listener : LISTENERS) {
+                //JavaFX code allows updating the UI from an JavaFX application thread.            
+                Platform.runLater(() -> listener.recentValuesChanged(e));
+            }
         }
     }
 

--- a/CorePluginFramework/src/au/gov/asd/tac/constellation/plugins/parameters/RecentParameterValues.java
+++ b/CorePluginFramework/src/au/gov/asd/tac/constellation/plugins/parameters/RecentParameterValues.java
@@ -32,7 +32,6 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.prefs.BackingStoreException;
 import java.util.prefs.Preferences;
-import javafx.application.Platform;
 import org.openide.util.NbPreferences;
 
 /**
@@ -108,11 +107,9 @@ public class RecentParameterValues {
      */
     public static void fireChangeEvent(RecentValuesChangeEvent e) {
         synchronized (LISTENERS) {
-            Platform.runLater(() -> {
-                for (RecentValuesListener listener : LISTENERS) {
-                  listener.recentValuesChanged(e);
-                }
-            });               
+            for (RecentValuesListener listener : LISTENERS) {
+                listener.recentValuesChanged(e);
+            }               
         }
     }
 

--- a/CorePluginFramework/src/au/gov/asd/tac/constellation/plugins/parameters/RecentParameterValues.java
+++ b/CorePluginFramework/src/au/gov/asd/tac/constellation/plugins/parameters/RecentParameterValues.java
@@ -32,6 +32,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.prefs.BackingStoreException;
 import java.util.prefs.Preferences;
+import javafx.application.Platform;
 import org.openide.util.NbPreferences;
 
 /**
@@ -108,7 +109,8 @@ public class RecentParameterValues {
     public static void fireChangeEvent(RecentValuesChangeEvent e) {
         synchronized (LISTENERS) {
             for (RecentValuesListener listener : LISTENERS) {
-                listener.recentValuesChanged(e);
+                //JavaFX code allows updating the UI from an JavaFX application thread.            
+                Platform.runLater(() -> listener.recentValuesChanged(e));
             }
         }
     }

--- a/CorePluginFramework/src/au/gov/asd/tac/constellation/plugins/parameters/RecentParameterValues.java
+++ b/CorePluginFramework/src/au/gov/asd/tac/constellation/plugins/parameters/RecentParameterValues.java
@@ -108,10 +108,11 @@ public class RecentParameterValues {
      */
     public static void fireChangeEvent(RecentValuesChangeEvent e) {
         synchronized (LISTENERS) {
-            for (RecentValuesListener listener : LISTENERS) {
-                //JavaFX code allows updating the UI from an JavaFX application thread.            
-                Platform.runLater(() -> listener.recentValuesChanged(e));
-            }
+            Platform.runLater(() -> {
+                for (RecentValuesListener listener : LISTENERS) {
+                  listener.recentValuesChanged(e);
+                }
+            });               
         }
     }
 


### PR DESCRIPTION
<!--

### Requirements

* Filling out the template is required. Any pull request that does not include
enough information to be reviewed in a timely manner may be closed at the
maintainers' discretion.
* All new code requires unit tests to ensure they work as expected and will
continue to work as new code is added in the future (regression testing).
* Make sure your branch name is prefixed by `feature`, `bugfix` or `release`
* Have you read Constellation's Code of Conduct? By filing an issue, you are
expected to comply with it, including treating everyone with respect:
https://github.com/constellation-app/constellation/blob/master/CODE_OF_CONDUCT.md

-->

### Prerequisites

- [ ] Reviewed the [checklist](CHECKLIST.md)

- [ ] Reviewed feedback from the "Sonar Cloud" bot. Note that you have to wait
    for the "CI / Unit Tests") to complete first. Failed Unit tests can be 
    debugged by adding the label "verbose logging" to the GitHub PR.

### Description of the Change

llegalStateException in Data access view when multiple tabs are added. JavaFX code allows updating the UI from an JavaFX application thread. Need to put the code which is changing the tab pane values under application thread.

### Alternate Designs

<!--

Explain what other alternates were considered and why the proposed version was
selected.

-->

### Why Should This Be In Core?

<!--

Explain why this functionality should be in Constellation Core as opposed to a
different module suite. Note that this question is more applicable when adding
new functionality. If this change is a minor update to an existing file then it
is understood that this change has to be to this module suite and a response
and therefore a response to this question is not required.

-->

### Benefits

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process

Open DAV, select 4-5 plugins, leaving the default parameters.

Open a second tab, and click on it immediately. There should be no exception thrown.

### Applicable Issues

#1608 
