### PR TITLE
added lock around getUniqueRecentFiles to avoid concurrent mod

### DIFF
--- a/CoreGraphFile/src/au/gov/asd/tac/constellation/graph/file/open/RecentFiles.java
+++ b/CoreGraphFile/src/au/gov/asd/tac/constellation/graph/file/open/RecentFiles.java
@@ -139,10 +139,9 @@ public final class RecentFiles {
      * @return list of recent files
      */
     protected static List<HistoryItem> getRecentFiles() {
-        synchronized (HISTORY_LOCK) {
-            checkHistory();
-            return Collections.unmodifiableList(HISTORY);
-        }
+        assert Thread.holdsLock(HISTORY_LOCK);
+        checkHistory();
+        return Collections.unmodifiableList(HISTORY);
     }
 
     /**
@@ -151,10 +150,12 @@ public final class RecentFiles {
      * @return list of recent files
      */
     public static List<HistoryItem> getUniqueRecentFiles() {
-        return getRecentFiles().stream()
-                .filter(file -> convertPath2File(file.getPath()) != null)
-                .distinct()
-                .collect(ImmutableList.toImmutableList());
+        synchronized (HISTORY_LOCK) {
+            return getRecentFiles().stream()
+                    .filter(file -> convertPath2File(file.getPath()) != null)
+                    .distinct()
+                    .collect(ImmutableList.toImmutableList());
+        }
     }
 
     private static volatile boolean historyProbablyValid;


### PR DESCRIPTION
<!--

### Requirements

* Filling out the template is required. Any pull request that does not include
enough information to be reviewed in a timely manner may be closed at the
maintainers' discretion.
* All new code requires unit tests to ensure they work as expected and will
continue to work as new code is added in the future (regression testing).
* Make sure your branch name is prefixed by `feature`, `bugfix` or `release`
* Have you read Constellation's Code of Conduct? By filing an issue, you are
expected to comply with it, including treating everyone with respect:
https://github.com/constellation-app/constellation/blob/master/CODE_OF_CONDUCT.md

-->

### Prerequisites

- [x] Reviewed the [checklist](CHECKLIST.md)

- [ ] Reviewed feedback from the "Sonar Cloud" bot. Note that you have to wait
    for the "CI / Unit Tests") to complete first. Failed Unit tests can be 
    debugged by adding the label "verbose logging" to the GitHub PR.

### Description of the Change

a concurrent mod was occasionally happening after a graph save. The source of the issue appears to be in `RecentFiles.getUniqueRecentFiles()` which doesn't have a lock around the static list it plays with. Have modified the code slightly to wrap the function around the history lock.

### Alternate Designs

Considered creating a separate lock specifically for the function (since the concurrent mod wasn't occurring until after the history list had been used) but decided the the performance cost using the existing wouldn't be so bad that the existing one couldn't be used.

If performance truly does take a significant hit, this alternate approach could be implemented.

### Why Should This Be In Core?

bug fix

### Benefits

bug fix

### Possible Drawbacks

Possible small performance hit, but I suspect nothing significant

### Verification Process

<!--

What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (e.g. buttons you clicked, text you typed,
commands you ran, etc.), and describe the results you observed.

-->

### Applicable Issues

#1757