### PR TITLE
Only reset view/camera position on related graph.

### DIFF
--- a/CoreInteractiveGraph/src/au/gov/asd/tac/constellation/graph/interaction/plugins/zoom/ResetViewPlugin.java
+++ b/CoreInteractiveGraph/src/au/gov/asd/tac/constellation/graph/interaction/plugins/zoom/ResetViewPlugin.java
@@ -19,6 +19,7 @@ import au.gov.asd.tac.constellation.graph.Graph;
 import au.gov.asd.tac.constellation.graph.GraphWriteMethods;
 import au.gov.asd.tac.constellation.graph.interaction.animation.Animation;
 import au.gov.asd.tac.constellation.graph.interaction.animation.PanAnimation;
+import au.gov.asd.tac.constellation.graph.manager.GraphManager;
 import au.gov.asd.tac.constellation.graph.schema.visual.concept.VisualConcept;
 import au.gov.asd.tac.constellation.graph.visual.utilities.BoundingBoxUtilities;
 import au.gov.asd.tac.constellation.plugins.Plugin;
@@ -107,7 +108,14 @@ public final class ResetViewPlugin extends SimpleEditPlugin {
             }
 
             // add an animation to the refocused camera so that it pans from the old position.
-            Animation.startAnimation(new PanAnimation("Reset View", oldCamera, camera, parameters.getBooleanValue(SIGNIFICANT_PARAMETER_ID)));
+            final Graph activeGraph = GraphManager.getDefault().getActiveGraph();
+            if (activeGraph != null && activeGraph.getId().equals(graph.getId())) {
+                // Only do the camera animation if the edited graph is currently active
+                Animation.startAnimation(new PanAnimation("Reset View", oldCamera, camera, parameters.getBooleanValue(SIGNIFICANT_PARAMETER_ID)));
+            } else {
+                // Skip the animation, just set the new camera position
+                graph.setObjectValue(cameraAttribute, 0, camera);
+            }
         }
     }
 }

--- a/CoreInteractiveGraph/src/au/gov/asd/tac/constellation/graph/interaction/plugins/zoom/RotateCameraPlugin.java
+++ b/CoreInteractiveGraph/src/au/gov/asd/tac/constellation/graph/interaction/plugins/zoom/RotateCameraPlugin.java
@@ -19,6 +19,7 @@ import au.gov.asd.tac.constellation.graph.Graph;
 import au.gov.asd.tac.constellation.graph.GraphWriteMethods;
 import au.gov.asd.tac.constellation.graph.interaction.animation.Animation;
 import au.gov.asd.tac.constellation.graph.interaction.animation.PanAnimation;
+import au.gov.asd.tac.constellation.graph.manager.GraphManager;
 import au.gov.asd.tac.constellation.graph.schema.visual.concept.VisualConcept;
 import au.gov.asd.tac.constellation.plugins.Plugin;
 import au.gov.asd.tac.constellation.plugins.PluginException;
