### PR TITLE
Closing Graph on Save Bug & Screenshot Null Pointer 

### DIFF
--- a/CoreInteractiveGraph/src/au/gov/asd/tac/constellation/graph/interaction/gui/VisualGraphTopComponent.java
+++ b/CoreInteractiveGraph/src/au/gov/asd/tac/constellation/graph/interaction/gui/VisualGraphTopComponent.java
@@ -673,9 +673,8 @@ public final class VisualGraphTopComponent extends CloneableTopComponent impleme
             } else if (o.equals(SAVE)) {
                 try {
                     savable.handleSave();
-                    if (!savable.isSaved()) {
-                        return false;
-                    }
+                    return savable.isSaved();
+                    
                 } catch (final IOException ex) {
                     LOGGER.log(Level.SEVERE, ex.getLocalizedMessage(), ex);
                 }
@@ -977,7 +976,7 @@ public final class VisualGraphTopComponent extends CloneableTopComponent impleme
                 // graph will get saved each time.
                 requestActive();
 
-                SaveAsAction action = new SaveAsAction();
+                SaveAsAction action = new SaveAsAction();               
                 action.actionPerformed(null);
                 isSaved = action.isSaved();
                 return;
@@ -1179,7 +1178,9 @@ public final class VisualGraphTopComponent extends CloneableTopComponent impleme
 
             PluginExecution.withPlugin(new WriteGraphFile(copy, freshGdo)).executeLater(null);
 
-            GraphNode.getGraphNode(graph).makeBusy(false);
+            if (GraphNode.getGraphNode(graph) != null) {
+                GraphNode.getGraphNode(graph).makeBusy(false);
+            }
         }
     }
 

--- a/CoreInteractiveGraph/src/au/gov/asd/tac/constellation/graph/interaction/gui/VisualGraphTopComponent.java
+++ b/CoreInteractiveGraph/src/au/gov/asd/tac/constellation/graph/interaction/gui/VisualGraphTopComponent.java
@@ -989,6 +989,7 @@ public final class VisualGraphTopComponent extends CloneableTopComponent impleme
             final GraphDataObject freshGdo = (GraphDataObject) gdo.createFromTemplate(gdo.getFolder(), tmpnam);
             final BackgroundWriter writer = new BackgroundWriter(name, freshGdo, true);
             writer.execute();
