### PR TITLE
updated datetime formatters in importers

### DIFF
--- a/CoreImportExportPlugins/src/au/gov/asd/tac/constellation/plugins/importexport/translator/DatetimeAttributeTranslator.java
+++ b/CoreImportExportPlugins/src/au/gov/asd/tac/constellation/plugins/importexport/translator/DatetimeAttributeTranslator.java
@@ -66,12 +66,15 @@ public class DatetimeAttributeTranslator extends AttributeTranslator {
     private static final Map<String, String> DATETIME_FORMATS = new LinkedHashMap<>();
 
     static {
-        DATETIME_FORMATS.put("MM/dd/yyyy HH:mm:ss", "MM/dd/yyyy HH:mm:ss");
-        DATETIME_FORMATS.put("dd/MM/yyyy HH:mm:ss", "dd/MM/yyyy HH:mm:ss");
-        DATETIME_FORMATS.put("yyyy-MM-dd HH:mm:ss", "yyyy-MM-dd HH:mm:ss");
-        DATETIME_FORMATS.put("yyyy-MM-dd'T'HH:mm:ss'Z'", "yyyy-MM-dd'T'HH:mm:ss'Z'");
-        DATETIME_FORMATS.put("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'");
-        DATETIME_FORMATS.put("yyyyMMdd HHmmss'Z'", "yyyyMMdd HHmmss'Z'");
+        DATETIME_FORMATS.put("MM/d/yyyy H:mm", "MM/d/yyyy H:mm");
+        DATETIME_FORMATS.put("MM/d/yyyy H:mm:ss", "MM/d/yyyy H:mm:ss");
+        DATETIME_FORMATS.put("d/MM/yyyy H:mm", "d/MM/yyyy H:mm");
+        DATETIME_FORMATS.put("d/MM/yyyy H:mm:ss", "d/MM/yyyy H:mm:ss");
+        DATETIME_FORMATS.put("yyyy-MM-d H:mm", "yyyy-MM-d H:mm");
+        DATETIME_FORMATS.put("yyyy-MM-d H:mm:ss", "yyyy-MM-d H:mm:ss");
+        DATETIME_FORMATS.put("yyyy-MM-d'T'H:mm:ss'Z'", "yyyy-MM-d'T'H:mm:ss'Z'");
+        DATETIME_FORMATS.put("yyyy-MM-d'T'H:mm:ss.SSS'Z'", "yyyy-MM-d'T'H:mm:ss.SSS'Z'");
+        DATETIME_FORMATS.put("yyyyMMdd Hmmss'Z'", "yyyyMMdd Hmmss'Z'");
         DATETIME_FORMATS.put("yyyyMMddHHmmss", "yyyyMMddHHmmss");
         DATETIME_FORMATS.put(EPOCH, null);
         DATETIME_FORMATS.put(EXCEL, null);

--- a/CoreWhatsNewView/src/au/gov/asd/tac/constellation/views/whatsnew/whatsnew.txt
+++ b/CoreWhatsNewView/src/au/gov/asd/tac/constellation/views/whatsnew/whatsnew.txt
@@ -1,6 +1,10 @@
 == 3030-12-31 Getting Started
 <p>If you're new to Constellation, read the <a href="" helpId="au.gov.asd.tac.constellation.functionality.gettingstarted">getting started guide</a>.</p>
 
+== 2022-11-10 Datetime Formatters
+<p>Datetime formatters have been updated in the File and Database importers to allow single digit days and hours to be passed through most default formats.</p>
+<p>A few new formatters, which don't contain seconds, have been added to the default list.</p>
+
 == 2022-10-21 Constellation Options Menu
 <p>The Constellation Options menu has now been grouped together and is ordered alphabetically.</p>
 <p>To reduce the overall number of options tabs the Application Font options can now be found under the Application tab, and the Anaglyphic Displays options can be found under the Graph tab.</p>


### PR DESCRIPTION
<!--

### Requirements

* Filling out the template is required. Any pull request that does not include
enough information to be reviewed in a timely manner may be closed at the
maintainers' discretion.
* All new code requires unit tests to ensure they work as expected and will
continue to work as new code is added in the future (regression testing).
* Make sure your branch name is prefixed by `feature`, `bugfix` or `release`
* Have you read Constellation's Code of Conduct? By filing an issue, you are
expected to comply with it, including treating everyone with respect:
https://github.com/constellation-app/constellation/blob/master/CODE_OF_CONDUCT.md

-->

### Prerequisites

- [x] Reviewed the [checklist](CHECKLIST.md)

- [ ] Reviewed feedback from the "Sonar Cloud" bot. Note that you have to wait
    for the "CI / Unit Tests") to complete first. Failed Unit tests can be 
    debugged by adding the label "verbose logging" to the GitHub PR.

### Description of the Change

Updated a number of the default datetime formatters to be single digit d and H as this allows both single digit and double digits days and hours to parse (e.g. 1, 01, 12). Not all could be updated to accommodate this though so I only updated the ones I could. Also added a couple of new default formatters which don't contain seconds in them

### Alternate Designs

<!--

Explain what other alternates were considered and why the proposed version was
selected.

-->

### Why Should This Be In Core?

Enhances work already done in Core

### Benefits

Greater flexibility in the default datetime formatters.

### Possible Drawbacks

Nil

### Verification Process

1) Created some csv files containing data with both single and double digit days and hours that matched the default formats
2) Tried applying the formatter to the datetime attribute and applying it to the relevant column in the csv

### Applicable Issues

#1732