@@ -105,7 +106,9 @@ public final class RotateCameraPlugin extends SimpleEditPlugin {
 
             CameraUtilities.rotate(camera, xrot, yrot, zrot);
 
-            if (animate) {
+            final Graph activeGraph = GraphManager.getDefault().getActiveGraph();
+            if (animate && activeGraph != null && activeGraph.getId().equals(graph.getId())) {
+                // Only do the camera animation if the edited graph is currently active
                 Animation.startAnimation(new PanAnimation("Rotate camera", oldCamera, camera, true));
             } else {
                 // Don't do an animation; we don't want to be asynchronous.

--- a/CoreInteractiveGraph/src/au/gov/asd/tac/constellation/graph/interaction/plugins/zoom/ZoomToSelectionPlugin.java
+++ b/CoreInteractiveGraph/src/au/gov/asd/tac/constellation/graph/interaction/plugins/zoom/ZoomToSelectionPlugin.java
@@ -15,9 +15,11 @@
  */
 package au.gov.asd.tac.constellation.graph.interaction.plugins.zoom;
 
+import au.gov.asd.tac.constellation.graph.Graph;
 import au.gov.asd.tac.constellation.graph.GraphWriteMethods;
 import au.gov.asd.tac.constellation.graph.interaction.animation.Animation;
 import au.gov.asd.tac.constellation.graph.interaction.animation.PanAnimation;
+import au.gov.asd.tac.constellation.graph.manager.GraphManager;
 import au.gov.asd.tac.constellation.graph.visual.utilities.BoundingBoxUtilities;
 import au.gov.asd.tac.constellation.graph.visual.utilities.VisualGraphUtilities;
 import au.gov.asd.tac.constellation.plugins.Plugin;
@@ -51,6 +53,13 @@ public final class ZoomToSelectionPlugin extends SimpleEditPlugin {
         final Camera camera = new Camera(oldCamera);
         BoundingBoxUtilities.recalculateFromGraph(box, graph, true);
         CameraUtilities.zoomToBoundingBox(camera, box);
-        Animation.startAnimation(new PanAnimation("Zoom to Selection", oldCamera, camera, true));
+        final Graph activeGraph = GraphManager.getDefault().getActiveGraph();
+        if (activeGraph != null && activeGraph.getId().equals(graph.getId())) {
+            // Only do the camera animation if the edited graph is currently active
+            Animation.startAnimation(new PanAnimation("Zoom to Selection", oldCamera, camera, true));
+        } else {
+            // Skip the animation, just set the new camera position
+            VisualGraphUtilities.setCamera(graph, camera);
+        }        
     }
 }

--- a/CoreInteractiveGraph/src/au/gov/asd/tac/constellation/graph/interaction/plugins/zoom/ZoomToVerticesPlugin.java
+++ b/CoreInteractiveGraph/src/au/gov/asd/tac/constellation/graph/interaction/plugins/zoom/ZoomToVerticesPlugin.java
@@ -19,6 +19,7 @@ import au.gov.asd.tac.constellation.graph.Graph;
 import au.gov.asd.tac.constellation.graph.GraphWriteMethods;
 import au.gov.asd.tac.constellation.graph.interaction.animation.Animation;
 import au.gov.asd.tac.constellation.graph.interaction.animation.PanAnimation;
+import au.gov.asd.tac.constellation.graph.manager.GraphManager;
 import au.gov.asd.tac.constellation.graph.visual.utilities.BoundingBoxUtilities;
 import au.gov.asd.tac.constellation.graph.visual.utilities.VisualGraphUtilities;
 import au.gov.asd.tac.constellation.plugins.Plugin;
@@ -98,7 +99,14 @@ public final class ZoomToVerticesPlugin extends SimpleEditPlugin {
         final BoundingBox box = new BoundingBox();
         final Camera camera = new Camera(oldCamera);
         BoundingBoxUtilities.encompassSpecifiedElements(box, graph, vertices);
-        CameraUtilities.zoomToBoundingBox(camera, box);
-        Animation.startAnimation(new PanAnimation("Zoom to Vertices", oldCamera, camera, true));
+        CameraUtilities.zoomToBoundingBox(camera, box);        
+        final Graph activeGraph = GraphManager.getDefault().getActiveGraph();
+        if (activeGraph != null && activeGraph.getId().equals(graph.getId())) {
+            // Only do the camera animation if the edited graph is currently active
+            Animation.startAnimation(new PanAnimation("Zoom to Vertices", oldCamera, camera, true));
+        } else {
+            // Skip the animation, just set the new camera position
+            VisualGraphUtilities.setCamera(graph, camera);
+        }                
     }
 }


### PR DESCRIPTION
<!--

### Requirements

* Filling out the template is required. Any pull request that does not include
enough information to be reviewed in a timely manner may be closed at the
maintainers' discretion.
* All new code requires unit tests to ensure they work as expected and will
continue to work as new code is added in the future (regression testing).
* Make sure your branch name is prefixed by `feature`, `bugfix` or `release`
* Have you read Constellation's Code of Conduct? By filing an issue, you are
expected to comply with it, including treating everyone with respect:
https://github.com/constellation-app/constellation/blob/master/CODE_OF_CONDUCT.md

-->

### Prerequisites

- [ ] Reviewed the [checklist](CHECKLIST.md)

- [ ] Reviewed feedback from the "Sonar Cloud" bot. Note that you have to wait
    for the "CI / Unit Tests") to complete first. Failed Unit tests can be 
    debugged by adding the label "verbose logging" to the GitHub PR.

### Description of the Change

Modified the plugins which alter the camera position (zoom level) to check if the related graph is active before doing an animated camera zoom.
If the related graph is not the active one, the new camera position will be set directly in the related graph, skipping the animation process.

<!--

We must be able to understand the design of your change from this description.
If we can't get a good idea of what the code will be doing from the description
here, the pull request may be closed at the maintainers' discretion. Keep in
mind that the maintainer reviewing this PR may not be familiar with or have
worked with the code here recently, so please walk us through the concepts.

-->

### Alternate Designs

<!--

Explain what other alternates were considered and why the proposed version was
selected.

-->

### Why Should This Be In Core?

<!--

Explain why this functionality should be in Constellation Core as opposed to a
different module suite. Note that this question is more applicable when adding
new functionality. If this change is a minor update to an existing file then it
is understood that this change has to be to this module suite and a response
and therefore a response to this question is not required.

-->

### Benefits

If you are working on multiple graphs and run a plugin on one of those graphs, and then switch to a different graph while waiting for the plugin to complete.
The current graph being viewed will not suddenly have it's zoom level changed when the first graph's plugin has completed.

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process

<!--

What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (e.g. buttons you clicked, text you typed,
commands you ran, etc.), and describe the results you observed.

-->

### Applicable Issues

<!-- Link any applicable issues here -->