+            isSaved = true;
         }
 
         /**

--- a/CoreInteractiveGraph/src/au/gov/asd/tac/constellation/graph/interaction/plugins/io/screenshot/RecentGraphScreenshotUtilities.java
+++ b/CoreInteractiveGraph/src/au/gov/asd/tac/constellation/graph/interaction/plugins/io/screenshot/RecentGraphScreenshotUtilities.java
@@ -140,23 +140,24 @@ public class RecentGraphScreenshotUtilities {
 
         final Path source = Paths.get(imageFile);
         final GraphNode graphNode = GraphNode.getGraphNode(GraphManager.getDefault().getActiveGraph());
-        final VisualManager visualManager = graphNode.getVisualManager();
+        if (graphNode != null) {
+            final VisualManager visualManager = graphNode.getVisualManager();
 
-        final BufferedImage[] originalImage = new BufferedImage[1];
-        originalImage[0] = new BufferedImage(IMAGE_SIZE, IMAGE_SIZE, BufferedImage.TYPE_INT_ARGB);
+            final BufferedImage[] originalImage = new BufferedImage[1];
+            originalImage[0] = new BufferedImage(IMAGE_SIZE, IMAGE_SIZE, BufferedImage.TYPE_INT_ARGB);
 
-        if (visualManager != null) {
-            final Semaphore waiter = new Semaphore(0);
-            visualManager.exportToBufferedImage(originalImage, waiter);
-            waiter.acquireUninterruptibly();
-        }
-
-        try {
-            // resizeAndSave the buffered image in memory and write the image to disk
-            resizeAndSave(originalImage[0], source, IMAGE_SIZE, IMAGE_SIZE);
-            refreshScreenshotsDir();
-        } catch (final IOException ex) {
-            LOGGER.log(Level.SEVERE, ex.getLocalizedMessage(), ex);
+            if (visualManager != null) {
+                final Semaphore waiter = new Semaphore(0);
+                visualManager.exportToBufferedImage(originalImage, waiter);
+                waiter.acquireUninterruptibly();
+            }
+            try {
+                // resizeAndSave the buffered image in memory and write the image to disk
+                resizeAndSave(originalImage[0], source, IMAGE_SIZE, IMAGE_SIZE);
+                refreshScreenshotsDir();
+            } catch (final IOException ex) {
+                LOGGER.log(Level.SEVERE, ex.getLocalizedMessage(), ex);
+            }
         }
     }
 

--- a/CoreUtilities/src/au/gov/asd/tac/constellation/utilities/gui/filechooser/FileChooser.java
+++ b/CoreUtilities/src/au/gov/asd/tac/constellation/utilities/gui/filechooser/FileChooser.java
@@ -68,8 +68,7 @@ public class FileChooser {
      *     an empty optional if the user selects cancel
      */
     public static CompletableFuture<Optional<File>> openOpenDialog(final FileChooserBuilder fileChooserBuilder) {
-            return CompletableFuture.completedFuture(
-                openFileDialogAndGetFirstFile(fileChooserBuilder, FileChooserMode.OPEN));
+        return CompletableFuture.completedFuture(openFileDialogAndGetFirstFile(fileChooserBuilder, FileChooserMode.OPEN));
     }
     
     /**
@@ -86,8 +85,7 @@ public class FileChooser {
      *     an empty optional if the user selects cancel
      */
     public static CompletableFuture<Optional<List<File>>> openMultiDialog(final FileChooserBuilder fileChooserBuilder) {
-            return CompletableFuture.completedFuture(
-                openFileDialog(fileChooserBuilder, FileChooserMode.MULTI));
+        return CompletableFuture.completedFuture(openFileDialog(fileChooserBuilder, FileChooserMode.MULTI));
     }
     
     /**
@@ -99,10 +97,8 @@ public class FileChooser {
      * @param fileDialogMode the type of file chooser dialog to open, save, open or multi
      * @return the selected file(s) or an empty optional if the user selects cancel
      */
