### PR TITLE
Wip/blue tab look and feel

### DIFF
--- a/CoreFunctionality/src/au/gov/asd/tac/constellation/functionality/startup/ConstellationLAFSettings.java
+++ b/CoreFunctionality/src/au/gov/asd/tac/constellation/functionality/startup/ConstellationLAFSettings.java
@@ -114,11 +114,14 @@ public class ConstellationLAFSettings {
                 if (displayerClass != null) {
                     // Update the UIManager with settings appropriate for Windows (XP) LAF
                     UIManager.getDefaults().put("TabbedPane.highlight", activeMidSectionBlue);
-                    UIManager.getDefaults().put("tab_sel_border", activeMidSectionBlue);
                     UIManager.getDefaults().put("tab_focus_fill_bright", selectedUpperLightBlue);
                     UIManager.getDefaults().put("tab_focus_fill_dark", selectedLowerDarkBlue);
                     UIManager.getDefaults().put("tab_unsel_fill_bright", unselectedUpperGray);
                     UIManager.getDefaults().put("tab_unsel_fill_dark", unselectedLowerGreyBlue);
+                    // Put a light blue highlight on the selected tab
+                    final Color activeLighterMidBlue = new Color(180, 220, 255);
+                    UIManager.getDefaults().put("tab_highlight_header", activeLighterMidBlue);
+                    UIManager.getDefaults().put("tab_highlight_header_fill", activeLighterMidBlue);
 
                     // reset static field "colorsReady" value to false
                     final Field colsReady = displayerClass.getDeclaredField("colorsReady"); //NOSONAR

--- a/CoreFunctionality/src/au/gov/asd/tac/constellation/functionality/startup/ConstellationLAFSettings.java
+++ b/CoreFunctionality/src/au/gov/asd/tac/constellation/functionality/startup/ConstellationLAFSettings.java
@@ -122,6 +122,10 @@ public class ConstellationLAFSettings {
                     final Color activeLighterMidBlue = new Color(180, 220, 255);
                     UIManager.getDefaults().put("tab_highlight_header", activeLighterMidBlue);
                     UIManager.getDefaults().put("tab_highlight_header_fill", activeLighterMidBlue);
+                    // The following settings are used in the WinXPEditorTabCellRenderer
+                    UIManager.getDefaults().put("TabbedPane.selectionIndicator", activeLighterMidBlue);
+                    UIManager.getDefaults().put("tab_sel_fill_bright", selectedUpperLightBlue);
+                    UIManager.getDefaults().put("tab_sel_fill_dark", selectedLowerDarkBlue);
 
                     // reset static field "colorsReady" value to false
                     final Field colsReady = displayerClass.getDeclaredField("colorsReady"); //NOSONAR

--- a/CoreFunctionality/src/au/gov/asd/tac/constellation/functionality/startup/ConstellationLAFSettings.java
+++ b/CoreFunctionality/src/au/gov/asd/tac/constellation/functionality/startup/ConstellationLAFSettings.java
@@ -54,7 +54,9 @@ public class ConstellationLAFSettings {
         } else if (currentLafName.contains("METAL")) {
             initMetalTabColors(currentLafName.contains("DARK"));
         }
-        SwingUtilities.updateComponentTreeUI(mainframe);
+        if (mainframe != null) {
+            SwingUtilities.updateComponentTreeUI(mainframe);
+        }
     }
 
     /**

--- a/CoreFunctionality/src/au/gov/asd/tac/constellation/functionality/startup/ConstellationLAFSettings.java
+++ b/CoreFunctionality/src/au/gov/asd/tac/constellation/functionality/startup/ConstellationLAFSettings.java
@@ -88,7 +88,7 @@ public class ConstellationLAFSettings {
                 final Class<?> tabDisplayer = displayerClass.getSuperclass();
 
                 if (tabDisplayer == null) {
-                    LOGGER.info(" >>> Unable to apply Tab coloring to Windows LAF : no superclass for displayerClass :");
+                    LOGGER.log(Level.WARNING, " >>> Unable to apply Tab coloring to Windows LAF : no superclass for displayerClass :");
                     ouputUIDefaultValues(null, null);
                     return;
                 }
@@ -117,8 +117,7 @@ public class ConstellationLAFSettings {
                 if (displayerClass != null) {
                     // get Reflection objects before updating any UI settings
                     final Field colsReady = displayerClass.getDeclaredField("colorsReady"); //NOSONAR
-                    Class<?>[] argList = null;
-                    final Method initCols = displayerClass.getDeclaredMethod("initColors", argList);
+                    final Method initCols = displayerClass.getDeclaredMethod("initColors");
 
                     // Update the UIManager with settings appropriate for Windows (XP) LAF
                     UIManager.getDefaults().put("TabbedPane.highlight", activeMidSectionBlue);
@@ -145,7 +144,7 @@ public class ConstellationLAFSettings {
                 } else {
                     // Unable to apply changes to Windows LAF
                     // Possibly caused by a change in a newer NetBeans version
-                    LOGGER.info(" >>> Unable to apply Tab coloring to Windows LAF : neither Windows8VectorViewTabDisplayerUI nor WinXPViewTabDisplayerUI are defined :");
+                    LOGGER.log(Level.WARNING, " >>> Unable to apply Tab coloring to Windows LAF : neither Windows8VectorViewTabDisplayerUI nor WinXPViewTabDisplayerUI are defined :");
                     ouputUIDefaultValues(null, null);
                 }
             }
@@ -242,8 +241,7 @@ public class ConstellationLAFSettings {
             if (tabDisplayer != null) {
                 // get Reflection objects before updating any UI settings
                 final Field colready = tabDisplayer.getDeclaredField("colorsReady");
-                Class<?>[] argList = null;
-                final Method initCols = tabDisplayer.getDeclaredMethod("initColors", argList);
+                final Method initCols = tabDisplayer.getDeclaredMethod("initColors");
 
                 // Update the UIManager with settings appropriate for FlatLaf
                 UIManager.getDefaults().put("ViewTab.selectedBackground", selectedBackgroundBlue);
@@ -268,7 +266,7 @@ public class ConstellationLAFSettings {
             } else {
                 // Unable to apply changes to FlatLaf
                 // Possibly caused by a change in a newer NetBeans version
-                LOGGER.info(" >>> Unable to apply Tab coloring to FlatLAF : org.netbeans.swing.laf.flatlaf.ui.FlatViewTabDisplayerUI not defined :");
+                LOGGER.log(Level.WARNING, " >>> Unable to apply Tab coloring to FlatLAF : org.netbeans.swing.laf.flatlaf.ui.FlatViewTabDisplayerUI not defined :");
                 ouputUIDefaultValues(null, null);
             }
         } catch (final IllegalAccessException | IllegalArgumentException | NoSuchFieldException | 
@@ -332,7 +330,7 @@ public class ConstellationLAFSettings {
             } else {
                 // Unable to apply changes to Metal LAF
                 // Possibly caused by a change in a newer NetBeans version
-                LOGGER.info(" >>> Unable to apply Tab coloring to Metal LAF : org.netbeans.swing.tabcontrol.plaf.MetalViewTabDisplayerUI not defined.");
+                LOGGER.log(Level.WARNING, " >>> Unable to apply Tab coloring to Metal LAF : org.netbeans.swing.tabcontrol.plaf.MetalViewTabDisplayerUI not defined.");
                 ouputUIDefaultValues(null, null);
             }
         } catch (final IllegalAccessException | IllegalArgumentException | 
@@ -427,21 +425,13 @@ public class ConstellationLAFSettings {
          * @param bottomShadeColor Color to paint at bottom of Tab
          */
         public NimbusCustomGradientTabPainter(final Color topShadeColor, final Color bottomShadeColor) {
-            if (topShadeColor != null) {
-                upperColor = topShadeColor;
-            } else {
-                upperColor = Color.WHITE;
-            }
-            if (bottomShadeColor != null) {
-                lowerColor = bottomShadeColor;
-            } else {
-                lowerColor = Color.BLACK;
-            }
+            upperColor = (topShadeColor != null) ? topShadeColor : Color.WHITE;
+            lowerColor = (bottomShadeColor != null) ? bottomShadeColor : Color.BLACK;
         }
 
         
         @Override
-        public void paint(Graphics2D g, Object j, int w, int h) {
+        public void paint(final Graphics2D g, final Object j, final int w, final int h) {
 
             // set some fixed positioning values relating to the tab's height
             final int startOffset = h / 6;

--- a/CoreFunctionality/src/au/gov/asd/tac/constellation/functionality/startup/ConstellationLAFSettings.java
+++ b/CoreFunctionality/src/au/gov/asd/tac/constellation/functionality/startup/ConstellationLAFSettings.java
@@ -84,6 +84,11 @@ public class ConstellationLAFSettings {
             if (displayerClass != null) {
                 final Class<?> tabDisplayer = displayerClass.getSuperclass();
 
+                if (tabDisplayer == null) {
+                    logger.info(" >>> Windows LAF error : no superclass for displayerClass :");
+                    ouputUIDefaultValues(null, null);
+                    return;
+                }
                 // reset static field "colorsReady" value to false
                 final Field colsReady = tabDisplayer.getDeclaredField("colorsReady");
                 colsReady.setAccessible(true);
@@ -92,9 +97,9 @@ public class ConstellationLAFSettings {
                 logger.info(" >>> Windows LAF error : org.netbeans.swing.tabcontrol.plaf.Windows8VectorViewTabDisplayerUI not defined :");
                 ouputUIDefaultValues(null, null);
             }
-        } catch (IllegalAccessException | IllegalArgumentException | 
+        } catch (final IllegalAccessException | IllegalArgumentException | 
                 NoSuchFieldException | SecurityException e) {
-            String errorMessage = " >>> Error applying Windows LaF colors : " + e.toString();
+            final String errorMessage = " >>> Error applying Windows LaF colors : " + e.toString();
             logger.info(errorMessage);
         }     
     }
@@ -197,9 +202,9 @@ public class ConstellationLAFSettings {
                 logger.info(" >>> FlatLAF error : org.netbeans.swing.laf.flatlaf.ui.FlatViewTabDisplayerUI not defined :");
                 ouputUIDefaultValues(null, null);
             }
-        } catch (IllegalAccessException | IllegalArgumentException | NoSuchFieldException | 
+        } catch (final IllegalAccessException | IllegalArgumentException | NoSuchFieldException | 
                 NoSuchMethodException | SecurityException | InvocationTargetException e) {
-            String errorMessage = " >>> Error applying FlatLaf colors : " + e.toString();
+            final String errorMessage = " >>> Error applying FlatLaf colors : " + e.toString();
             logger.info(errorMessage);
         }
     }
@@ -248,9 +253,9 @@ public class ConstellationLAFSettings {
                 logger.info(" >>> Metal LAF error : org.netbeans.swing.tabcontrol.plaf.MetalViewTabDisplayerUI not defined :");
                 ouputUIDefaultValues(null, null);
             }
-        } catch (IllegalAccessException | IllegalArgumentException | 
+        } catch (final IllegalAccessException | IllegalArgumentException | 
                 NoSuchFieldException | SecurityException e) {
-            String errorMessage = " >>> Error applying Metal Laf colors : " + e.toString();
+            final String errorMessage = " >>> Error applying Metal Laf colors : " + e.toString();
             logger.info(errorMessage);
         }
     }

--- a/CoreFunctionality/src/au/gov/asd/tac/constellation/functionality/startup/ConstellationLAFSettings.java
+++ b/CoreFunctionality/src/au/gov/asd/tac/constellation/functionality/startup/ConstellationLAFSettings.java
@@ -152,8 +152,7 @@ public class ConstellationLAFSettings {
                 NoSuchMethodException | NoSuchFieldException | SecurityException e) {
             // An exception here would indicate a change in the internal LAF 
             // packages provided by NetBeans
-            final String errorMessage = " >>> Error applying Windows LaF colors : " + e.toString();
-            LOGGER.log(Level.SEVERE, errorMessage, e);
+            LOGGER.log(Level.SEVERE, " >>> Error applying Windows LaF colors :", e);
         }     
     }
 
@@ -273,8 +272,7 @@ public class ConstellationLAFSettings {
                 NoSuchMethodException | SecurityException | InvocationTargetException e) {
             // An exception here would indicate a change in the internal LAF 
             // packages provided by NetBeans
-            final String errorMessage = " >>> Error applying FlatLaf colors : " + e.toString();
-            LOGGER.log(Level.SEVERE, errorMessage, e);
+            LOGGER.log(Level.SEVERE, " >>> Error applying FlatLaf colors :", e);
         }
     }
 
