### PR TITLE
updated file and database import bubbles to ensure time order

### DIFF
--- a/CoreImportExportPlugins/src/au/gov/asd/tac/constellation/plugins/importexport/delimited/ImportDelimitedPlugin.java
+++ b/CoreImportExportPlugins/src/au/gov/asd/tac/constellation/plugins/importexport/delimited/ImportDelimitedPlugin.java
@@ -165,9 +165,9 @@ public class ImportDelimitedPlugin extends SimpleEditPlugin {
                 // At least 1 object was successfully imported. List all successful file imports, as well as any files
                 // that there were issues for. If there were any files with issues use a warning dialog.
                 final String fileFiles = (validFilenames.size() == 1) ? "file" : "files";
-                sbHeader.append(String.format("Extracted data from %d rows in %d %s. Skipped rows %d due to import error.",
+                sbMessage.append(String.format("Extracted data from %d rows in %d %s. Skipped rows %d due to import error.",
                         importedRows, validFilenames.size(), fileFiles, skippedRows));
-                sbMessage.append("Files with data: ");
+                sbMessage.append(" Files with data: ");
                 for (int i = 0; i < validFilenames.size(); i++) {
                     if (i > 0) {
                         sbMessage.append(", ");
@@ -177,7 +177,7 @@ public class ImportDelimitedPlugin extends SimpleEditPlugin {
                 sbMessage.append(".");
             } else {
                 // No rows were imported list all files that resulted in failures.
-                sbHeader.append("No data found.");
+                sbMessage.append("No data found.\n");
             }
 
             if (!emptyFilenames.isEmpty()) {
@@ -213,7 +213,7 @@ public class ImportDelimitedPlugin extends SimpleEditPlugin {
                 }
                 sbMessage.append(".");
             }
-            NotificationDisplayer.getDefault().notify(sbHeader.toString(), UserInterfaceIconProvider.UPLOAD.buildIcon(16, ConstellationColor.BLUE.getJavaColor()), sbMessage.toString(), null, NotificationDisplayer.Priority.HIGH);
+            NotificationDisplayer.getDefault().notify("File Import", UserInterfaceIconProvider.UPLOAD.buildIcon(16, ConstellationColor.BLUE.getJavaColor()), sbMessage.toString(), null, NotificationDisplayer.Priority.HIGH);
         });
     }
 

--- a/CoreImportExportPlugins/src/au/gov/asd/tac/constellation/plugins/importexport/jdbc/ImportJDBCPlugin.java
+++ b/CoreImportExportPlugins/src/au/gov/asd/tac/constellation/plugins/importexport/jdbc/ImportJDBCPlugin.java
@@ -320,20 +320,18 @@ public class ImportJDBCPlugin extends SimpleEditPlugin {
      */
     private void displaySummaryAlert(final int importedRows, final int totalRows, final String connectionName) {
         Platform.runLater(() -> {
-            final StringBuilder sbHeader = new StringBuilder();
             final StringBuilder sbMessage = new StringBuilder();
 
             if (importedRows > 0) {
                 // At least 1 row was successfully imported. List all successful file imports, as well as any files that there were
                 // issues for. If there were any files with issues use a warning dialog.
-                sbHeader.append(String.format("Imported %d out of %d rows of data from connection: %s", importedRows, totalRows, connectionName));
+                sbMessage.append(String.format("Imported %d out of %d rows of data from connection: %s", importedRows, totalRows, connectionName));
 
             } else {
-                // No rows were imported list all files that resulted in failures.
-                sbHeader.append("No data found to import");                
-                sbMessage.append(String.format("Please check the connection %s or specified mappings. No data was extracted.", connectionName));
+                // No rows were imported list all files that resulted in failures.              
+                sbMessage.append(String.format("No data found to import%nPlease check the connection %s or specified mappings. No data was extracted.", connectionName));
             }
-            NotificationDisplayer.getDefault().notify(sbHeader.toString(), UserInterfaceIconProvider.UPLOAD.buildIcon(16, ConstellationColor.BLUE.getJavaColor()), sbMessage.toString(), null, NotificationDisplayer.Priority.HIGH);
+            NotificationDisplayer.getDefault().notify("Database Import", UserInterfaceIconProvider.UPLOAD.buildIcon(16, ConstellationColor.BLUE.getJavaColor()), sbMessage.toString(), null, NotificationDisplayer.Priority.HIGH);
         });
     }
 


### PR DESCRIPTION
<!--

### Requirements

* Filling out the template is required. Any pull request that does not include
enough information to be reviewed in a timely manner may be closed at the
maintainers' discretion.
* All new code requires unit tests to ensure they work as expected and will
continue to work as new code is added in the future (regression testing).
* Make sure your branch name is prefixed by `feature`, `bugfix` or `release`
* Have you read Constellation's Code of Conduct? By filing an issue, you are
expected to comply with it, including treating everyone with respect:
https://github.com/constellation-app/constellation/blob/master/CODE_OF_CONDUCT.md

-->

### Prerequisites

- [x] Reviewed the [checklist](CHECKLIST.md)

- [ ] Reviewed feedback from the "Sonar Cloud" bot. Note that you have to wait
    for the "CI / Unit Tests") to complete first. Failed Unit tests can be 
    debugged by adding the label "verbose logging" to the GitHub PR.

### Description of the Change

Updated the import bubbles from the file and database imports so that the bubbles appear in time order rather than alphabetical order.

The underlying issue appears to be that netbeans sorts the bubbles alphabetical by header and then where the headers are the same, it goes in time order after that. That part I couldn't figure out how to change (I think it may be a netbeans thing) but I could get around it by making the import headers the same, that way the bubbles will show up in time order (as it can't order by header).

Worth noting as part of this that I made the header from file imports "File Import" and from database imports "Database Import" so this will group the database imports together and the file imports together.

Before:
![ImportPopupBefore](https://user-images.githubusercontent.com/62311243/202931944-6d8c8685-a8a6-4552-a7a2-d9b731eb3ae9.png)

After:
![ImportPopupAfter](https://user-images.githubusercontent.com/62311243/202931961-4bd27bb4-4ef3-47cb-86a3-3bf9979714e2.png)

### Alternate Designs

<!--

Explain what other alternates were considered and why the proposed version was
selected.

-->

### Why Should This Be In Core?

This affects functionality present in Core

### Benefits

Imports (File and Database separately) can be viewed in order they are imported

### Possible Drawbacks

The main drawback of this is that notification bubbles ignore newlines which means that any text previously in the header is now the first sentence in the message and it couldn't really be separated neatly from the rest of the message text (which was already there). This is mainly an issue for the file import though, this doesn't really end up being an issue for database imports (due to the way the message is currently constructed).

### Verification Process

<!--

What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (e.g. buttons you clicked, text you typed,
commands you ran, etc.), and describe the results you observed.

-->

### Applicable Issues

#1630
