### PR TITLE
Add option to specify display time zone for Datetime formatters in Importers

### DIFF
--- a/CoreImportExportPlugins/src/au/gov/asd/tac/constellation/plugins/importexport/docs/import-from-file.md
+++ b/CoreImportExportPlugins/src/au/gov/asd/tac/constellation/plugins/importexport/docs/import-from-file.md
@@ -109,7 +109,17 @@ a graph, select "Show all schema attributes".
 
 If you have a specific format for example the DateTime, then you can
 right click on the DateTime attribute and select the format from the
-drop down list or enter your own.
+drop down list or enter your own Custom Format.
+
+E.g.
+
+-   Select "MM/dd/yyyy HH:mm:ss" (for 05/12/2009 23:59:13)
+-   Enter Custom format "yyyy-MM-dd'T'HH:mmXXX" (for 1999-07-16T19:20-03:30)
+-   Enter Custom format "yyyy-MM-dd HH:mm:ss.SSS XXX" (for 2020-05-09 22:14:14.037 +09:00)
+-   Enter Custom format "yyyy-MM-dd'T'HH:mm:ssXX" (for 2016-06-10T13:53:22+0400)
+
+If the DateTime format is not EPOCH and it doesn't contain a time zone in the Datetime Parameters window, 
+the "Time Zone" field is enabled and you can specify the input time zone specially when it's not GMT.
 
 If you want to create your own attributes then you can by clicking on
 <img src="../constellation/CoreImportExportPlugins/src/au/gov/asd/tac/constellation/plugins/importexport/docs/resources/plus_black.png" alt="Add Attribute