-    private static Optional<List<File>> openFileDialog(final FileChooserBuilder fileChooserBuilder,
-            final FileChooserMode fileDialogMode) {
-        final ShowFileChooserDialog showDialog = new ShowFileChooserDialog(
-                fileChooserBuilder, fileDialogMode);
+    private static Optional<List<File>> openFileDialog(final FileChooserBuilder fileChooserBuilder, final FileChooserMode fileDialogMode) {
+        final ShowFileChooserDialog showDialog = new ShowFileChooserDialog(fileChooserBuilder, fileDialogMode);
         showDialog.run();
 
         return showDialog.getSelectedFiles();

--- a/CoreUtilities/src/au/gov/asd/tac/constellation/utilities/gui/filechooser/FileChooser.java
+++ b/CoreUtilities/src/au/gov/asd/tac/constellation/utilities/gui/filechooser/FileChooser.java
@@ -19,8 +19,6 @@ import java.io.File;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
-import javafx.application.Platform;
-import javax.swing.SwingUtilities;
 import org.openide.filesystems.FileChooserBuilder;
 
 /**
@@ -70,17 +68,8 @@ public class FileChooser {
      *     an empty optional if the user selects cancel
      */
     public static CompletableFuture<Optional<File>> openOpenDialog(final FileChooserBuilder fileChooserBuilder) {
-        if (SwingUtilities.isEventDispatchThread() || Platform.isFxApplicationThread()) {
-            // Wrap the open call in a completable future so this happens on another
-            // thread and return immediately
-            return CompletableFuture.supplyAsync(() ->
-                    openFileDialogAndGetFirstFile(fileChooserBuilder, FileChooserMode.OPEN));
-        } else {
-            // This is not the UI thread so just call the open dialog method
             return CompletableFuture.completedFuture(
-                    openFileDialogAndGetFirstFile(fileChooserBuilder, FileChooserMode.OPEN)
-            );
-        }
+                openFileDialogAndGetFirstFile(fileChooserBuilder, FileChooserMode.OPEN));
     }
     
     /**
@@ -97,17 +86,8 @@ public class FileChooser {
      *     an empty optional if the user selects cancel
      */
     public static CompletableFuture<Optional<List<File>>> openMultiDialog(final FileChooserBuilder fileChooserBuilder) {
-        if (SwingUtilities.isEventDispatchThread() || Platform.isFxApplicationThread()) {
-            // Wrap the open call in a completable future so this happens on another
-            // thread and return immediately
-            return CompletableFuture.supplyAsync(() ->
-                    openFileDialog(fileChooserBuilder, FileChooserMode.MULTI));
-        } else {
-            // This is not the UI thread so just call the open dialog method
             return CompletableFuture.completedFuture(
-                    openFileDialog(fileChooserBuilder, FileChooserMode.MULTI)
-            );
-        }
+                openFileDialog(fileChooserBuilder, FileChooserMode.MULTI));
     }
     
     /**
@@ -120,7 +100,7 @@ public class FileChooser {
      * @return the selected file(s) or an empty optional if the user selects cancel
      */
     private static Optional<List<File>> openFileDialog(final FileChooserBuilder fileChooserBuilder,
-                                                       final FileChooserMode fileDialogMode) {
+            final FileChooserMode fileDialogMode) {
         final ShowFileChooserDialog showDialog = new ShowFileChooserDialog(
                 fileChooserBuilder, fileDialogMode);
         showDialog.run();


### PR DESCRIPTION
<!--

### Requirements

* Filling out the template is required. Any pull request that does not include
enough information to be reviewed in a timely manner may be closed at the
maintainers' discretion.
* All new code requires unit tests to ensure they work as expected and will
continue to work as new code is added in the future (regression testing).
* Make sure your branch name is prefixed by `feature`, `bugfix` or `release`
* Have you read Constellation's Code of Conduct? By filing an issue, you are
expected to comply with it, including treating everyone with respect:
https://github.com/constellation-app/constellation/blob/master/CODE_OF_CONDUCT.md

-->

### Prerequisites

- [x] Reviewed the [checklist](CHECKLIST.md)

- [ ] Reviewed feedback from the "Sonar Cloud" bot. Note that you have to wait
    for the "CI / Unit Tests") to complete first. Failed Unit tests can be 
    debugged by adding the label "verbose logging" to the GitHub PR.

### Description of the Change
Added a null check so that the recent graph screenshot class does not try to take a screenshot if the graph has already been closed.
Fixed bug where graph did not close after clicking on the X on the graph title tab to close the graph and then saving the graph.
<!--

We must be able to understand the design of your change from this description.
If we can't get a good idea of what the code will be doing from the description
here, the pull request may be closed at the maintainers' discretion. Keep in
mind that the maintainer reviewing this PR may not be familiar with or have
worked with the code here recently, so please walk us through the concepts.

-->

### Alternate Designs
N/A
<!--

Explain what other alternates were considered and why the proposed version was
selected.

-->

### Why Should This Be In Core?
Bug fixes. 
<!--

Explain why this functionality should be in Constellation Core as opposed to a
different module suite. Note that this question is more applicable when adding
new functionality. If this change is a minor update to an existing file then it
is understood that this change has to be to this module suite and a response
and therefore a response to this question is not required.

-->

### Benefits
Actually closes the graph after clicking on the X on the graph title tab and saving the graph, as it would expect to. 
<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks
None realised.
<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process
1. Open a graph and add a vertex.
2. Close the graph using the X on the graph title tab.
3. Choose Save, and save the graph somewhere.
4. Observe that the graph closes and no null pointers are thrown.
5. Reopen the graph to confirm that it was saved correctly.

<!--

What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (e.g. buttons you clicked, text you typed,
commands you ran, etc.), and describe the results you observed.

-->

### Applicable Issues
#1664 
<!-- Link any applicable issues here -->