@@ -337,13 +335,16 @@ public class ConstellationLAFSettings {
                 NoSuchFieldException | SecurityException e) {
             // An exception here would indicate a change in the internal LAF 
             // packages provided by NetBeans
-            final String errorMessage = " >>> Error applying Metal Laf colors : " + e.toString();
-            LOGGER.log(Level.SEVERE, errorMessage, e);
+            LOGGER.log(Level.SEVERE, " >>> Error applying Metal Laf colors :", e);
         }
     }
 
     /**
      * Convenience method to assist with identifying UImanager settings
+     * 
+     * Note: This method should only remain in the code temporarily, 
+     * for a few releases after its introduction, to assist in any additional changes
+     * that may be needed for other Look and Feels being used     
      * 
      * @param keyFilter limit output to key entries containing the keyFilter
      * @param valueFilter limit output to values containing the valueFilter

--- a/CoreFunctionality/src/au/gov/asd/tac/constellation/functionality/startup/ConstellationLAFSettings.java
+++ b/CoreFunctionality/src/au/gov/asd/tac/constellation/functionality/startup/ConstellationLAFSettings.java
@@ -1,0 +1,333 @@
+/*
+ * Copyright 2010-2022 Australian Signals Directorate
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package au.gov.asd.tac.constellation.functionality.startup;
+
+import java.awt.Color;
+import java.awt.Graphics2D;
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.logging.Logger;
+import javax.swing.JFrame;
+import javax.swing.Painter;
+import javax.swing.SwingUtilities;
+import javax.swing.UIManager;
+import org.openide.windows.WindowManager;
+
+/**
+ * This class contains a collection of separate UI settings to apply for a
+ * few different Look and Feels packaged with NetBeans 12.0
+ *
+ * Note: Since the code is based on NetBeans 12.0, it may require updating with
+ * newer versions NetBeans if the internal Look And Feel packages are changed.
+ *
+ * @author OrionsGuardian
+ */
+public class ConstellationLAFSettings {
+
+    public static void applyTabColorSettings() {
+        JFrame mainframe = (JFrame) WindowManager.getDefault().getMainWindow();
+        String currentLafName = UIManager.getLookAndFeel().getName().toUpperCase();
+        if (currentLafName.startsWith("WINDOWS")) {
+            initWindowsTabColors();
+        } else if (currentLafName.contains("NIMBUS")) {
+            initNimbusTabColors(currentLafName.contains("DARK"));
+        } else if (currentLafName.contains("FLAT")) {
+            initFlatLafTabColors(currentLafName.contains("DARK"));
+        } else if (currentLafName.contains("METAL")) {
+            initMetalTabColors(currentLafName.contains("DARK"));
+        }
+        SwingUtilities.updateComponentTreeUI(mainframe);
+    }
+
+    /**
+     * Applies a Blue color theme for the main window tabs when using either the
+     * <b>Windows</b> or <b>Windows Classic</b> Look and Feel.
+     */
+    private static void initWindowsTabColors() {
+        Color selectedUpperLightBlue = new Color(225, 235, 255);
+        Color activeMidSectionBlue = new Color(140, 185, 255);
+        Color selectedLowerDarkBlue = new Color(50, 130, 255);
+        Color unselectedUpperGray = new Color(220, 220, 220);
+        Color unselectedLowerGreyBlue = new Color(165, 175, 185);
+
+        UIManager.getDefaults().put("tab_sel_fill", activeMidSectionBlue);
+        UIManager.getDefaults().put("tab_focus_fill_upper", selectedUpperLightBlue);
+        UIManager.getDefaults().put("tab_focus_fill_lower", selectedLowerDarkBlue);
+        UIManager.getDefaults().put("tab_unsel_fill_upper", unselectedUpperGray);
+        UIManager.getDefaults().put("tab_unsel_fill_lower", unselectedLowerGreyBlue);
+        UIManager.getDefaults().put("tab_mouse_over_fill_upper", selectedUpperLightBlue);
+        UIManager.getDefaults().put("tab_mouse_over_fill_lower", activeMidSectionBlue);
+        UIManager.getDefaults().put("tab_attention_fill_upper", activeMidSectionBlue);
+        UIManager.getDefaults().put("tab_attention_fill_lower", selectedLowerDarkBlue);
+
+        try {
+            Class<?> tabDisplayer = ((Class<?>) UIManager.getDefaults()
+                    .get("org.netbeans.swing.tabcontrol.plaf.Windows8VectorViewTabDisplayerUI")).getSuperclass();
+            
+            // reset static field "colorsReady" value to false
+            Field colsReady = tabDisplayer.getDeclaredField("colorsReady");
+            colsReady.setAccessible(true);
+            colsReady.setBoolean(tabDisplayer, false);
+        } catch (IllegalAccessException | IllegalArgumentException | 
+                NoSuchFieldException | SecurityException e) {
+            String errorMessage = " >>> Error applying Windows LaF colors : " + e.toString();
+            Logger.getLogger(ConstellationLAFSettings.class.getName()).info(errorMessage);
+        }
+    }
+
+    /**
+     * Applies a Blue color theme for the main window tabs when using the
+     * <b>Nimbus</b> Look and Feel.
+     *
+     * @param darkMode When true, allocates Look and Feel tab colors suitable for 
+     * <u>Dark Nimbus</u>, otherwise allocates colors suitable for <u>Nimbus</u>
+     */
+    private static void initNimbusTabColors(boolean darkMode) {
+        Color activeBlue,
+                activeDarkBlue,
+                selectedBlue,
+                selectedDarkBlue,
+                unselectedGreyBlue,
+                unselectedDarkGreyBlue;
+        
+        if (darkMode) {
+            activeBlue = new Color(125, 170, 225);
+            activeDarkBlue = new Color(65, 100, 155);
+            selectedBlue = new Color(110, 155, 200);
+            selectedDarkBlue = new Color(45, 80, 140);
+            unselectedGreyBlue = new Color(140, 150, 155);
+            unselectedDarkGreyBlue = new Color(100, 110, 115);
+        } else {
+            activeBlue = new Color(150, 200, 255);
+            activeDarkBlue = new Color(90, 125, 180);
+            selectedBlue = new Color(140, 180, 245);
+            selectedDarkBlue = new Color(75, 115, 170);
+            unselectedGreyBlue = new Color(190, 205, 215);
+            unselectedDarkGreyBlue = new Color(150, 160, 175);
+        }
+        
+        UIManager.getLookAndFeelDefaults().put("TabbedPane:TabbedPaneTab[MouseOver+Selected].backgroundPainter", 
+                new NimbusCustomGradientTabPainter(activeBlue, activeDarkBlue));
+        UIManager.getLookAndFeelDefaults().put("TabbedPane:TabbedPaneTab[Selected].backgroundPainter", 
+                new NimbusCustomGradientTabPainter(selectedBlue, selectedDarkBlue));
+        UIManager.getLookAndFeelDefaults().put("TabbedPane:TabbedPaneTab[Enabled].backgroundPainter", 
+                new NimbusCustomGradientTabPainter(unselectedGreyBlue, unselectedDarkGreyBlue));
+        
+        UIManager.getLookAndFeel().uninitialize();
+        UIManager.getLookAndFeel().initialize();
+    }
+
+    /**
+     * Applies a Blue color theme for the main window tabs when using the
+     * <b>FlatLaf</b> Look and Feel.
+     *
+     * @param darkMode When true, allocates Look and Feel tab colors suitable for 
+     * <u>FlatLafDark</u>, otherwise allocates colors suitable for <u>FlatLafLight</u>
+     */
+    private static void initFlatLafTabColors(boolean darkMode) {
+        Color selectedUnderlineBlue,
+                inactiveUnderlineBlue,
+                selectedBackgroundBlue,
+                hoverBackgroundBlue;
+
+        if (darkMode) {
+            selectedUnderlineBlue = new Color(30, 110, 190);
+            inactiveUnderlineBlue = new Color(20, 100, 175);
+            selectedBackgroundBlue = new Color(30, 60, 95);
+            hoverBackgroundBlue = new Color(45, 75, 115);
+        } else {
+            selectedUnderlineBlue = new Color(105, 145, 240);
+            inactiveUnderlineBlue = new Color(95, 130, 185);
+            selectedBackgroundBlue = new Color(200, 220, 255);
+            hoverBackgroundBlue = new Color(190, 210, 255);
+        }
+
+        UIManager.put("ViewTab.selectedBackground", selectedBackgroundBlue);
+        UIManager.put("ViewTab.hoverBackground", hoverBackgroundBlue);
+        UIManager.put("ViewTab.underlineHeight", 5);
+        UIManager.put("ViewTab.underlineColor", selectedUnderlineBlue);
+        UIManager.put("ViewTab.inactiveUnderlineColor", inactiveUnderlineBlue);
+
+        UIManager.put("EditorTab.selectedBackground", selectedBackgroundBlue);
+        UIManager.put("EditorTab.hoverBackground", hoverBackgroundBlue);
+        UIManager.put("EditorTab.underlineHeight", 5);
+        UIManager.put("EditorTab.underlineColor", selectedUnderlineBlue);
+        UIManager.put("EditorTab.inactiveUnderlineColor", inactiveUnderlineBlue);
+
+        try {
+            Class<?> tabDisplayer = (Class<?>) UIManager.getDefaults()
+                    .get("org.netbeans.swing.laf.flatlaf.ui.FlatViewTabDisplayerUI");
+            
+            // reset static field "colorsReady" value to false
+            Field colready = tabDisplayer.getDeclaredField("colorsReady");
+            colready.setAccessible(true);
+            colready.setBoolean(tabDisplayer, false);
+            
+            // re-run class method "initColors" to load the updated colors
+            Class<?>[] argList = null;
+            Method initCols = tabDisplayer.getDeclaredMethod("initColors", argList);
+            initCols.setAccessible(true);
+            initCols.invoke(tabDisplayer);
+        } catch (IllegalAccessException | IllegalArgumentException | NoSuchFieldException | 
+                NoSuchMethodException | SecurityException | InvocationTargetException e) {
+            String errorMessage = " >>> Error applying FlatLaf colors : " + e.toString();
+            Logger.getLogger(ConstellationLAFSettings.class.getName()).info(errorMessage);
+        }
+    }
+
+    /**
+     * Applies a Blue color theme for the main window tabs when using the
+     * <b>Metal</b> Look and Feel.
+     *
+     * @param darkMode When true, allocates Look and Feel tab colors suitable for 
+     * <u>Dark Metal</u>, otherwise allocates colors suitable for <u>Metal</u>
+     */
+    private static void initMetalTabColors(boolean darkMode) {
+        Color activeTabBackground, inactiveTabBackground, tabDarkShadow;
+        
+        if (darkMode) {
+            activeTabBackground = new Color(45, 95, 180);
+            tabDarkShadow = new Color(20, 25, 30);
+            inactiveTabBackground = new Color(40, 55, 90);
+        } else {
+            activeTabBackground = new Color(130, 170, 255);
+            tabDarkShadow = new Color(220, 235, 250);
+            inactiveTabBackground = new Color(170, 195, 230);
+        }
+
+        UIManager.put("control", inactiveTabBackground);
+        UIManager.put("controlHighlight", activeTabBackground);
+        UIManager.put("controlDkShadow", tabDarkShadow);
+        UIManager.put("TabRenderer.selectedActivatedBackground", activeTabBackground);
+        UIManager.put("TabRenderer.selectedBackground", inactiveTabBackground);
+        
+        try {
+            Class<?> tabDisplayer = (Class<?>) UIManager.getDefaults()
+                    .get("org.netbeans.swing.tabcontrol.plaf.MetalViewTabDisplayerUI");
+            
+            // reset static field "actBgColor" value to activeTabBackground
+            Field actBgCol = tabDisplayer.getDeclaredField("actBgColor");
+            actBgCol.setAccessible(true);
+            actBgCol.set(tabDisplayer, activeTabBackground);
+            
+            // reset static field "inactBgColor" value to inactiveTabBackground
+            Field inactBgCol = tabDisplayer.getDeclaredField("inactBgColor");
+            inactBgCol.setAccessible(true);
+            inactBgCol.set(tabDisplayer, inactiveTabBackground);
+        } catch (IllegalAccessException | IllegalArgumentException | 
+                NoSuchFieldException | SecurityException e) {
+            String errorMessage = " >>> Error applying Metal Laf colors : " + e.toString();
+            Logger.getLogger(ConstellationLAFSettings.class.getName()).info(errorMessage);
+        }
+    }
+
+    /**
+     * Custom painter required for Nimbus Look and Feel to override the default
+     * colors used for tabs.
+     * Will fill the background color of the tab with a gradient transition of
+     * color between the color(s) specified in the constructor call.
+     */
+    private static class NimbusCustomGradientTabPainter implements Painter {
+
+        private Color upperColor = Color.WHITE;
+        private Color lowerColor = Color.BLACK;
+
+        /**
+         * Default constructor will use a White to Black color gradient.
+         */
+        public NimbusCustomGradientTabPainter() {
+        }
+
+        /**
+         * Single color constructor will use the specified color as the upper
+         * (lighter shade) color and calculate a darker shade of the same color
+         * to use as the bottom shade.
+         * The background color of the tab will be painted with a gradient
+         * transition between the light and dark shades of the color.
+         * @param baseColor upper/lighter shade of color to be used in the color gradient
+         */
+        public NimbusCustomGradientTabPainter(Color baseColor) {
+            if (baseColor != null) {
+                upperColor = baseColor;
+                float[] baseHSB = new float[3];
+                Color.RGBtoHSB(baseColor.getRed(), baseColor.getGreen(), baseColor.getBlue(), baseHSB);
+                lowerColor = new Color(Color.HSBtoRGB(baseHSB[0], baseHSB[1], baseHSB[2] * 2 / 3));
+            }
+        }
+
+        /**
+         * Dual color constructor allows top and bottom shades to be specified
+         * individually. The Tab background will be painted as a gradient from
+         * top to bottom, transitioning between the specified colors.
+         * @param topShadeColor Color to paint at top of Tab
+         * @param bottomShadeColor Color to paint at bottom of Tab
+         */
+        public NimbusCustomGradientTabPainter(Color topShadeColor, Color bottomShadeColor) {
+            if (topShadeColor != null) {
+                upperColor = topShadeColor;
+            }
+            if (bottomShadeColor != null) {
+                lowerColor = bottomShadeColor;
+            }
+        }
+
+        @Override
+        public void paint(Graphics2D g, Object j, int w, int h) {
+
+            int startOffset = h / 6;
+            int endOffset = h - startOffset;
+            int gradientRange = endOffset > startOffset ? endOffset - startOffset : 1;
+            
+            // fill top section of tab with upper color
+            g.setColor(upperColor);
+            g.fillRect(1, 0, w - 2, startOffset);
+
+            int highRed = upperColor.getRed();
+            int highGreen = upperColor.getGreen();
+            int highBlue = upperColor.getBlue();
+            int lowRed = lowerColor.getRed();
+            int lowGreen = lowerColor.getGreen();
+            int lowBlue = lowerColor.getBlue();
+
+            int newRedShade, newGreenShade, newBlueShade;
+
+            // draw a color gradient background in the middle section of the tab
+            for (int heightPosition = startOffset; heightPosition < endOffset; heightPosition++) {
+                // calculate a linear increase for each color component
+                newRedShade = highRed - (highRed - lowRed) * (heightPosition - startOffset) / gradientRange;
+                newGreenShade = highGreen - (highGreen - lowGreen) * (heightPosition - startOffset) / gradientRange;
+                newBlueShade = highBlue - (highBlue - lowBlue) * (heightPosition - startOffset) / gradientRange;
+                
+                // iteratively draw a line with the adjusted color components
+                g.setColor(new Color(newRedShade, newGreenShade, newBlueShade));
+                g.fillRect(1, heightPosition, w - 2, 1);
+            }
+
+            // fill bottom section of tab with lower color
+            g.setColor(lowerColor);
+            g.fillRect(1, endOffset, w - 2, startOffset);
+
+            // draw a border line around the tab with a smoothed corner
+            g.drawLine(1, 0, w - 2, 0);
+            g.drawLine(1, 1, 1, 1);
+            g.drawLine(w - 2, 1, w - 2, 1);
+            g.drawLine(0, 1, 0, h - 1);
+            g.drawLine(w - 1, 1, w - 1, h - 1);
+        }
+    }
+
+}