--- a/CoreImportExportPlugins/src/au/gov/asd/tac/constellation/plugins/importexport/translator/DatetimeAttributeTranslator.java
+++ b/CoreImportExportPlugins/src/au/gov/asd/tac/constellation/plugins/importexport/translator/DatetimeAttributeTranslator.java
@@ -189,9 +189,9 @@ public class DatetimeAttributeTranslator extends AttributeTranslator {
         final String timeZone = timeZoneParam.getStringValue();
         // ZonedDateTime.parse requires a time zone identifier in the string (`value`)
         // hence zonedDateTime = ZonedDateTime.parse(value, df); doesn't work for all other formats
+        if (timeZoneParam.isEnabled() && StringUtils.isNotBlank(timeZone)) {
             ZonedDateTime dateTimeInSpecifiedTimeZone = ZonedDateTime.parse(value, df.withZone(TimeZone.getTimeZone(StringUtils.substringBetween(timeZone, "[", "]")).toZoneId()));
             return TemporalFormatting.ZONED_DATE_TIME_FORMATTER.format(dateTimeInSpecifiedTimeZone);
-        if (timeZoneParam.isEnabled() && StringUtils.isNotBlank(timeZone)) {
         } else {
             final TemporalAccessor temporalAccessorDateTime = df.parse(value);
             return TemporalFormatting.formatAsZonedDateTime(temporalAccessorDateTime);

--- a/CoreImportExportPlugins/src/au/gov/asd/tac/constellation/plugins/importexport/translator/DatetimeAttributeTranslator.java
+++ b/CoreImportExportPlugins/src/au/gov/asd/tac/constellation/plugins/importexport/translator/DatetimeAttributeTranslator.java
@@ -37,6 +37,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.TimeZone;
+import java.util.regex.Pattern;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import org.apache.commons.lang3.StringUtils;
@@ -117,6 +118,16 @@ public class DatetimeAttributeTranslator extends AttributeTranslator {
             if (change == ParameterChange.VALUE) {
                 final PluginParameter<?> slave = params.get(CUSTOM_PARAMETER_ID);
                 slave.setEnabled(master.getStringValue().equals(CUSTOM));
+
+                //disable Time Zone if the Datettime Format contains a Time Zone
+                params.get(TIMEZONE_PARAMETER_ID).setEnabled(!Pattern.matches(".*[XxZzOV']$", master.getStringValue()));
+            }
+        });
+
+        parameters.addController(CUSTOM_PARAMETER_ID, (final PluginParameter<?> master, final Map<String, PluginParameter<?>> params, final ParameterChange change) -> {
+            if (change == ParameterChange.VALUE) {
+                //disable Time Zone if the Custom Format contains a Time Zone
+                params.get(TIMEZONE_PARAMETER_ID).setEnabled(!Pattern.matches(".*[XxZzOV']$", master.getStringValue()));
             }
         });
 
@@ -164,7 +175,7 @@ public class DatetimeAttributeTranslator extends AttributeTranslator {
     }
     
     private String translateFromTemporalAccessorDateTime(final String value, final String format, final String timeZone){
-         final DateTimeFormatter df = DateTimeFormatter.ofPattern(format);
+        final DateTimeFormatter df = DateTimeFormatter.ofPattern(format);
         // ZonedDateTime.parse requires a time zone identifier in the string (`value`)
         // hence zonedDateTime = ZonedDateTime.parse(value, df); doesn't work for all other formats
         if (!StringUtils.isBlank(timeZone)) {

--- a/CoreImportExportPlugins/src/au/gov/asd/tac/constellation/plugins/importexport/translator/DatetimeAttributeTranslator.java
+++ b/CoreImportExportPlugins/src/au/gov/asd/tac/constellation/plugins/importexport/translator/DatetimeAttributeTranslator.java
@@ -138,7 +138,7 @@ public class DatetimeAttributeTranslator extends AttributeTranslator {
         params.get(TIMEZONE_PARAMETER_ID).setEnabled(!containsTimeZone(format) && !format.equals(EPOCH));
     }
 
-    private boolean containsTimeZone(String format){
+    private boolean containsTimeZone(final String format){
         return Pattern.matches(".*[XxZzOV']$", format);
     }
 
@@ -176,7 +176,7 @@ public class DatetimeAttributeTranslator extends AttributeTranslator {
 
     private String translateFromZonedDateTime( final ZonedDateTime zonedDateTime, final PluginParameter timeZoneParam){
         final String timeZone = timeZoneParam.getStringValue();
-        if ( timeZoneParam.isEnabled() && !StringUtils.isBlank(timeZone)) {
+        if (timeZoneParam.isEnabled() && StringUtils.isNotBlank(timeZone)) {
             ZonedDateTime dateTimeInSpecifiedTimeZone = zonedDateTime.withZoneSameLocal(TimeZone.getTimeZone(StringUtils.substringBetween(timeZone, "[", "]")).toZoneId());
             return TemporalFormatting.ZONED_DATE_TIME_FORMATTER.format(dateTimeInSpecifiedTimeZone);
         } else {
@@ -189,9 +189,9 @@ public class DatetimeAttributeTranslator extends AttributeTranslator {
         final String timeZone = timeZoneParam.getStringValue();
         // ZonedDateTime.parse requires a time zone identifier in the string (`value`)
         // hence zonedDateTime = ZonedDateTime.parse(value, df); doesn't work for all other formats
-        if (timeZoneParam.isEnabled() && !StringUtils.isBlank(timeZone)) {
             ZonedDateTime dateTimeInSpecifiedTimeZone = ZonedDateTime.parse(value, df.withZone(TimeZone.getTimeZone(StringUtils.substringBetween(timeZone, "[", "]")).toZoneId()));
             return TemporalFormatting.ZONED_DATE_TIME_FORMATTER.format(dateTimeInSpecifiedTimeZone);
+        if (timeZoneParam.isEnabled() && StringUtils.isNotBlank(timeZone)) {
         } else {
             final TemporalAccessor temporalAccessorDateTime = df.parse(value);
             return TemporalFormatting.formatAsZonedDateTime(temporalAccessorDateTime);

--- a/CoreImportExportPlugins/src/au/gov/asd/tac/constellation/plugins/importexport/translator/DatetimeAttributeTranslator.java
+++ b/CoreImportExportPlugins/src/au/gov/asd/tac/constellation/plugins/importexport/translator/DatetimeAttributeTranslator.java
@@ -219,10 +219,7 @@ public class DatetimeAttributeTranslator extends AttributeTranslator {
     }
 
     private ZonedDateTime convertToDisplayTimeZone(final ZonedDateTime dateTime, final String displayTimeZone){
-        if (StringUtils.isNotBlank(displayTimeZone)) {
-            return dateTime.withZoneSameInstant(getTimeZoneId(displayTimeZone));
-        }
-        return dateTime;
+        return StringUtils.isNotBlank(displayTimeZone) ? dateTime.withZoneSameInstant(getTimeZoneId(displayTimeZone)) : dateTime;
     }
 
     private ZoneId getTimeZoneId(final String timeZone){

--- a/CoreImportExportPlugins/src/au/gov/asd/tac/constellation/plugins/importexport/translator/DatetimeAttributeTranslator.java
+++ b/CoreImportExportPlugins/src/au/gov/asd/tac/constellation/plugins/importexport/translator/DatetimeAttributeTranslator.java
@@ -98,8 +98,8 @@ public class DatetimeAttributeTranslator extends AttributeTranslator {
         parameters.addParameter(customParam);
 
         final PluginParameter<SingleChoiceParameterValue> timeZoneParam = SingleChoiceParameterType.build(TIMEZONE_PARAMETER_ID);
-        timeZoneParam.setName("Custom Format");
-        timeZoneParam.setDescription("A custom datetime format");
+        timeZoneParam.setName("Time Zone");
+        timeZoneParam.setDescription("The time zone the dates represent");
 
         final ObservableList<ZoneId> timeZones = FXCollections.observableArrayList();
         ZoneId.getAvailableZoneIds().forEach(id -> timeZones.add(ZoneId.of(id)));

--- a/CoreImportExportPlugins/src/au/gov/asd/tac/constellation/plugins/importexport/translator/DatetimeAttributeTranslator.java
+++ b/CoreImportExportPlugins/src/au/gov/asd/tac/constellation/plugins/importexport/translator/DatetimeAttributeTranslator.java
@@ -27,6 +27,7 @@ import au.gov.asd.tac.constellation.utilities.temporal.TemporalFormatting;
 import au.gov.asd.tac.constellation.utilities.temporal.TimeZoneUtilities;
 import au.gov.asd.tac.constellation.utilities.text.SeparatorConstants;
 import java.time.DateTimeException;
+import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
@@ -55,6 +56,7 @@ public class DatetimeAttributeTranslator extends AttributeTranslator {
     public static final String FORMAT_PARAMETER_ID = PluginParameter.buildId(DatetimeAttributeTranslator.class, "format");
     public static final String CUSTOM_PARAMETER_ID = PluginParameter.buildId(DatetimeAttributeTranslator.class, "custom");
     public static final String TIMEZONE_PARAMETER_ID = PluginParameter.buildId(DatetimeAttributeTranslator.class, "timezone");
+    public static final String CONVERTED_TIMEZONE_PARAMETER_ID = PluginParameter.buildId(DatetimeAttributeTranslator.class, "convertedtimezone");
 
     private static final String CUSTOM = "CUSTOM";
     private static final String EXCEL = "EXCEL";
@@ -100,10 +102,6 @@ public class DatetimeAttributeTranslator extends AttributeTranslator {
         customParam.setStringValue("");
         parameters.addParameter(customParam);
 
-        final PluginParameter<SingleChoiceParameterValue> timeZoneParam = SingleChoiceParameterType.build(TIMEZONE_PARAMETER_ID);
-        timeZoneParam.setName("Time Zone");
-        timeZoneParam.setDescription("The time zone the dates represent");
-
         final ObservableList<ZoneId> timeZones = FXCollections.observableArrayList();
         ZoneId.getAvailableZoneIds().forEach(id -> timeZones.add(ZoneId.of(id)));
         final ObservableList<ZoneId> timeZonesSorted = timeZones.sorted(zoneIdComparator);
@@ -112,9 +110,19 @@ public class DatetimeAttributeTranslator extends AttributeTranslator {
         timeZonesSortedString.add("");
         timeZonesSorted.forEach(id -> timeZonesSortedString.add(TimeZoneUtilities.getTimeZoneAsString(id)));
 
+        final PluginParameter<SingleChoiceParameterValue> timeZoneParam = SingleChoiceParameterType.build(TIMEZONE_PARAMETER_ID);
+        timeZoneParam.setName("Time Zone");
+        timeZoneParam.setDescription("The time zone the dates represent");
         SingleChoiceParameterType.setOptions(timeZoneParam, timeZonesSortedString);
         SingleChoiceParameterType.setChoice(timeZoneParam, timeZonesSortedString.get(0));
         parameters.addParameter(timeZoneParam);
+
+        final PluginParameter<SingleChoiceParameterValue> convertedTimeZoneParam = SingleChoiceParameterType.build(CONVERTED_TIMEZONE_PARAMETER_ID);
+        convertedTimeZoneParam.setName("Display Time Zone");
+        convertedTimeZoneParam.setDescription("The time zone to convert and display the dates");
+        SingleChoiceParameterType.setOptions(convertedTimeZoneParam, timeZonesSortedString);
+        SingleChoiceParameterType.setChoice(convertedTimeZoneParam, timeZonesSortedString.get(0));
+        parameters.addParameter(convertedTimeZoneParam);
 
         parameters.addController(FORMAT_PARAMETER_ID, (final PluginParameter<?> master, final Map<String, PluginParameter<?>> params, final ParameterChange change) -> {
             if (change == ParameterChange.VALUE) {
@@ -148,25 +156,23 @@ public class DatetimeAttributeTranslator extends AttributeTranslator {
 
         try {
             String format = parameters.getParameters().get(FORMAT_PARAMETER_ID).getStringValue();
-            final PluginParameter timeZoneParam = parameters.getParameters().get(TIMEZONE_PARAMETER_ID);
-
             final ZonedDateTime zonedDateTime;
             switch (format) {
                 case EPOCH:
                     zonedDateTime = TemporalFormatting.zonedDateTimeFromLong(Long.parseLong(value));
-                    return translateFromZonedDateTime(zonedDateTime, timeZoneParam);
+                    return translateFromZonedDateTime(zonedDateTime, parameters);
                 case EXCEL:
-                    // "GMT" is used here to avoid it using the user's local time zone. 
+                    // "GMT" is used here to avoid it using the user's local time zone.
                     // If the user has selected a time zone, it is applied seperately in `translateFromZonedDateTime`
                     zonedDateTime = TemporalFormatting.zonedDateTimeFromLong(DateUtil.getJavaDate(Double.parseDouble(value), TimeZone.getTimeZone("GMT")).getTime());
-                    return translateFromZonedDateTime(zonedDateTime, timeZoneParam);
+                    return translateFromZonedDateTime(zonedDateTime, parameters);
                 case CUSTOM: {
                     format = parameters.getParameters().get(CUSTOM_PARAMETER_ID).getStringValue();
-                    return translateFromTemporalAccessorDateTime(value, format, timeZoneParam);
-                }                
+                    return translateFromTemporalAccessorDateTime(value, format, parameters);
+                }
                 default: {
                     format = DATETIME_FORMATS.get(format);
-                    return translateFromTemporalAccessorDateTime(value, format, timeZoneParam);
+                    return translateFromTemporalAccessorDateTime(value, format, parameters);
                 }
             }
         } catch (final DateTimeException | IllegalArgumentException ex) {
@@ -174,28 +180,53 @@ public class DatetimeAttributeTranslator extends AttributeTranslator {
         }
     }
 
-    private String translateFromZonedDateTime( final ZonedDateTime zonedDateTime, final PluginParameter timeZoneParam){
-        final String timeZone = timeZoneParam.getStringValue();
-        if (timeZoneParam.isEnabled() && StringUtils.isNotBlank(timeZone)) {
-            ZonedDateTime dateTimeInSpecifiedTimeZone = zonedDateTime.withZoneSameLocal(TimeZone.getTimeZone(StringUtils.substringBetween(timeZone, "[", "]")).toZoneId());
-            return TemporalFormatting.ZONED_DATE_TIME_FORMATTER.format(dateTimeInSpecifiedTimeZone);
+    private String translateFromZonedDateTime( final ZonedDateTime zonedDateTime, final PluginParameters parameters){
+        final PluginParameter timeZoneParam = parameters.getParameters().get(TIMEZONE_PARAMETER_ID);
+        final PluginParameter convertedTimeZoneParam = parameters.getParameters().get(CONVERTED_TIMEZONE_PARAMETER_ID);
+
+        final String timeZoneString = timeZoneParam.getStringValue();
+        if (timeZoneParam.isEnabled() && StringUtils.isNotBlank(timeZoneString)) {
+            ZonedDateTime dateTimeInSpecifiedTimeZone = zonedDateTime.withZoneSameLocal(getTimeZoneId(timeZoneString));
+            return TemporalFormatting.ZONED_DATE_TIME_FORMATTER.format(convertToDisplayTimeZone(dateTimeInSpecifiedTimeZone, convertedTimeZoneParam.getStringValue()));
         } else {
-            return TemporalFormatting.formatAsZonedDateTime(zonedDateTime);
+            return TemporalFormatting.formatAsZonedDateTime(convertToDisplayTimeZone(zonedDateTime, convertedTimeZoneParam.getStringValue()));
         }
     }
-    
-    private String translateFromTemporalAccessorDateTime(final String value, final String format, final PluginParameter timeZoneParam){
+
+    private String translateFromTemporalAccessorDateTime(final String value, final String format, final PluginParameters parameters){
+        final PluginParameter timeZoneParam = parameters.getParameters().get(TIMEZONE_PARAMETER_ID);
+        final PluginParameter convertedTimeZoneParam = parameters.getParameters().get(CONVERTED_TIMEZONE_PARAMETER_ID);
+
         final DateTimeFormatter df = DateTimeFormatter.ofPattern(format);
-        final String timeZone = timeZoneParam.getStringValue();
+        final String timeZoneString = timeZoneParam.getStringValue();
         // ZonedDateTime.parse requires a time zone identifier in the string (`value`)
         // hence zonedDateTime = ZonedDateTime.parse(value, df); doesn't work for all other formats
-        if (timeZoneParam.isEnabled() && StringUtils.isNotBlank(timeZone)) {
-            ZonedDateTime dateTimeInSpecifiedTimeZone = ZonedDateTime.parse(value, df.withZone(TimeZone.getTimeZone(StringUtils.substringBetween(timeZone, "[", "]")).toZoneId()));
-            return TemporalFormatting.ZONED_DATE_TIME_FORMATTER.format(dateTimeInSpecifiedTimeZone);
+        if (timeZoneParam.isEnabled() && StringUtils.isNotBlank(timeZoneString)) {
+            final ZonedDateTime dateTimeInSpecifiedTimeZone = ZonedDateTime.parse(value, df.withZone(getTimeZoneId(timeZoneString)));
+            return TemporalFormatting.ZONED_DATE_TIME_FORMATTER.format(convertToDisplayTimeZone(dateTimeInSpecifiedTimeZone, convertedTimeZoneParam.getStringValue()));
+
+
         } else {
             final TemporalAccessor temporalAccessorDateTime = df.parse(value);
+            if (StringUtils.isNotBlank(convertedTimeZoneParam.getStringValue())) {
+                final LocalDateTime localDateTime = LocalDateTime.parse(value, df);
+                final ZoneId zoneId = (!containsTimeZone(format) || format.endsWith("'Z'")) ? ZoneId.of("UTC") : ZoneId.from(temporalAccessorDateTime);
+                final ZonedDateTime zonedDateTime = ZonedDateTime.of(localDateTime, zoneId);
+                return TemporalFormatting.ZONED_DATE_TIME_FORMATTER.format(convertToDisplayTimeZone(zonedDateTime, convertedTimeZoneParam.getStringValue()));
+            }
             return TemporalFormatting.formatAsZonedDateTime(temporalAccessorDateTime);
         }
+    }
+
+    private ZonedDateTime convertToDisplayTimeZone(final ZonedDateTime dateTime, final String displayTimeZone){
+        if (StringUtils.isNotBlank(displayTimeZone)) {
+            return dateTime.withZoneSameInstant(getTimeZoneId(displayTimeZone));
+        }
+        return dateTime;
+    }
+
+    private ZoneId getTimeZoneId(final String timeZone){
+        return TimeZone.getTimeZone(StringUtils.substringBetween(timeZone, "[", "]")).toZoneId();
     }
 
     private final Comparator<ZoneId> zoneIdComparator = (t1, t2) -> {

--- a/CoreWhatsNewView/src/au/gov/asd/tac/constellation/views/whatsnew/whatsnew.txt
+++ b/CoreWhatsNewView/src/au/gov/asd/tac/constellation/views/whatsnew/whatsnew.txt
@@ -1,6 +1,9 @@
 == 3030-12-31 Getting Started
 <p>If you're new to Constellation, read the <a href="" helpId="au.gov.asd.tac.constellation.functionality.gettingstarted">getting started guide</a>.</p>
 
+== 2022-05-27 Option to specify time zone in Importers
+<p>A new field 'Time Zone' is added in the Datetime formatter of attributes in the File Importer and Database Importer. You can find it by right-clicking an attribute, navigating to Formatter -&gt; Datetime. Choosing 'EPOCH' as the Datetime format or entering a format that already contains a time zone will disable this field.</p>
+
 == 2022-04-13 Plugins
 <p>Some plugin parameters have been updated to have '*' at the end of the name to indicate that the plugin will require a value in order for the plugin to work.</p>
 

--- a/CoreWhatsNewView/src/au/gov/asd/tac/constellation/views/whatsnew/whatsnew.txt
+++ b/CoreWhatsNewView/src/au/gov/asd/tac/constellation/views/whatsnew/whatsnew.txt
@@ -1,6 +1,9 @@
 == 3030-12-31 Getting Started
 <p>If you're new to Constellation, read the <a href="" helpId="au.gov.asd.tac.constellation.functionality.gettingstarted">getting started guide</a>.</p>
 
+== 2022-06-17 Datetime Formatter
+<p>The Datetime formatter for attributes in the File Importer and Database Importer has been updated to include a new field 'Display Time Zone'. This field allows you to easily convert your datetime data to the desired timezone before importing.</p>
+
 == 2022-05-27 Option to specify time zone in Importers
 <p>A new field 'Time Zone' is added in the Datetime formatter of attributes in the File Importer and Database Importer. You can find it by right-clicking an attribute, navigating to Formatter -&gt; Datetime. Choosing 'EPOCH' as the Datetime format or entering a format that already contains a time zone will disable this field.</p>
 


### PR DESCRIPTION
<!--

### Requirements

* Filling out the template is required. Any pull request that does not include
enough information to be reviewed in a timely manner may be closed at the
maintainers' discretion.
* All new code requires unit tests to ensure they work as expected and will
continue to work as new code is added in the future (regression testing).
* Make sure your branch name is prefixed by `feature`, `bugfix` or `release`
* Have you read Constellation's Code of Conduct? By filing an issue, you are
expected to comply with it, including treating everyone with respect:
https://github.com/constellation-app/constellation/blob/master/CODE_OF_CONDUCT.md

-->

### Prerequisites

- [x] Reviewed the [checklist](CHECKLIST.md)

- [ ] Reviewed feedback from the "Sonar Cloud" bot. Note that you have to wait
    for the "CI / Unit Tests") to complete first. Failed Unit tests can be 
    debugged by adding the label "verbose logging" to the GitHub PR.

### Description of the Change
In the File or Database Importer the date times can now be converted to a specified time zone before importing, to avoid that step being performed in the Attribute editor. `Display Time Zone` is available in the pop up window when right-clicking the DateTime attribute, and navigating to Formatter -> Datetime.

(Added the changes here on top of the branch in https://github.com/constellation-app/constellation/pull/1705 because they were required. Only the last commit relates here.)
![image](https://user-images.githubusercontent.com/64826928/171373349-d64a778d-7051-4fb3-a657-8eddc6e2dad1.png)

<!--

We must be able to understand the design of your change from this description.
If we can't get a good idea of what the code will be doing from the description
here, the pull request may be closed at the maintainers' discretion. Keep in
mind that the maintainer reviewing this PR may not be familiar with or have
worked with the code here recently, so please walk us through the concepts.

-->

### Alternate Designs

<!--

Explain what other alternates were considered and why the proposed version was
selected.

-->

### Why Should This Be In Core?

<!--

Explain why this functionality should be in Constellation Core as opposed to a
different module suite. Note that this question is more applicable when adding
new functionality. If this change is a minor update to an existing file then it
is understood that this change has to be to this module suite and a response
and therefore a response to this question is not required.

-->

### Benefits

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process

1. Open Constellation and the File Importer
2. Load a file in to the importer containing date time columns of different formats
3. Right-click on the Datetime transaction attribute
4. Navigate to Formatter -> Datetime 
5. Select/enter different formats, with and without different values for input and display Time Zones, and verify the datetime values in the table format correctly.
6. Click Import button and check the date time column is imported in the graph with the converted time zone.
7. Repeat with the database importer.

<!--

What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (e.g. buttons you clicked, text you typed,
commands you ran, etc.), and describe the results you observed.

-->

### Applicable Issues
https://github.com/constellation-app/constellation/issues/1673
 https://github.com/constellation-app/constellation/pull/1705 precedes this.
<!-- Link any applicable issues here -->
