### PR TITLE
fixed issue with some default parameter values not triggering controllers

### DIFF
--- a/CoreDataAccessView/src/au/gov/asd/tac/constellation/views/dataaccess/plugins/clean/MergeNodesPlugin.java
+++ b/CoreDataAccessView/src/au/gov/asd/tac/constellation/views/dataaccess/plugins/clean/MergeNodesPlugin.java
@@ -140,7 +140,6 @@ public class MergeNodesPlugin extends SimpleQueryPlugin implements DataAccessPlu
         mergeType.setRequired(true);
         final List<String> mergeTypes = new ArrayList<>(MERGE_TYPES.keySet());
         SingleChoiceParameterType.setOptions(mergeType, mergeTypes);
-        SingleChoiceParameterType.setChoice(mergeType, mergeTypes.get(0));
         params.addParameter(mergeType);
 
         final PluginParameter<IntegerParameterValue> threshold = IntegerParameterType.build(THRESHOLD_PARAMETER_ID);
@@ -183,6 +182,7 @@ public class MergeNodesPlugin extends SimpleQueryPlugin implements DataAccessPlu
                 }
             }
         });
+        SingleChoiceParameterType.setChoice(mergeType, mergeTypes.get(0));
 
         return params;
     }

--- a/CoreDataAccessView/src/au/gov/asd/tac/constellation/views/dataaccess/plugins/clean/MergeNodesPlugin.java
+++ b/CoreDataAccessView/src/au/gov/asd/tac/constellation/views/dataaccess/plugins/clean/MergeNodesPlugin.java
@@ -182,6 +182,7 @@ public class MergeNodesPlugin extends SimpleQueryPlugin implements DataAccessPlu
                 }
             }
         });
+        // value is set after the controller definition so that the controller gets triggered
         SingleChoiceParameterType.setChoice(mergeType, mergeTypes.get(0));
 
         return params;

--- a/CoreDataAccessView/src/au/gov/asd/tac/constellation/views/dataaccess/plugins/clean/MergeTransactionsPlugin.java
+++ b/CoreDataAccessView/src/au/gov/asd/tac/constellation/views/dataaccess/plugins/clean/MergeTransactionsPlugin.java
@@ -152,7 +152,6 @@ public class MergeTransactionsPlugin extends SimpleQueryPlugin implements DataAc
         mergeType.setRequired(true);
         final List<String> mergeTypes = new ArrayList<>(MERGE_TYPES.keySet());
         SingleChoiceParameterType.setOptions(mergeType, mergeTypes);
-        SingleChoiceParameterType.setChoice(mergeType, mergeTypes.get(0));
         params.addParameter(mergeType);
 
         final PluginParameter<IntegerParameterValue> threshold = IntegerParameterType.build(THRESHOLD_PARAMETER_ID);
@@ -195,6 +194,7 @@ public class MergeTransactionsPlugin extends SimpleQueryPlugin implements DataAc
                 }
             }
         });
+        SingleChoiceParameterType.setChoice(mergeType, mergeTypes.get(0));
 
         return params;
     }

--- a/CoreDataAccessView/src/au/gov/asd/tac/constellation/views/dataaccess/plugins/clean/MergeTransactionsPlugin.java
+++ b/CoreDataAccessView/src/au/gov/asd/tac/constellation/views/dataaccess/plugins/clean/MergeTransactionsPlugin.java
@@ -194,6 +194,7 @@ public class MergeTransactionsPlugin extends SimpleQueryPlugin implements DataAc
                 }
             }
         });
+        // value is set after the controller definition so that the controller gets triggered
         SingleChoiceParameterType.setChoice(mergeType, mergeTypes.get(0));
 
         return params;

--- a/CoreDataAccessView/test/unit/src/au/gov/asd/tac/constellation/views/dataaccess/plugins/clean/TestMergeType.java
+++ b/CoreDataAccessView/test/unit/src/au/gov/asd/tac/constellation/views/dataaccess/plugins/clean/TestMergeType.java
@@ -47,8 +47,8 @@ public class TestMergeType implements MergeNodeType {
     }
 
     @Override
-    public void updateParameters(Map<String, PluginParameter<?>> parameters) {
-        throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+    public void updateParameters(final Map<String, PluginParameter<?>> parameters) {
+        //Do nothing
     }
 
     @Override


### PR DESCRIPTION
<!--

### Requirements

* Filling out the template is required. Any pull request that does not include
enough information to be reviewed in a timely manner may be closed at the
maintainers' discretion.
* All new code requires unit tests to ensure they work as expected and will
continue to work as new code is added in the future (regression testing).
* Make sure your branch name is prefixed by `feature`, `bugfix` or `release`
* Have you read Constellation's Code of Conduct? By filing an issue, you are
expected to comply with it, including treating everyone with respect:
https://github.com/constellation-app/constellation/blob/master/CODE_OF_CONDUCT.md

-->

### Prerequisites

- [x] Reviewed the [checklist](CHECKLIST.md)

- [ ] Reviewed feedback from the "Sonar Cloud" bot. Note that you have to wait
    for the "CI / Unit Tests") to complete first. Failed Unit tests can be 
    debugged by adding the label "verbose logging" to the GitHub PR.

### Description of the Change

A couple of plugins had a default value added to one of the parameters. The problem was that changing the value in these parameter was meant to trigger a controller but since the default value was set before the controller was defined, the expected actions didn't happen (e.g. other parameters in the plugin being enabled or disabled). This small change just moves the setting of those default parameter values to after the controller definition so that the controller code gets triggered.

### Alternate Designs

<!--

Explain what other alternates were considered and why the proposed version was
selected.

-->

### Why Should This Be In Core?

Ensures plugins in Core follow expected behaviour

### Benefits

parameters don't have to be re-selected to trigger intended behaviour

### Possible Drawbacks

Nil

### Verification Process

<!--

What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (e.g. buttons you clicked, text you typed,
commands you ran, etc.), and describe the results you observed.

-->

### Applicable Issues