--- a/CoreFunctionality/src/au/gov/asd/tac/constellation/functionality/startup/ConstellationLAFSettings.java
+++ b/CoreFunctionality/src/au/gov/asd/tac/constellation/functionality/startup/ConstellationLAFSettings.java
@@ -386,7 +386,7 @@ public class ConstellationLAFSettings {
      * Will fill the background color of the tab with a gradient transition of
      * color between the color(s) specified in the constructor call.
      */
-    private static class NimbusCustomGradientTabPainter<T> implements Painter<T> {
+    public static class NimbusCustomGradientTabPainter<T> implements Painter<T> {
 
         private final Color upperColor;
         private final Color lowerColor;

--- a/CoreFunctionality/src/au/gov/asd/tac/constellation/functionality/startup/ConstellationLAFSettings.java
+++ b/CoreFunctionality/src/au/gov/asd/tac/constellation/functionality/startup/ConstellationLAFSettings.java
@@ -69,13 +69,18 @@ public class ConstellationLAFSettings {
      * <b>Windows</b> or <b>Windows Classic</b> Look and Feel.
      */
     private static void initWindowsTabColors() {
+        // Fixed set of Blue shade colors
+        // appropriate for Windows LAF
         final Color selectedUpperLightBlue = new Color(225, 235, 255);
-        final Color activeMidSectionBlue = new Color(140, 185, 255);
-        final Color selectedLowerDarkBlue = new Color(50, 130, 255);
-        final Color unselectedUpperGray = new Color(220, 220, 220);
-        final Color unselectedLowerGreyBlue = new Color(165, 175, 185);
+        final Color activeMidSectionBlue = new Color(160, 205, 255);
+        final Color selectedLowerDarkBlue = new Color(80, 160, 255);
+        final Color unselectedUpperGray = new Color(225, 225, 225);
+        final Color unselectedLowerGreyBlue = new Color(175, 185, 195);
 
         try {
+            // To apply new tab colors to a Windows LAF
+            // we need to find the current TabDisplayerUI
+            // and force it to re-read from a revised set of colors
             Class<?> displayerClass = (Class<?>) UIManager.getDefaults()
                     .get("org.netbeans.swing.tabcontrol.plaf.Windows8VectorViewTabDisplayerUI");
             if (displayerClass != null) {
@@ -85,8 +90,7 @@ public class ConstellationLAFSettings {
                     LOGGER.info(" >>> Windows LAF note : no superclass for displayerClass :");
                     ouputUIDefaultValues(null, null);
                     return;
-                }
-                
+                }                
                 // Update the UIManager with settings appropriate for Windows (8+) LAF
                 UIManager.getDefaults().put("tab_sel_fill", activeMidSectionBlue);
                 UIManager.getDefaults().put("tab_focus_fill_upper", selectedUpperLightBlue);
@@ -99,7 +103,7 @@ public class ConstellationLAFSettings {
                 UIManager.getDefaults().put("tab_attention_fill_lower", selectedLowerDarkBlue);
                 
                 // reset static field "colorsReady" value to false
-                final Field colsReady = tabDisplayer.getDeclaredField("colorsReady");
+                final Field colsReady = tabDisplayer.getDeclaredField("colorsReady"); //NOSONAR
                 colsReady.setAccessible(true); //NOSONAR
                 colsReady.setBoolean(tabDisplayer, false); //NOSONAR
             } else {
@@ -110,13 +114,14 @@ public class ConstellationLAFSettings {
                 if (displayerClass != null) {
                     // Update the UIManager with settings appropriate for Windows (XP) LAF
                     UIManager.getDefaults().put("TabbedPane.highlight", activeMidSectionBlue);
+                    UIManager.getDefaults().put("tab_sel_border", activeMidSectionBlue);
                     UIManager.getDefaults().put("tab_focus_fill_bright", selectedUpperLightBlue);
                     UIManager.getDefaults().put("tab_focus_fill_dark", selectedLowerDarkBlue);
                     UIManager.getDefaults().put("tab_unsel_fill_bright", unselectedUpperGray);
                     UIManager.getDefaults().put("tab_unsel_fill_dark", unselectedLowerGreyBlue);
 
                     // reset static field "colorsReady" value to false
-                    final Field colsReady = displayerClass.getDeclaredField("colorsReady");
+                    final Field colsReady = displayerClass.getDeclaredField("colorsReady"); //NOSONAR
                     colsReady.setAccessible(true); //NOSONAR
                     colsReady.setBoolean(displayerClass, false); //NOSONAR                
                     
@@ -156,6 +161,8 @@ public class ConstellationLAFSettings {
         final Color unselectedDarkGreyBlue;
         
         if (darkMode) {
+            // Fixed set of Blue shade colors
+            // appropriate for Nimbus dark LAF
             activeBlue = new Color(125, 170, 225);
             activeDarkBlue = new Color(65, 100, 155);
             selectedBlue = new Color(110, 155, 200);
@@ -163,6 +170,8 @@ public class ConstellationLAFSettings {
             unselectedGreyBlue = new Color(140, 150, 155);
             unselectedDarkGreyBlue = new Color(100, 110, 115);
         } else {
+            // Fixed set of Blue shade colors
+            // appropriate for standard Nimbus LAF
             activeBlue = new Color(150, 200, 255);
             activeDarkBlue = new Color(90, 125, 180);
             selectedBlue = new Color(140, 180, 245);
@@ -179,6 +188,7 @@ public class ConstellationLAFSettings {
         UIManager.getLookAndFeelDefaults().put("TabbedPane:TabbedPaneTab[Enabled].backgroundPainter", 
                 new NimbusCustomGradientTabPainter<>(unselectedGreyBlue, unselectedDarkGreyBlue));
         
+        // Some components may need to be reinitialized
         UIManager.getLookAndFeel().uninitialize();
         UIManager.getLookAndFeel().initialize();
     }
@@ -197,11 +207,15 @@ public class ConstellationLAFSettings {
         final Color hoverBackgroundBlue;
 
         if (darkMode) {
+            // Fixed set of Blue shade colors
+            // appropriate for FlatLafDark LAF
             selectedUnderlineBlue = new Color(30, 110, 190);
             inactiveUnderlineBlue = new Color(20, 100, 175);
             selectedBackgroundBlue = new Color(30, 60, 95);
             hoverBackgroundBlue = new Color(45, 75, 115);
         } else {
+            // Fixed set of Blue shade colors
+            // appropriate for FlatLafLight LAF
             selectedUnderlineBlue = new Color(105, 145, 240);
             inactiveUnderlineBlue = new Color(95, 130, 185);
             selectedBackgroundBlue = new Color(200, 220, 255);
@@ -266,10 +280,14 @@ public class ConstellationLAFSettings {
         final Color tabDarkShadow;
         
         if (darkMode) {
+            // Fixed set of Blue shade colors
+            // appropriate for Dark Metal LAF
             activeTabBackground = new Color(45, 95, 180);
             tabDarkShadow = new Color(20, 25, 30);
             inactiveTabBackground = new Color(40, 55, 90);
         } else {
+            // Fixed set of Blue shade colors
+            // appropriate for standard Metal LAF
             activeTabBackground = new Color(130, 170, 255);
             tabDarkShadow = new Color(220, 235, 250);
             inactiveTabBackground = new Color(170, 195, 230);
@@ -329,8 +347,8 @@ public class ConstellationLAFSettings {
             // filter out any values which do not contain the valueFilter string
             if ( (keyFilter == null || uiKey.toString().contains(keyFilter)) && 
                  (valueFilter == null || UIManager.get(uiKey).toString().contains(valueFilter)) ) {
-                    msg = ">> :: " + uiKey + " = " + UIManager.get(uiKey);
-                    LOGGER.info(msg);                
+                msg = ">> :: " + uiKey + " = " + UIManager.get(uiKey);
+                LOGGER.info(msg);                
             }
         }
         uiList.clear();
@@ -342,8 +360,8 @@ public class ConstellationLAFSettings {
             // filter out any values which do not contain the valueFilter string
             if ( (keyFilter == null || uiKey.toString().contains(keyFilter)) &&
                  (valueFilter == null || UIManager.getLookAndFeelDefaults().get(uiKey).toString().contains(valueFilter)) ) {
-                    msg = ">> :::: " + uiKey + " = " + UIManager.getLookAndFeelDefaults().get(uiKey);
-                    LOGGER.info(msg);                
+                msg = ">> :::: " + uiKey + " = " + UIManager.getLookAndFeelDefaults().get(uiKey);
+                LOGGER.info(msg);                
             }
         }
     }    

--- a/CoreFunctionality/src/au/gov/asd/tac/constellation/functionality/startup/Startup.java
+++ b/CoreFunctionality/src/au/gov/asd/tac/constellation/functionality/startup/Startup.java
@@ -54,10 +54,9 @@ public class Startup implements Runnable {
                 ? String.format("%s %s", BrandingUtilities.APPLICATION_NAME, environment)
                 : BrandingUtilities.APPLICATION_NAME;
 
-        ConstellationLAFSettings.applyTabColorSettings();
-        
         // We only want to run this if headless is NOT set to true
         if (!Boolean.TRUE.toString().equalsIgnoreCase(System.getProperty(AWT_HEADLESS_PROPERTY))) {
+            ConstellationLAFSettings.applyTabColorSettings();        
             // update the main window title with the version number
             WindowManager.getDefault().invokeWhenUIReady(() -> {
                 final JFrame frame = (JFrame) WindowManager.getDefault().getMainWindow();

--- a/CoreFunctionality/src/au/gov/asd/tac/constellation/functionality/startup/Startup.java
+++ b/CoreFunctionality/src/au/gov/asd/tac/constellation/functionality/startup/Startup.java
@@ -19,9 +19,17 @@ import au.gov.asd.tac.constellation.security.ConstellationSecurityManager;
 import au.gov.asd.tac.constellation.security.proxy.ProxyUtilities;
 import au.gov.asd.tac.constellation.utilities.BrandingUtilities;
 import au.gov.asd.tac.constellation.utilities.font.FontUtilities;
+import java.awt.Color;
+import java.awt.Graphics2D;
+import java.lang.reflect.Field;
+import java.util.logging.Logger;
 import javax.swing.JFrame;
+import javax.swing.Painter;
+import javax.swing.SwingUtilities;
+import javax.swing.UIManager;
 import org.openide.windows.OnShowing;
 import org.openide.windows.WindowManager;
+
 
 /**
  * Application Bootstrap on start up
@@ -61,6 +69,28 @@ public class Startup implements Runnable {
                 final JFrame frame = (JFrame) WindowManager.getDefault().getMainWindow();
                 final String title = String.format("%s - %s", name, VERSION);
                 frame.setTitle(title);
+                try {
+                  String currentLafName = UIManager.getLookAndFeel().getName();
+                  if (currentLafName.contains("Windows")) {
+                    initWindowsColors();
+                    Class<?> tabDisplayer = ((Class<?>) UIManager.getDefaults().get("org.netbeans.swing.tabcontrol.plaf.Windows8VectorViewTabDisplayerUI")).getSuperclass();
+                    Field colsReady = tabDisplayer.getDeclaredField("colorsReady");
+                    colsReady.setAccessible(true);
+                    colsReady.setBoolean(tabDisplayer, false);
+                  } else if (currentLafName.contains("Nimbus")) {
+                    if (currentLafName.contains("Dark")) {
+                      initDarkNimbusColors();
+                    } else {
+                      initNimbusColors();
+                    }
+                    UIManager.getLookAndFeel().uninitialize();
+                    UIManager.getLookAndFeel().initialize();
+                    SwingUtilities.updateComponentTreeUI(frame);
+                  }
+                } catch (Exception e) {
+                  Logger.getLogger(Startup.class.getName()).info(" > > > > > Error applying Consty colours to LaF : " + e.toString());
+                }
+        
             });
         }
 
@@ -69,4 +99,117 @@ public class Startup implements Runnable {
 
         ProxyUtilities.setProxySelector(null);
     }
+    
+    private static void initWindowsColors() {
+      Color constyLightBlue = new Color(230, 240, 255);
+      Color  constyMidBlue = new Color(135, 180, 255);
+      Color  constyDarkBlue = new Color(50, 130, 255);
+      Color constyBackBlue = new Color(165, 175, 185);
+      Color constyGray = new Color(220, 220, 220);
+
+      UIManager.getDefaults().put("tab_sel_fill", constyMidBlue);
+      UIManager.getDefaults().put("tab_focus_fill_upper", constyLightBlue);
+      UIManager.getDefaults().put("tab_focus_fill_lower", constyDarkBlue);
+      UIManager.getDefaults().put("tab_unsel_fill_upper", constyGray);
+      UIManager.getDefaults().put("tab_unsel_fill_lower", constyBackBlue);
+      UIManager.getDefaults().put("tab_mouse_over_fill_upper", constyLightBlue);
+      UIManager.getDefaults().put("tab_mouse_over_fill_lower", constyMidBlue);
+      UIManager.getDefaults().put("tab_attention_fill_upper", constyMidBlue);
+      UIManager.getDefaults().put("tab_attention_fill_lower", constyDarkBlue);
+
+    }
+ 
+    private static void initNimbusColors() {
+
+      Color  constyActiveBlue = new Color(155, 200, 255);
+      Color  constyActiveDarkBlue = new Color(95, 130, 185);
+
+      Color  constySelectedBlue = new Color(140, 185, 230);
+      Color  constySelectedDarkBlue = new Color(75, 110, 170);
+
+      Color constyUnselectedGreyBlue = new Color(190, 205, 215);
+      Color constyUnselectedDarkGreyBlue = new Color(150, 160, 175);
+
+      UIManager.getLookAndFeelDefaults().put("TabbedPane:TabbedPaneTab[Selected].backgroundPainter", new CustomTabPainter(constySelectedBlue, constySelectedDarkBlue));
+      UIManager.getLookAndFeelDefaults().put("TabbedPane:TabbedPaneTab[MouseOver+Selected].backgroundPainter", new CustomTabPainter(constyActiveBlue, constyActiveDarkBlue));
+      UIManager.getLookAndFeelDefaults().put("TabbedPane:TabbedPaneTab[Enabled].backgroundPainter", new CustomTabPainter(constyUnselectedGreyBlue, constyUnselectedDarkGreyBlue));
+
+    }
+    private static void initDarkNimbusColors() {
+
+      Color  constyActiveBlue = new Color(125, 170, 225);
+      Color  constyActiveDarkBlue = new Color(65, 100, 155);
+
+      Color  constySelectedBlue = new Color(110, 155, 200);
+      Color  constySelectedDarkBlue = new Color(45, 80, 140);
+
+      Color constyUnselectedGreyBlue = new Color(140, 150, 155);
+      Color constyUnselectedDarkGreyBlue = new Color(100, 110, 115);
+
+      UIManager.getLookAndFeelDefaults().put("TabbedPane:TabbedPaneTab[Selected].backgroundPainter", new CustomTabPainter(constySelectedBlue, constySelectedDarkBlue));
+      UIManager.getLookAndFeelDefaults().put("TabbedPane:TabbedPaneTab[MouseOver+Selected].backgroundPainter", new CustomTabPainter(constyActiveBlue, constyActiveDarkBlue));
+      UIManager.getLookAndFeelDefaults().put("TabbedPane:TabbedPaneTab[Enabled].backgroundPainter", new CustomTabPainter(constyUnselectedGreyBlue, constyUnselectedDarkGreyBlue));
+
+    }
+
+
+
+    public static class CustomTabPainter implements Painter {
+
+      private Color upperColor = Color.WHITE;
+      private Color lowerColor = Color.BLACK;
+
+      public CustomTabPainter(Color baseColor) {
+        if (baseColor != null) {
+          upperColor = baseColor;
+          float[] baseHSB = new float[3];
+          Color.RGBtoHSB(baseColor.getRed(), baseColor.getGreen(), baseColor.getBlue(), baseHSB);
+          lowerColor = new Color(Color.HSBtoRGB(baseHSB[0], baseHSB[1], baseHSB[2] * 2 / 3));
+        }
+      }
+
+      public CustomTabPainter(Color topShadeColor, Color bottomShadeColor) {
+        if (topShadeColor != null) {
+          upperColor = topShadeColor;
+        }
+        if (bottomShadeColor != null) {
+          lowerColor = bottomShadeColor;
+        }
+      }
+
+      @Override
+      public void paint(Graphics2D g, Object j, int w, int h) {
+        g.setColor(upperColor);
+        int startOffset = h/6;
+        int endOffset = h - startOffset;
+        g.fillRect(1,0,w-2,startOffset);
+        int highRed = upperColor.getRed();
+        int highGreen = upperColor.getGreen();
+        int highBlue = upperColor.getBlue();
+        int lowRed = lowerColor.getRed();
+        int lowGreen = lowerColor.getGreen();
+        int lowBlue = lowerColor.getBlue();
+
+        int newRedShade, newGreenShade, newBlueShade;
+
+        for (int heightPosition = startOffset; heightPosition < endOffset; heightPosition++) {
+          newRedShade = highRed - (highRed - lowRed) * (heightPosition - startOffset + 1) / (endOffset - startOffset + 1);
+          newGreenShade = highGreen - (highGreen - lowGreen) * (heightPosition - startOffset + 1) / (endOffset - startOffset + 1);
+          newBlueShade = highBlue - (highBlue - lowBlue) * (heightPosition - startOffset + 1) / (endOffset - startOffset + 1);
+          g.setColor(new Color(newRedShade, newGreenShade, newBlueShade));
+          g.fillRect(1, heightPosition, w-2, 1);
+        }
+
+        g.setColor(lowerColor);
+        g.fillRect(1, endOffset, w-2, startOffset);
+        g.drawLine(1,0,w-2,0);
+        g.drawLine(1, 1, 1, 1);
+        g.drawLine(w-2,1,w-2,1);
+        g.drawLine(0,1,0,h-1);
+        g.drawLine(w-1,1,w-1,h-1);
+
+      }
+
+    }
+  
 }

--- a/CoreFunctionality/src/au/gov/asd/tac/constellation/functionality/startup/Startup.java
+++ b/CoreFunctionality/src/au/gov/asd/tac/constellation/functionality/startup/Startup.java
@@ -19,17 +19,9 @@ import au.gov.asd.tac.constellation.security.ConstellationSecurityManager;
 import au.gov.asd.tac.constellation.security.proxy.ProxyUtilities;
 import au.gov.asd.tac.constellation.utilities.BrandingUtilities;
 import au.gov.asd.tac.constellation.utilities.font.FontUtilities;
-import java.awt.Color;
-import java.awt.Graphics2D;
-import java.lang.reflect.Field;
-import java.util.logging.Logger;
 import javax.swing.JFrame;
-import javax.swing.Painter;
-import javax.swing.SwingUtilities;
-import javax.swing.UIManager;
 import org.openide.windows.OnShowing;
 import org.openide.windows.WindowManager;
-
 
 /**
  * Application Bootstrap on start up
@@ -62,6 +54,8 @@ public class Startup implements Runnable {
                 ? String.format("%s %s", BrandingUtilities.APPLICATION_NAME, environment)
                 : BrandingUtilities.APPLICATION_NAME;
 
+        ConstellationLAFSettings.applyTabColorSettings();
+        
         // We only want to run this if headless is NOT set to true
         if (!Boolean.TRUE.toString().equalsIgnoreCase(System.getProperty(AWT_HEADLESS_PROPERTY))) {
             // update the main window title with the version number
@@ -69,28 +63,6 @@ public class Startup implements Runnable {
                 final JFrame frame = (JFrame) WindowManager.getDefault().getMainWindow();
                 final String title = String.format("%s - %s", name, VERSION);
                 frame.setTitle(title);
-                try {
-                  String currentLafName = UIManager.getLookAndFeel().getName();
-                  if (currentLafName.contains("Windows")) {
-                    initWindowsColors();
-                    Class<?> tabDisplayer = ((Class<?>) UIManager.getDefaults().get("org.netbeans.swing.tabcontrol.plaf.Windows8VectorViewTabDisplayerUI")).getSuperclass();
-                    Field colsReady = tabDisplayer.getDeclaredField("colorsReady");
-                    colsReady.setAccessible(true);
-                    colsReady.setBoolean(tabDisplayer, false);
-                  } else if (currentLafName.contains("Nimbus")) {
-                    if (currentLafName.contains("Dark")) {
-                      initDarkNimbusColors();
-                    } else {
-                      initNimbusColors();
-                    }
-                    UIManager.getLookAndFeel().uninitialize();
-                    UIManager.getLookAndFeel().initialize();
-                    SwingUtilities.updateComponentTreeUI(frame);
-                  }
-                } catch (Exception e) {
-                  Logger.getLogger(Startup.class.getName()).info(" > > > > > Error applying Consty colours to LaF : " + e.toString());
-                }
-        
             });
         }
 
@@ -99,117 +71,5 @@ public class Startup implements Runnable {
 
         ProxyUtilities.setProxySelector(null);
     }
-    
-    private static void initWindowsColors() {
-      Color constyLightBlue = new Color(230, 240, 255);
-      Color  constyMidBlue = new Color(135, 180, 255);
-      Color  constyDarkBlue = new Color(50, 130, 255);
-      Color constyBackBlue = new Color(165, 175, 185);
-      Color constyGray = new Color(220, 220, 220);
 
-      UIManager.getDefaults().put("tab_sel_fill", constyMidBlue);
-      UIManager.getDefaults().put("tab_focus_fill_upper", constyLightBlue);
-      UIManager.getDefaults().put("tab_focus_fill_lower", constyDarkBlue);
-      UIManager.getDefaults().put("tab_unsel_fill_upper", constyGray);
-      UIManager.getDefaults().put("tab_unsel_fill_lower", constyBackBlue);
-      UIManager.getDefaults().put("tab_mouse_over_fill_upper", constyLightBlue);
-      UIManager.getDefaults().put("tab_mouse_over_fill_lower", constyMidBlue);
-      UIManager.getDefaults().put("tab_attention_fill_upper", constyMidBlue);
-      UIManager.getDefaults().put("tab_attention_fill_lower", constyDarkBlue);
-
-    }
- 
-    private static void initNimbusColors() {
-
-      Color  constyActiveBlue = new Color(155, 200, 255);
-      Color  constyActiveDarkBlue = new Color(95, 130, 185);
-
-      Color  constySelectedBlue = new Color(140, 185, 230);
-      Color  constySelectedDarkBlue = new Color(75, 110, 170);
-
-      Color constyUnselectedGreyBlue = new Color(190, 205, 215);
-      Color constyUnselectedDarkGreyBlue = new Color(150, 160, 175);
-
-      UIManager.getLookAndFeelDefaults().put("TabbedPane:TabbedPaneTab[Selected].backgroundPainter", new CustomTabPainter(constySelectedBlue, constySelectedDarkBlue));
-      UIManager.getLookAndFeelDefaults().put("TabbedPane:TabbedPaneTab[MouseOver+Selected].backgroundPainter", new CustomTabPainter(constyActiveBlue, constyActiveDarkBlue));
-      UIManager.getLookAndFeelDefaults().put("TabbedPane:TabbedPaneTab[Enabled].backgroundPainter", new CustomTabPainter(constyUnselectedGreyBlue, constyUnselectedDarkGreyBlue));
-
-    }
-    private static void initDarkNimbusColors() {
-
-      Color  constyActiveBlue = new Color(125, 170, 225);
-      Color  constyActiveDarkBlue = new Color(65, 100, 155);
-
-      Color  constySelectedBlue = new Color(110, 155, 200);
-      Color  constySelectedDarkBlue = new Color(45, 80, 140);
-
-      Color constyUnselectedGreyBlue = new Color(140, 150, 155);
-      Color constyUnselectedDarkGreyBlue = new Color(100, 110, 115);
-
-      UIManager.getLookAndFeelDefaults().put("TabbedPane:TabbedPaneTab[Selected].backgroundPainter", new CustomTabPainter(constySelectedBlue, constySelectedDarkBlue));
-      UIManager.getLookAndFeelDefaults().put("TabbedPane:TabbedPaneTab[MouseOver+Selected].backgroundPainter", new CustomTabPainter(constyActiveBlue, constyActiveDarkBlue));
-      UIManager.getLookAndFeelDefaults().put("TabbedPane:TabbedPaneTab[Enabled].backgroundPainter", new CustomTabPainter(constyUnselectedGreyBlue, constyUnselectedDarkGreyBlue));
-
-    }
-
-
-
-    public static class CustomTabPainter implements Painter {
-
-      private Color upperColor = Color.WHITE;
-      private Color lowerColor = Color.BLACK;
-
-      public CustomTabPainter(Color baseColor) {
-        if (baseColor != null) {
-          upperColor = baseColor;
-          float[] baseHSB = new float[3];
-          Color.RGBtoHSB(baseColor.getRed(), baseColor.getGreen(), baseColor.getBlue(), baseHSB);
-          lowerColor = new Color(Color.HSBtoRGB(baseHSB[0], baseHSB[1], baseHSB[2] * 2 / 3));
-        }
-      }
-
-      public CustomTabPainter(Color topShadeColor, Color bottomShadeColor) {
-        if (topShadeColor != null) {
-          upperColor = topShadeColor;
-        }
-        if (bottomShadeColor != null) {
-          lowerColor = bottomShadeColor;
-        }
-      }
-
-      @Override
-      public void paint(Graphics2D g, Object j, int w, int h) {
-        g.setColor(upperColor);
-        int startOffset = h/6;
-        int endOffset = h - startOffset;
-        g.fillRect(1,0,w-2,startOffset);
-        int highRed = upperColor.getRed();
-        int highGreen = upperColor.getGreen();
-        int highBlue = upperColor.getBlue();
-        int lowRed = lowerColor.getRed();
-        int lowGreen = lowerColor.getGreen();
-        int lowBlue = lowerColor.getBlue();
-
-        int newRedShade, newGreenShade, newBlueShade;
-
-        for (int heightPosition = startOffset; heightPosition < endOffset; heightPosition++) {
-          newRedShade = highRed - (highRed - lowRed) * (heightPosition - startOffset + 1) / (endOffset - startOffset + 1);
-          newGreenShade = highGreen - (highGreen - lowGreen) * (heightPosition - startOffset + 1) / (endOffset - startOffset + 1);
-          newBlueShade = highBlue - (highBlue - lowBlue) * (heightPosition - startOffset + 1) / (endOffset - startOffset + 1);
-          g.setColor(new Color(newRedShade, newGreenShade, newBlueShade));
-          g.fillRect(1, heightPosition, w-2, 1);
-        }
-
-        g.setColor(lowerColor);
-        g.fillRect(1, endOffset, w-2, startOffset);
-        g.drawLine(1,0,w-2,0);
-        g.drawLine(1, 1, 1, 1);
-        g.drawLine(w-2,1,w-2,1);
-        g.drawLine(0,1,0,h-1);
-        g.drawLine(w-1,1,w-1,h-1);
-
-      }
-
-    }
-  
 }

--- a/CoreFunctionality/test/unit/src/au/gov/asd/tac/constellation/functionality/startup/ConstellationLAFSettingsNGTest.java
+++ b/CoreFunctionality/test/unit/src/au/gov/asd/tac/constellation/functionality/startup/ConstellationLAFSettingsNGTest.java
@@ -16,6 +16,7 @@
 package au.gov.asd.tac.constellation.functionality.startup;
 
 import java.awt.Color;
+import java.awt.Graphics2D;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.logging.Level;
@@ -81,14 +82,14 @@ public class ConstellationLAFSettingsNGTest {
             // Test Nimbus LAF settings
             pseudoLAF.setName("Nimbus");
             ConstellationLAFSettings.applyTabColorSettings();
-            final String nimbusPainterName = UIManager.getDefaults().get("TabbedPane:TabbedPaneTab[Enabled].backgroundPainter").getClass().getName();
+            final String nimbusPainterName = UIManager.getLookAndFeelDefaults().get("TabbedPane:TabbedPaneTab[Enabled].backgroundPainter").getClass().getName();
             Assert.assertTrue(nimbusPainterName != null && nimbusPainterName.contains("NimbusCustomGradientTabPainter"));
             LOGGER.info("Testing LAF: Nimbus : PASSED");
 
             pseudoLAF.setName("Dark Nimbus");
             UIManager.getDefaults().put("TabbedPane:TabbedPaneTab[Enabled].backgroundPainter", null);
             ConstellationLAFSettings.applyTabColorSettings();
-            final String darkNimbusPainterName = UIManager.getDefaults().get("TabbedPane:TabbedPaneTab[Enabled].backgroundPainter").getClass().getName();
+            final String darkNimbusPainterName = UIManager.getLookAndFeelDefaults().get("TabbedPane:TabbedPaneTab[Enabled].backgroundPainter").getClass().getName();
             Assert.assertTrue(darkNimbusPainterName != null && darkNimbusPainterName.contains("NimbusCustomGradientTabPainter"));
             LOGGER.info("Testing LAF: Dark Nimbus : PASSED");
 
@@ -125,7 +126,9 @@ public class ConstellationLAFSettingsNGTest {
             Assert.assertTrue(darkHighlight != null && darkHighlight.equals(expectedDarkHighlight));
             LOGGER.info("Testing LAF: Dark Metal : PASSED");
             
+            // ERROR TESTS
             // Test that no changes are made when exceptions occur
+            
             pseudoLAF.setName("Windows XP");
             UIManager.getDefaults().put("org.netbeans.swing.tabcontrol.plaf.Windows8VectorViewTabDisplayerUI", null);
             UIManager.getDefaults().put("org.netbeans.swing.tabcontrol.plaf.WinXPViewTabDisplayerUI", pseudoViewDisplayerUIclass); 
@@ -156,8 +159,44 @@ public class ConstellationLAFSettingsNGTest {
             final Color selectedBackgroundSetting = (Color) UIManager.getDefaults().get("TabRenderer.selectedBackground");
             Assert.assertTrue(selectedBackgroundSetting != null && selectedBackgroundSetting.equals(Color.BLACK));
             
-            LOGGER.info("Testing exceptions / Processing invalid settings: PASSED\n");
-            LOGGER.info("TESTING ConstellationLAFSettings : COMPLETE");
+            LOGGER.info("Testing exceptions / Processing invalid settings: PASSED");
+            
+            // CLASS COVERAGE CALLS
+            // Tests more code paths in ConstellationLAFSettings class
+            ConstellationLAFSettings.ouputUIDefaultValues(null, "Tabbed");
+            ConstellationLAFSettings.ouputUIDefaultValues("Tabbed", null);
+
+            LOGGER.info("********************************************");
+            
+            pseudoLAF.setName("Windows 95");
+            UIManager.getDefaults().put("org.netbeans.swing.tabcontrol.plaf.Windows8VectorViewTabDisplayerUI", null);
+            UIManager.getDefaults().put("org.netbeans.swing.tabcontrol.plaf.WinXPViewTabDisplayerUI", null); 
+            ConstellationLAFSettings.applyTabColorSettings();
+            UIManager.getDefaults().put("org.netbeans.swing.tabcontrol.plaf.Windows8VectorViewTabDisplayerUI", pseudoTabDisplayerUIclass);
+            ConstellationLAFSettings.applyTabColorSettings();
+
+            LOGGER.info("********************************************");
+            
+            pseudoLAF.setName("FlatLafLight");
+            UIManager.getDefaults().put("org.netbeans.swing.laf.flatlaf.ui.FlatViewTabDisplayerUI", null);
+            ConstellationLAFSettings.applyTabColorSettings();
+            
+            LOGGER.info("********************************************");
+            
+            pseudoLAF.setName("Metal");
+            UIManager.getDefaults().put("org.netbeans.swing.tabcontrol.plaf.MetalViewTabDisplayerUI", null);
+            ConstellationLAFSettings.applyTabColorSettings();
+            
+            LOGGER.info("*******************************************");
+            
+            new ConstellationLAFSettings.NimbusCustomGradientTabPainter();
+            new ConstellationLAFSettings.NimbusCustomGradientTabPainter(null);
+            new ConstellationLAFSettings.NimbusCustomGradientTabPainter(Color.ORANGE);
+            new ConstellationLAFSettings.NimbusCustomGradientTabPainter(null, null);
+            new ConstellationLAFSettings.NimbusCustomGradientTabPainter(null, Color.ORANGE);
+            new ConstellationLAFSettings.NimbusCustomGradientTabPainter(Color.ORANGE, null);            
+            
+            LOGGER.info("\nTESTING ConstellationLAFSettings : COMPLETE");
             
         } catch (Exception e) {
             LOGGER.log(Level.SEVERE, "\n******* EXCEPTION *******\n", e);            
@@ -233,14 +272,4 @@ public class ConstellationLAFSettingsNGTest {
         
     }
     
-//    /**
-//     * This Pseudo class is used for testing purposes to simulate
-//     * an invalid entry to intentionally cause an exception.
-//     */
-//    public class PseudoInvalidTabDisplayerUI extends PseudoViewTabDisplayerUI {
-//        PseudoInvalidTabDisplayerUI(){
-//            super();
-//        }
-//    }
-
 }

--- a/CoreFunctionality/test/unit/src/au/gov/asd/tac/constellation/functionality/startup/ConstellationLAFSettingsNGTest.java
+++ b/CoreFunctionality/test/unit/src/au/gov/asd/tac/constellation/functionality/startup/ConstellationLAFSettingsNGTest.java
@@ -66,7 +66,8 @@ public class ConstellationLAFSettingsNGTest {
             LOGGER.info("Windows XP LAF Test: PASSED");
 
         } catch (Exception e) {
-            LOGGER.log(Level.SEVERE, "\n******* EXCEPTION *******\n", e);            
+            LOGGER.log(Level.SEVERE, "\n******* ERROR RUNNING TEST *******\n", e);
+            Assert.fail("\n******* ERROR RUNNING TEST *******\n" + e);
         }
     }
     
@@ -88,7 +89,8 @@ public class ConstellationLAFSettingsNGTest {
             Assert.assertTrue(selectedBackgroundFiller != null && selectedBackgroundFiller.equals(expectedBackgroundFiller));                                                              
             LOGGER.info("Windows 8+ LAF Test: PASSED");
         } catch (Exception e) {
-            LOGGER.log(Level.SEVERE, "\n******* EXCEPTION *******\n", e);            
+            LOGGER.log(Level.SEVERE, "\n******* ERROR RUNNING TEST *******\n", e);
+            Assert.fail("\n******* ERROR RUNNING TEST *******\n" + e);
         }
     }
     
@@ -108,7 +110,8 @@ public class ConstellationLAFSettingsNGTest {
             Assert.assertTrue(nimbusPainterName != null && nimbusPainterName.contains("NimbusCustomGradientTabPainter"));
             LOGGER.info("Nimbus LAF Test: PASSED");
         } catch (Exception e) {
-            LOGGER.log(Level.SEVERE, "\n******* EXCEPTION *******\n", e);            
+            LOGGER.log(Level.SEVERE, "\n******* ERROR RUNNING TEST *******\n", e);
+            Assert.fail("\n******* ERROR RUNNING TEST *******\n" + e);
         }
     }
 
@@ -129,7 +132,8 @@ public class ConstellationLAFSettingsNGTest {
             Assert.assertTrue(darkNimbusPainterName != null && darkNimbusPainterName.contains("NimbusCustomGradientTabPainter"));
             LOGGER.info("Dark Nimbus LAF Test: PASSED");
         } catch (Exception e) {
-            LOGGER.log(Level.SEVERE, "\n******* EXCEPTION *******\n", e);            
+            LOGGER.log(Level.SEVERE, "\n******* ERROR RUNNING TEST *******\n", e);
+            Assert.fail("\n******* ERROR RUNNING TEST *******\n" + e);
         }
     }
 
@@ -151,7 +155,8 @@ public class ConstellationLAFSettingsNGTest {
             Assert.assertTrue(highlight != null && highlight.equals(expectedHighlight));
             LOGGER.info("Metal LAF Test: PASSED");
         } catch (Exception e) {
-            LOGGER.log(Level.SEVERE, "\n******* EXCEPTION *******\n", e);            
+            LOGGER.log(Level.SEVERE, "\n******* ERROR RUNNING TEST *******\n", e);
+            Assert.fail("\n******* ERROR RUNNING TEST *******\n" + e);
         }
     }
     
@@ -173,7 +178,8 @@ public class ConstellationLAFSettingsNGTest {
             Assert.assertTrue(darkHighlight != null && darkHighlight.equals(expectedDarkHighlight));
             LOGGER.info("Dark Metal LAF Test: PASSED");
         } catch (Exception e) {
-            LOGGER.log(Level.SEVERE, "\n******* EXCEPTION *******\n", e);            
+            LOGGER.log(Level.SEVERE, "\n******* ERROR RUNNING TEST *******\n", e);
+            Assert.fail("\n******* ERROR RUNNING TEST *******\n" + e);
         }
     }
     
@@ -195,7 +201,8 @@ public class ConstellationLAFSettingsNGTest {
             Assert.assertTrue(inactiveUnderlineColor != null && inactiveUnderlineColor.equals(expectedInactiveUnderlineColor));
             LOGGER.info("FlatLafLight LAF Test: PASSED");
         } catch (Exception e) {
-            LOGGER.log(Level.SEVERE, "\n******* EXCEPTION *******\n", e);            
+            LOGGER.log(Level.SEVERE, "\n******* ERROR RUNNING TEST *******\n", e);
+            Assert.fail("\n******* ERROR RUNNING TEST *******\n" + e);
         }
     }
 
@@ -217,7 +224,8 @@ public class ConstellationLAFSettingsNGTest {
             Assert.assertTrue(inactiveDarkUnderlineColor != null && inactiveDarkUnderlineColor.equals(expectedInactiveDarkUnderlineColor));
             LOGGER.info("FlatLafDark LAF Test: PASSED");
         } catch (Exception e) {
-            LOGGER.log(Level.SEVERE, "\n******* EXCEPTION *******\n", e);            
+            LOGGER.log(Level.SEVERE, "\n******* ERROR RUNNING TEST *******\n", e);
+            Assert.fail("\n******* ERROR RUNNING TEST *******\n" + e);
         }
     }
 
@@ -242,7 +250,8 @@ public class ConstellationLAFSettingsNGTest {
             Assert.assertTrue(selectionIndicatorSetting != null && selectionIndicatorSetting.equals(Color.BLACK));                        
             LOGGER.info("ERROR TESTS on Windows: PASSED");
         } catch (Exception e) {
-            LOGGER.log(Level.SEVERE, "\n******* EXCEPTION *******\n", e);            
+            LOGGER.log(Level.SEVERE, "\n******* ERROR RUNNING TEST *******\n", e);
+            Assert.fail("\n******* ERROR RUNNING TEST *******\n" + e);
         }
     }
 
@@ -266,7 +275,8 @@ public class ConstellationLAFSettingsNGTest {
             Assert.assertTrue(selectedBackgroundSetting != null && selectedBackgroundSetting.equals(Color.BLACK));
             LOGGER.info("ERROR TESTS on Metal: PASSED");
         } catch (Exception e) {
-            LOGGER.log(Level.SEVERE, "\n******* EXCEPTION *******\n", e);            
+            LOGGER.log(Level.SEVERE, "\n******* ERROR RUNNING TEST *******\n", e);
+            Assert.fail("\n******* ERROR RUNNING TEST *******\n" + e);
         }
     }
 
@@ -290,7 +300,8 @@ public class ConstellationLAFSettingsNGTest {
             Assert.assertTrue(inactiveUnderlineColorSetting != null && inactiveUnderlineColorSetting.equals(Color.BLACK));
             LOGGER.info("ERROR TESTS on FlatLafLight: PASSED");
         } catch (Exception e) {
-            LOGGER.log(Level.SEVERE, "\n******* EXCEPTION *******\n", e);            
+            LOGGER.log(Level.SEVERE, "\n******* ERROR RUNNING TEST *******\n", e);
+            Assert.fail("\n******* ERROR RUNNING TEST *******\n" + e);
         }
     }
 
@@ -335,7 +346,8 @@ public class ConstellationLAFSettingsNGTest {
 
             LOGGER.info("CLASS COVERAGE TESTS COMPLETE");
         } catch (Exception e) {
-            LOGGER.log(Level.SEVERE, "\n******* EXCEPTION *******\n", e);            
+            LOGGER.log(Level.SEVERE, "\n******* ERROR RUNNING TEST *******\n", e);
+            Assert.fail("\n******* ERROR RUNNING TEST *******\n" + e);
         }
     }
    

--- a/CoreFunctionality/test/unit/src/au/gov/asd/tac/constellation/functionality/startup/ConstellationLAFSettingsNGTest.java
+++ b/CoreFunctionality/test/unit/src/au/gov/asd/tac/constellation/functionality/startup/ConstellationLAFSettingsNGTest.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2010-2021 Australian Signals Directorate
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package au.gov.asd.tac.constellation.functionality.startup;
+
+import java.awt.Color;
+import java.util.logging.Logger;
+import javax.swing.JFrame;
+import javax.swing.UIManager;
+import static org.mockito.ArgumentMatchers.any;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import org.openide.windows.WindowManager;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+/**
+ *
+ * @author OrionsGuardian
+ */
+public class ConstellationLAFSettingsNGTest {
+    
+    private static final Logger LOGGER = Logger.getLogger(ConstellationLAFSettingsNGTest.class.getName());
+    
+    @Test
+    public void runSetLAFTabColors() {
+        try (final MockedStatic<WindowManager> windowManagerMockedStatic = Mockito.mockStatic(WindowManager.class)) {
+            final WindowManager windowManager = mock(WindowManager.class);
+            windowManagerMockedStatic.when(WindowManager::getDefault).thenReturn(windowManager);
+            doAnswer(mockInvocation -> {
+                final Runnable runnable = (Runnable) mockInvocation.getArgument(0);
+
+                final JFrame frame = mock(JFrame.class);
+                when(windowManager.getMainWindow()).thenReturn(frame);
+
+                runnable.run();
+                for (javax.swing.UIManager.LookAndFeelInfo info : javax.swing.UIManager.getInstalledLookAndFeels()) {
+                    LOGGER.info("\n------ Found LAF: " + info.getName() + "\n");
+                    if (info.getName().toUpperCase().contains("NIMBUS")) {
+                        javax.swing.UIManager.setLookAndFeel(info.getClassName());
+                        ConstellationLAFSettings.applyTabColorSettings();
+                        final String painterName = UIManager.getLookAndFeelDefaults().get("TabbedPane:TabbedPaneTab[Enabled].backgroundPainter").getClass().getName();
+                        Assert.assertTrue(painterName.contains("NimbusCustomGradientTabPainter"));
+                    } else if (info.getName().toUpperCase().contains("FLATLAF")) {
+                        javax.swing.UIManager.setLookAndFeel(info.getClassName());
+                        final Class<?> tabDisplayer = (Class<?>) UIManager.getDefaults()
+                                .get("org.netbeans.swing.laf.flatlaf.ui.FlatViewTabDisplayerUI");
+                        if (tabDisplayer != null) {
+                            ConstellationLAFSettings.applyTabColorSettings();
+                            final String underlineHeight = (String) UIManager.get("ViewTab.underlineHeight");
+                            Assert.assertEquals(underlineHeight, "5");
+                        } else {
+                            ConstellationLAFSettings.ouputUIDefaultValues(null, null);
+                        }
+                    } else if (info.getName().toUpperCase().contains("METAL")) {
+                        javax.swing.UIManager.setLookAndFeel(info.getClassName());
+                        final Class<?> tabDisplayer = (Class<?>) UIManager.getDefaults()
+                            .get("org.netbeans.swing.tabcontrol.plaf.MetalViewTabDisplayerUI");            
+                        if (tabDisplayer != null) {
+                            ConstellationLAFSettings.applyTabColorSettings();
+                            final Color selectedActivatedBackground = (Color) UIManager.get("TabRenderer.selectedActivatedBackground");
+                            final Color expectedDarkBackground = new Color(45, 95, 180);
+                            final Color expectedLightBackground = new Color(130, 170, 255);
+                            if (info.getName().toUpperCase().contains("DARK")) {
+                                Assert.assertTrue(selectedActivatedBackground.equals(expectedDarkBackground));
+                            } else {
+                                Assert.assertTrue(selectedActivatedBackground.equals(expectedLightBackground));
+                            }
+                        } else {
+                            ConstellationLAFSettings.ouputUIDefaultValues(null, null);
+                        }
+                    } else if (info.getName().toUpperCase().contains("WINDOWS")) {
+                        javax.swing.UIManager.setLookAndFeel(info.getClassName());
+                        Class<?> displayerClass = (Class<?>) UIManager.getDefaults()
+                            .get("org.netbeans.swing.tabcontrol.plaf.Windows8VectorViewTabDisplayerUI");
+                        if (displayerClass == null) {
+                            displayerClass = (Class<?>) UIManager.getDefaults()
+                                .get("org.netbeans.swing.tabcontrol.plaf.WinXPViewTabDisplayerUI");
+                            if (displayerClass != null) {
+                                // check XP settings
+                                ConstellationLAFSettings.applyTabColorSettings();
+                                final Color selectionIndicator = (Color) UIManager.get("TabbedPane.selectionIndicator");
+                                final Color expectedSelectionIndicator = new Color(180, 220, 255);                                                                
+                                Assert.assertTrue(selectionIndicator.equals(expectedSelectionIndicator));                                                              
+                            } else {
+                               ConstellationLAFSettings.ouputUIDefaultValues(null, null);
+                            }
+                        } else {
+                            // check Win8+ settings
+                            ConstellationLAFSettings.applyTabColorSettings();
+                            final Color selectedBackgroundFiller = (Color) UIManager.get("tab_sel_fill");
+                            final Color expectedBackgroundFiller = new Color(160, 205, 255);                                                                
+                            Assert.assertTrue(selectedBackgroundFiller.equals(expectedBackgroundFiller));                                                              
+                        }
+                    }
+
+                }
+
+                return null;
+            }).when(windowManager).invokeWhenUIReady(any(Runnable.class));
+
+            new Startup().run();
+            
+        } catch (Exception e) {
+            LOGGER.info("\n******* EXCEPTION \n" + e.toString());
+        }
+    }
+
+    
+}

--- a/CoreFunctionality/test/unit/src/au/gov/asd/tac/constellation/functionality/startup/ConstellationLAFSettingsNGTest.java
+++ b/CoreFunctionality/test/unit/src/au/gov/asd/tac/constellation/functionality/startup/ConstellationLAFSettingsNGTest.java
@@ -16,7 +16,6 @@
 package au.gov.asd.tac.constellation.functionality.startup;
 
 import java.awt.Color;
-import java.awt.Graphics2D;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.logging.Level;
@@ -42,93 +41,196 @@ public class ConstellationLAFSettingsNGTest {
     private static final Logger LOGGER = Logger.getLogger(ConstellationLAFSettingsNGTest.class.getName());
     final static PseudoLookAndFeel pseudoLAF = new PseudoLookAndFeel();
     final static PseudoUIDefaults pseudoUIdefaults = new PseudoUIDefaults();
-    
+    final static PseudoViewTabDisplayerUI pseudoViewDisplayerUI = new PseudoViewTabDisplayerUI();
+    final static PseudoTabDisplayerUI pseudoTabDisplayerUI = new PseudoTabDisplayerUI();
+    final static Class<?> pseudoViewDisplayerUIclass = pseudoViewDisplayerUI.getClass();
+    final static Class<?> pseudoTabDisplayerUIclass = pseudoTabDisplayerUI.getClass();
+
     @Test
-    public void runSetLAFTabColors() {
+    public void runSetWindowsXPTabColors() {
         try (final MockedStatic<WindowManager> windowManagerMockedStatic = Mockito.mockStatic(WindowManager.class)) {
             final WindowManager windowManager = mock(WindowManager.class);
             windowManagerMockedStatic.when(WindowManager::getDefault).thenReturn(windowManager);
-            
-            LOGGER.info("TESTING ConstellationLAFSettings ...");
-            UIManager.setLookAndFeel(pseudoLAF);
             final JFrame frame = mock(JFrame.class);
             when(windowManager.getMainWindow()).thenReturn(frame);
-
-            PseudoViewTabDisplayerUI pseudoViewDisplayerUI = new PseudoViewTabDisplayerUI();
-            PseudoTabDisplayerUI pseudoTabDisplayerUI = new PseudoTabDisplayerUI();
-            Class<?> pseudoViewDisplayerUIclass = pseudoViewDisplayerUI.getClass();
-            Class<?> pseudoTabDisplayerUIclass = pseudoTabDisplayerUI.getClass();
-
-            // Test XP LAF settings
+            
+            LOGGER.info("TESTING ConstellationLAFSettings for Windows XP ...");
+            UIManager.setLookAndFeel(pseudoLAF);
             pseudoLAF.setName("Windows XP");
             UIManager.getDefaults().put("org.netbeans.swing.tabcontrol.plaf.Windows8VectorViewTabDisplayerUI", null);
             UIManager.getDefaults().put("org.netbeans.swing.tabcontrol.plaf.WinXPViewTabDisplayerUI", pseudoTabDisplayerUIclass);
-
             ConstellationLAFSettings.applyTabColorSettings();
             final Color selectionIndicator = (Color) UIManager.getDefaults().get("TabbedPane.selectionIndicator");
             final Color expectedSelectionIndicator = new Color(180, 220, 255);                                                                
             Assert.assertTrue(selectionIndicator != null && selectionIndicator.equals(expectedSelectionIndicator));                                                              
-            LOGGER.info("Testing LAF: Windows XP : PASSED");
+            LOGGER.info("Windows XP LAF Test: PASSED");
 
-            // Test Win 8+ LAF settings
+        } catch (Exception e) {
+            LOGGER.log(Level.SEVERE, "\n******* EXCEPTION *******\n", e);            
+        }
+    }
+    
+    @Test
+    public void runSetWindows8TabColors() {
+        try (final MockedStatic<WindowManager> windowManagerMockedStatic = Mockito.mockStatic(WindowManager.class)) {
+            final WindowManager windowManager = mock(WindowManager.class);
+            windowManagerMockedStatic.when(WindowManager::getDefault).thenReturn(windowManager);            
+            final JFrame frame = mock(JFrame.class);
+            when(windowManager.getMainWindow()).thenReturn(frame);            
+            
+            LOGGER.info("TESTING ConstellationLAFSettings for Windows 8+ ...");
+            UIManager.setLookAndFeel(pseudoLAF);
             pseudoLAF.setName("Windows 8+");
             UIManager.getDefaults().put("org.netbeans.swing.tabcontrol.plaf.Windows8VectorViewTabDisplayerUI", pseudoViewDisplayerUIclass);
             ConstellationLAFSettings.applyTabColorSettings();
             final Color selectedBackgroundFiller = (Color) UIManager.getDefaults().get("tab_sel_fill");
             final Color expectedBackgroundFiller = new Color(160, 205, 255);                                                                
             Assert.assertTrue(selectedBackgroundFiller != null && selectedBackgroundFiller.equals(expectedBackgroundFiller));                                                              
-            LOGGER.info("Testing LAF: Windows 8+ : PASSED");
+            LOGGER.info("Windows 8+ LAF Test: PASSED");
+        } catch (Exception e) {
+            LOGGER.log(Level.SEVERE, "\n******* EXCEPTION *******\n", e);            
+        }
+    }
+    
+    @Test
+    public void runSetNimbusTabColors() {
+        try (final MockedStatic<WindowManager> windowManagerMockedStatic = Mockito.mockStatic(WindowManager.class)) {
+            final WindowManager windowManager = mock(WindowManager.class);
+            windowManagerMockedStatic.when(WindowManager::getDefault).thenReturn(windowManager);            
+            final JFrame frame = mock(JFrame.class);
+            when(windowManager.getMainWindow()).thenReturn(frame);            
             
-            // Test Nimbus LAF settings
+            LOGGER.info("TESTING ConstellationLAFSettings for Nimbus ...");
+            UIManager.setLookAndFeel(pseudoLAF);
             pseudoLAF.setName("Nimbus");
             ConstellationLAFSettings.applyTabColorSettings();
             final String nimbusPainterName = UIManager.getLookAndFeelDefaults().get("TabbedPane:TabbedPaneTab[Enabled].backgroundPainter").getClass().getName();
             Assert.assertTrue(nimbusPainterName != null && nimbusPainterName.contains("NimbusCustomGradientTabPainter"));
-            LOGGER.info("Testing LAF: Nimbus : PASSED");
+            LOGGER.info("Nimbus LAF Test: PASSED");
+        } catch (Exception e) {
+            LOGGER.log(Level.SEVERE, "\n******* EXCEPTION *******\n", e);            
+        }
+    }
 
+        @Test
+    public void runSetDarkNimbusTabColors() {
+        try (final MockedStatic<WindowManager> windowManagerMockedStatic = Mockito.mockStatic(WindowManager.class)) {
+            final WindowManager windowManager = mock(WindowManager.class);
+            windowManagerMockedStatic.when(WindowManager::getDefault).thenReturn(windowManager);            
+            final JFrame frame = mock(JFrame.class);
+            when(windowManager.getMainWindow()).thenReturn(frame);            
+            
+            LOGGER.info("TESTING ConstellationLAFSettings for Dark Nimbus ...");
+            UIManager.setLookAndFeel(pseudoLAF);
             pseudoLAF.setName("Dark Nimbus");
             UIManager.getDefaults().put("TabbedPane:TabbedPaneTab[Enabled].backgroundPainter", null);
             ConstellationLAFSettings.applyTabColorSettings();
             final String darkNimbusPainterName = UIManager.getLookAndFeelDefaults().get("TabbedPane:TabbedPaneTab[Enabled].backgroundPainter").getClass().getName();
             Assert.assertTrue(darkNimbusPainterName != null && darkNimbusPainterName.contains("NimbusCustomGradientTabPainter"));
-            LOGGER.info("Testing LAF: Dark Nimbus : PASSED");
+            LOGGER.info("Dark Nimbus LAF Test: PASSED");
+        } catch (Exception e) {
+            LOGGER.log(Level.SEVERE, "\n******* EXCEPTION *******\n", e);            
+        }
+    }
 
-            // Test FlatLaf settings
-            pseudoLAF.setName("FlatLafLight");
-            UIManager.getDefaults().put("org.netbeans.swing.laf.flatlaf.ui.FlatViewTabDisplayerUI", pseudoTabDisplayerUIclass);
-            ConstellationLAFSettings.applyTabColorSettings();
-            final Color inactiveUnderlineColor = (Color) UIManager.getDefaults().get("ViewTab.inactiveUnderlineColor");
-            final Color expectedInactiveUnderlineColor = new Color(95, 130, 185);
-            Assert.assertTrue(inactiveUnderlineColor != null && inactiveUnderlineColor.equals(expectedInactiveUnderlineColor));
-            LOGGER.info("Testing LAF: FlatLafLight : PASSED");
-
-            pseudoLAF.setName("FlatLafDark");
-            UIManager.getDefaults().put("ViewTab.underlineHeight", 1);
-            ConstellationLAFSettings.applyTabColorSettings();
-            final Color inactiveDarkUnderlineColor = (Color) UIManager.getDefaults().get("ViewTab.inactiveUnderlineColor");
-            final Color expectedInactiveDarkUnderlineColor = new Color(20, 100, 175);
-            Assert.assertTrue(inactiveDarkUnderlineColor != null && inactiveDarkUnderlineColor.equals(expectedInactiveDarkUnderlineColor));
-            LOGGER.info("Testing LAF: FlatLafDark : PASSED");
-
-            // Test Metal LAF settings
+    @Test
+    public void runSetMetalTabColors() {
+        try (final MockedStatic<WindowManager> windowManagerMockedStatic = Mockito.mockStatic(WindowManager.class)) {
+            final WindowManager windowManager = mock(WindowManager.class);
+            windowManagerMockedStatic.when(WindowManager::getDefault).thenReturn(windowManager);            
+            final JFrame frame = mock(JFrame.class);
+            when(windowManager.getMainWindow()).thenReturn(frame);            
+            
+            LOGGER.info("TESTING ConstellationLAFSettings for Metal ...");
+            UIManager.setLookAndFeel(pseudoLAF);
             pseudoLAF.setName("Metal");
             UIManager.getDefaults().put("org.netbeans.swing.tabcontrol.plaf.MetalViewTabDisplayerUI", pseudoTabDisplayerUIclass);
             ConstellationLAFSettings.applyTabColorSettings();
             final Color highlight = (Color) UIManager.getDefaults().get("controlHighlight");
             final Color expectedHighlight = new Color(130, 170, 255);
             Assert.assertTrue(highlight != null && highlight.equals(expectedHighlight));
-            LOGGER.info("Testing LAF: Metal : PASSED");
-
+            LOGGER.info("Metal LAF Test: PASSED");
+        } catch (Exception e) {
+            LOGGER.log(Level.SEVERE, "\n******* EXCEPTION *******\n", e);            
+        }
+    }
+    
+    @Test
+    public void runSetDarkMetalTabColors() {
+        try (final MockedStatic<WindowManager> windowManagerMockedStatic = Mockito.mockStatic(WindowManager.class)) {
+            final WindowManager windowManager = mock(WindowManager.class);
+            windowManagerMockedStatic.when(WindowManager::getDefault).thenReturn(windowManager);            
+            final JFrame frame = mock(JFrame.class);
+            when(windowManager.getMainWindow()).thenReturn(frame);            
+            
+            LOGGER.info("TESTING ConstellationLAFSettings for Dark Metal ...");
+            UIManager.setLookAndFeel(pseudoLAF);
             pseudoLAF.setName("Dark Metal");
+            UIManager.getDefaults().put("org.netbeans.swing.tabcontrol.plaf.MetalViewTabDisplayerUI", pseudoTabDisplayerUIclass);
             ConstellationLAFSettings.applyTabColorSettings();
             final Color darkHighlight = (Color) UIManager.getDefaults().get("controlHighlight");
             final Color expectedDarkHighlight = new Color(45, 95, 180);
             Assert.assertTrue(darkHighlight != null && darkHighlight.equals(expectedDarkHighlight));
-            LOGGER.info("Testing LAF: Dark Metal : PASSED");
+            LOGGER.info("Dark Metal LAF Test: PASSED");
+        } catch (Exception e) {
+            LOGGER.log(Level.SEVERE, "\n******* EXCEPTION *******\n", e);            
+        }
+    }
+    
+    @Test
+    public void runSetFlatLafLightTabColors() {
+        try (final MockedStatic<WindowManager> windowManagerMockedStatic = Mockito.mockStatic(WindowManager.class)) {
+            final WindowManager windowManager = mock(WindowManager.class);
+            windowManagerMockedStatic.when(WindowManager::getDefault).thenReturn(windowManager);            
+            final JFrame frame = mock(JFrame.class);
+            when(windowManager.getMainWindow()).thenReturn(frame);            
             
-            // ERROR TESTS
-            // Test that no changes are made when exceptions occur
+            LOGGER.info("TESTING ConstellationLAFSettings for FlatLafLight ...");
+            UIManager.setLookAndFeel(pseudoLAF);
+            pseudoLAF.setName("FlatLafLight");
+            UIManager.getDefaults().put("org.netbeans.swing.laf.flatlaf.ui.FlatViewTabDisplayerUI", pseudoTabDisplayerUIclass);
+            ConstellationLAFSettings.applyTabColorSettings();
+            final Color inactiveUnderlineColor = (Color) UIManager.getDefaults().get("ViewTab.inactiveUnderlineColor");
+            final Color expectedInactiveUnderlineColor = new Color(95, 130, 185);
+            Assert.assertTrue(inactiveUnderlineColor != null && inactiveUnderlineColor.equals(expectedInactiveUnderlineColor));
+            LOGGER.info("FlatLafLight LAF Test: PASSED");
+        } catch (Exception e) {
+            LOGGER.log(Level.SEVERE, "\n******* EXCEPTION *******\n", e);            
+        }
+    }
+
+    @Test
+    public void runSetFlatLafDarkTabColors() {
+        try (final MockedStatic<WindowManager> windowManagerMockedStatic = Mockito.mockStatic(WindowManager.class)) {
+            final WindowManager windowManager = mock(WindowManager.class);
+            windowManagerMockedStatic.when(WindowManager::getDefault).thenReturn(windowManager);            
+            final JFrame frame = mock(JFrame.class);
+            when(windowManager.getMainWindow()).thenReturn(frame);            
             
+            LOGGER.info("TESTING ConstellationLAFSettings for FlatLafDark ...");
+            UIManager.setLookAndFeel(pseudoLAF);
+            pseudoLAF.setName("FlatLafDark");
+            UIManager.getDefaults().put("org.netbeans.swing.laf.flatlaf.ui.FlatViewTabDisplayerUI", pseudoTabDisplayerUIclass);
+            ConstellationLAFSettings.applyTabColorSettings();
+            final Color inactiveDarkUnderlineColor = (Color) UIManager.getDefaults().get("ViewTab.inactiveUnderlineColor");
+            final Color expectedInactiveDarkUnderlineColor = new Color(20, 100, 175);
+            Assert.assertTrue(inactiveDarkUnderlineColor != null && inactiveDarkUnderlineColor.equals(expectedInactiveDarkUnderlineColor));
+            LOGGER.info("FlatLafDark LAF Test: PASSED");
+        } catch (Exception e) {
+            LOGGER.log(Level.SEVERE, "\n******* EXCEPTION *******\n", e);            
+        }
+    }
+
+    @Test
+    public void runErroredWindowsSetTabColors() {
+        try (final MockedStatic<WindowManager> windowManagerMockedStatic = Mockito.mockStatic(WindowManager.class)) {
+            final WindowManager windowManager = mock(WindowManager.class);
+            windowManagerMockedStatic.when(WindowManager::getDefault).thenReturn(windowManager);            
+            final JFrame frame = mock(JFrame.class);
+            when(windowManager.getMainWindow()).thenReturn(frame);            
+            
+            LOGGER.info("ERROR TESTING on Windows ConstellationLAFSettings ...");
+            UIManager.setLookAndFeel(pseudoLAF);
             pseudoLAF.setName("Windows XP");
             UIManager.getDefaults().put("org.netbeans.swing.tabcontrol.plaf.Windows8VectorViewTabDisplayerUI", null);
             UIManager.getDefaults().put("org.netbeans.swing.tabcontrol.plaf.WinXPViewTabDisplayerUI", pseudoViewDisplayerUIclass); 
@@ -137,19 +239,23 @@ public class ConstellationLAFSettingsNGTest {
             UIManager.getDefaults().put("TabbedPane.selectionIndicator", Color.BLACK);            
             ConstellationLAFSettings.applyTabColorSettings();
             final Color selectionIndicatorSetting = (Color) UIManager.getDefaults().get("TabbedPane.selectionIndicator");
-            Assert.assertTrue(selectionIndicatorSetting != null && selectionIndicatorSetting.equals(Color.BLACK));
-            
-            
-            pseudoLAF.setName("FlatLafLight");
-            UIManager.getDefaults().put("org.netbeans.swing.laf.flatlaf.ui.FlatViewTabDisplayerUI", pseudoViewDisplayerUIclass);
-            // Incorrect class used as the FlatViewTabDisplayerUI should log an exception and make no color changes
-            
-            UIManager.getDefaults().put("ViewTab.inactiveUnderlineColor", Color.BLACK); 
-            ConstellationLAFSettings.applyTabColorSettings();
-            final Color inactiveUnderlineColorSetting = (Color) UIManager.getDefaults().get("ViewTab.inactiveUnderlineColor");
-            Assert.assertTrue(inactiveUnderlineColorSetting != null && inactiveUnderlineColorSetting.equals(Color.BLACK));
+            Assert.assertTrue(selectionIndicatorSetting != null && selectionIndicatorSetting.equals(Color.BLACK));                        
+            LOGGER.info("ERROR TESTS on Windows: PASSED");
+        } catch (Exception e) {
+            LOGGER.log(Level.SEVERE, "\n******* EXCEPTION *******\n", e);            
+        }
+    }
 
-
+    @Test
+    public void runErroredMetalSetTabColors() {
+        try (final MockedStatic<WindowManager> windowManagerMockedStatic = Mockito.mockStatic(WindowManager.class)) {
+            final WindowManager windowManager = mock(WindowManager.class);
+            windowManagerMockedStatic.when(WindowManager::getDefault).thenReturn(windowManager);            
+            final JFrame frame = mock(JFrame.class);
+            when(windowManager.getMainWindow()).thenReturn(frame);            
+            
+            LOGGER.info("ERROR TESTING on Metal ConstellationLAFSettings ...");
+            UIManager.setLookAndFeel(pseudoLAF);
             pseudoLAF.setName("Metal");
             UIManager.getDefaults().put("org.netbeans.swing.tabcontrol.plaf.MetalViewTabDisplayerUI", pseudoViewDisplayerUIclass);
             // Incorrect class used as the MetalViewTabDisplayerUI should log an exception and make no color changes
@@ -158,36 +264,49 @@ public class ConstellationLAFSettingsNGTest {
             ConstellationLAFSettings.applyTabColorSettings();
             final Color selectedBackgroundSetting = (Color) UIManager.getDefaults().get("TabRenderer.selectedBackground");
             Assert.assertTrue(selectedBackgroundSetting != null && selectedBackgroundSetting.equals(Color.BLACK));
+            LOGGER.info("ERROR TESTS on Metal: PASSED");
+        } catch (Exception e) {
+            LOGGER.log(Level.SEVERE, "\n******* EXCEPTION *******\n", e);            
+        }
+    }
+
+    @Test
+    public void runErroredFlatLafSetTabColors() {
+        try (final MockedStatic<WindowManager> windowManagerMockedStatic = Mockito.mockStatic(WindowManager.class)) {
+            final WindowManager windowManager = mock(WindowManager.class);
+            windowManagerMockedStatic.when(WindowManager::getDefault).thenReturn(windowManager);            
+            final JFrame frame = mock(JFrame.class);
+            when(windowManager.getMainWindow()).thenReturn(frame);            
             
-            LOGGER.info("Testing exceptions / Processing invalid settings: PASSED");
+            LOGGER.info("ERROR TESTING on FlatLafLight ConstellationLAFSettings ...");
+            UIManager.setLookAndFeel(pseudoLAF);
+            pseudoLAF.setName("FlatLafLight");
+            UIManager.getDefaults().put("org.netbeans.swing.laf.flatlaf.ui.FlatViewTabDisplayerUI", pseudoViewDisplayerUIclass);
+            // Incorrect class used as the FlatViewTabDisplayerUI should log an exception and make no color changes
             
-            // CLASS COVERAGE CALLS
-            // Tests more code paths in ConstellationLAFSettings class
+            UIManager.getDefaults().put("ViewTab.inactiveUnderlineColor", Color.BLACK); 
+            ConstellationLAFSettings.applyTabColorSettings();
+            final Color inactiveUnderlineColorSetting = (Color) UIManager.getDefaults().get("ViewTab.inactiveUnderlineColor");
+            Assert.assertTrue(inactiveUnderlineColorSetting != null && inactiveUnderlineColorSetting.equals(Color.BLACK));
+            LOGGER.info("ERROR TESTS on FlatLafLight: PASSED");
+        } catch (Exception e) {
+            LOGGER.log(Level.SEVERE, "\n******* EXCEPTION *******\n", e);            
+        }
+    }
+
+    @Test
+    public void runClassCoverageTestingTabColors() {
+        try (final MockedStatic<WindowManager> windowManagerMockedStatic = Mockito.mockStatic(WindowManager.class)) {
+            final WindowManager windowManager = mock(WindowManager.class);
+            windowManagerMockedStatic.when(WindowManager::getDefault).thenReturn(windowManager);            
+            final JFrame frame = mock(JFrame.class);
+            when(windowManager.getMainWindow()).thenReturn(frame);            
+            
+            UIManager.setLookAndFeel(pseudoLAF);
+            LOGGER.info("CLASS COVERAGE TESTING on ConstellationLAFSettings ...");
+
             ConstellationLAFSettings.ouputUIDefaultValues(null, "Tabbed");
             ConstellationLAFSettings.ouputUIDefaultValues("Tabbed", null);
-
-            LOGGER.info("********************************************");
-            
-            pseudoLAF.setName("Windows 95");
-            UIManager.getDefaults().put("org.netbeans.swing.tabcontrol.plaf.Windows8VectorViewTabDisplayerUI", null);
-            UIManager.getDefaults().put("org.netbeans.swing.tabcontrol.plaf.WinXPViewTabDisplayerUI", null); 
-            ConstellationLAFSettings.applyTabColorSettings();
-            UIManager.getDefaults().put("org.netbeans.swing.tabcontrol.plaf.Windows8VectorViewTabDisplayerUI", pseudoTabDisplayerUIclass);
-            ConstellationLAFSettings.applyTabColorSettings();
-
-            LOGGER.info("********************************************");
-            
-            pseudoLAF.setName("FlatLafLight");
-            UIManager.getDefaults().put("org.netbeans.swing.laf.flatlaf.ui.FlatViewTabDisplayerUI", null);
-            ConstellationLAFSettings.applyTabColorSettings();
-            
-            LOGGER.info("********************************************");
-            
-            pseudoLAF.setName("Metal");
-            UIManager.getDefaults().put("org.netbeans.swing.tabcontrol.plaf.MetalViewTabDisplayerUI", null);
-            ConstellationLAFSettings.applyTabColorSettings();
-            
-            LOGGER.info("*******************************************");
             
             new ConstellationLAFSettings.NimbusCustomGradientTabPainter();
             new ConstellationLAFSettings.NimbusCustomGradientTabPainter(null);
@@ -195,14 +314,31 @@ public class ConstellationLAFSettingsNGTest {
             new ConstellationLAFSettings.NimbusCustomGradientTabPainter(null, null);
             new ConstellationLAFSettings.NimbusCustomGradientTabPainter(null, Color.ORANGE);
             new ConstellationLAFSettings.NimbusCustomGradientTabPainter(Color.ORANGE, null);            
+                                    
+            pseudoLAF.setName("Windows 95");
+            UIManager.getDefaults().put("org.netbeans.swing.tabcontrol.plaf.Windows8VectorViewTabDisplayerUI", null);
+            UIManager.getDefaults().put("org.netbeans.swing.tabcontrol.plaf.WinXPViewTabDisplayerUI", null); 
+            ConstellationLAFSettings.applyTabColorSettings();
+            UIManager.getDefaults().put("org.netbeans.swing.tabcontrol.plaf.Windows8VectorViewTabDisplayerUI", pseudoTabDisplayerUIclass);
+            ConstellationLAFSettings.applyTabColorSettings();
+
+            pseudoLAF.setName("FlatLafLight");
+            UIManager.getDefaults().put("org.netbeans.swing.laf.flatlaf.ui.FlatViewTabDisplayerUI", null);
+            ConstellationLAFSettings.applyTabColorSettings();
             
-            LOGGER.info("\nTESTING ConstellationLAFSettings : COMPLETE");
-            
+            pseudoLAF.setName("Metal");
+            UIManager.getDefaults().put("org.netbeans.swing.tabcontrol.plaf.MetalViewTabDisplayerUI", null);
+            UIManager.getDefaults().put("TabRenderer.selectedBackground", Color.BLACK); 
+            ConstellationLAFSettings.applyTabColorSettings();
+            final Color selectedBackgroundSetting = (Color) UIManager.getDefaults().get("TabRenderer.selectedBackground");
+            Assert.assertTrue(selectedBackgroundSetting != null && selectedBackgroundSetting.equals(Color.BLACK));
+
+            LOGGER.info("CLASS COVERAGE TESTS COMPLETE");
         } catch (Exception e) {
             LOGGER.log(Level.SEVERE, "\n******* EXCEPTION *******\n", e);            
         }
     }
-
+   
     /**
      * This Pseudo class is used for testing purposes to simulate
      * a changeable look and feel.

--- a/CoreFunctionality/test/unit/src/au/gov/asd/tac/constellation/functionality/startup/PseudoTabDisplayerUI.java
+++ b/CoreFunctionality/test/unit/src/au/gov/asd/tac/constellation/functionality/startup/PseudoTabDisplayerUI.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2010-2022 Australian Signals Directorate
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package au.gov.asd.tac.constellation.functionality.startup;
+
+import java.awt.Color;
+import java.util.logging.Logger;
+
+/**
+ * This Pseudo class is used for testing purposes as a Reflection target.
+ *
+ * @author OrionsGuardian
+ */
+public class PseudoTabDisplayerUI {
+    private static final Logger LOGGER = Logger.getLogger(PseudoTabDisplayerUI.class.getName());
+    // The colorsReady variable is used in Windows FlatLAf and Metal Look and Feel classes.
+    private static boolean colorsReady = false;
+    
+    // The actBgColor and inactBgColor variable are only used in Metal Look and Feel classes.
+    private static Color actBgColor = Color.LIGHT_GRAY;
+    private static Color inactBgColor = Color.GRAY;
+
+    PseudoTabDisplayerUI() {
+        actBgColor = Color.WHITE;
+        inactBgColor = Color.BLACK;
+    }
+
+    private static void initColors() {
+        colorsReady = true;
+        LOGGER.info("Called PseudoTabDisplayerUI.initColors()");
+    }
+    
+    private static Color getColor(boolean active){
+        return active ? actBgColor : inactBgColor;
+    }
+    
+    private static boolean getColorsReady(){
+        return colorsReady;
+    }
+    
+}

--- a/CoreFunctionality/test/unit/src/au/gov/asd/tac/constellation/functionality/startup/PseudoViewTabDisplayerUI.java
+++ b/CoreFunctionality/test/unit/src/au/gov/asd/tac/constellation/functionality/startup/PseudoViewTabDisplayerUI.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2010-2022 Australian Signals Directorate
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package au.gov.asd.tac.constellation.functionality.startup;
+
+/**
+ * This Pseudo class is used for testing purposes as a Reflection target.
+ *
+ * @author OrionsGuardian
+ */
+public class PseudoViewTabDisplayerUI extends PseudoTabDisplayerUI {
+    PseudoViewTabDisplayerUI(){
+        super();
+    }
+}


### PR DESCRIPTION
<!--

### Requirements

* Filling out the template is required. Any pull request that does not include
enough information to be reviewed in a timely manner may be closed at the
maintainers' discretion.
* All new code requires unit tests to ensure they work as expected and will
continue to work as new code is added in the future (regression testing).
* Make sure your branch name is prefixed by `feature`, `bugfix` or `release`
* Have you read Constellation's Code of Conduct? By filing an issue, you are
expected to comply with it, including treating everyone with respect:
https://github.com/constellation-app/constellation/blob/master/CODE_OF_CONDUCT.md

-->

### Prerequisites

- [ ] Reviewed the [checklist](CHECKLIST.md)

- [ ] Reviewed feedback from the "Sonar Cloud" bot. Note that you have to wait
    for the "CI / Unit Tests") to complete first. Failed Unit tests can be 
    debugged by adding the label "verbose logging" to the GitHub PR.

### Description of the Change

The colors of the main window tabs have been modified to an appropriate blue shade depending on the the Look and Feel selected.
The modifications take place when using the following Look and Feels:
Windows
Windows Classic
Nimbus
Dark Nimbus
FlatLafLight
FlatLafDark
Metal
Dark Metal

### Alternate Designs

N/A

### Why Should This Be In Core?

To address the issue described in ticket #997

### Benefits

Improved user experience.

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

Code may need to be modified if internal NetBeans packages are changed in future releases

### Verification Process

<!--

What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (e.g. buttons you clicked, text you typed,
commands you ran, etc.), and describe the results you observed.

-->

Selected and restarted the product using each affected Look and Feel and confirmed the tab coloring has been changed appropriately.

### Applicable Issues

<!-- Link any applicable issues here -->
#997

