### PR TITLE
updated epoch parser to allow scientific notation to parse

### DIFF
--- a/CoreImportExportPlugins/src/au/gov/asd/tac/constellation/plugins/importexport/translator/DatetimeAttributeTranslator.java
+++ b/CoreImportExportPlugins/src/au/gov/asd/tac/constellation/plugins/importexport/translator/DatetimeAttributeTranslator.java
@@ -162,7 +162,9 @@ public class DatetimeAttributeTranslator extends AttributeTranslator {
             final ZonedDateTime zonedDateTime;
             switch (format) {
                 case EPOCH:
-                    zonedDateTime = TemporalFormatting.zonedDateTimeFromLong(Long.parseLong(value));
+                    // using Double.valueOf(value).longValue() rather than Long.parseLong(value)
+                    // allows Epoch times in scietific notation to be parsed through successfully
+                    zonedDateTime = TemporalFormatting.zonedDateTimeFromLong(Double.valueOf(value).longValue());
                     return translateFromZonedDateTime(zonedDateTime, parameters);
                 case EXCEL:
                     // "GMT" is used here to avoid it using the user's local time zone.


### PR DESCRIPTION
<!--

### Requirements

* Filling out the template is required. Any pull request that does not include
enough information to be reviewed in a timely manner may be closed at the
maintainers' discretion.
* All new code requires unit tests to ensure they work as expected and will
continue to work as new code is added in the future (regression testing).
* Make sure your branch name is prefixed by `feature`, `bugfix` or `release`
* Have you read Constellation's Code of Conduct? By filing an issue, you are
expected to comply with it, including treating everyone with respect:
https://github.com/constellation-app/constellation/blob/master/CODE_OF_CONDUCT.md

-->

### Prerequisites

- [x] Reviewed the [checklist](CHECKLIST.md)

- [ ] Reviewed feedback from the "Sonar Cloud" bot. Note that you have to wait
    for the "CI / Unit Tests") to complete first. Failed Unit tests can be 
    debugged by adding the label "verbose logging" to the GitHub PR.

### Description of the Change

Values that came through as scientfic notation couldn't have the datetime attribute applied as the code immediately tried to parse the number as a long (which causes an issue for decimals). By getting the double value and then extracting the long value, the parser can handle epoch times in both standard and scientific notation

### Alternate Designs

Could've created a BigDecimal and got the long value out of that. It would be a more accurate long but for most use cases I think it may possibly incur more overhead than needed (as that solution works best if the number can't be represented as a long immediately).

### Why Should This Be In Core?

Improves parsing functionality of importer

### Benefits

Can parse epoch datetimes in both standard an scientific notation

### Possible Drawbacks

There is a possibility that if the epoch datetime is big enough that the proposed solution may lose some precision but I think this is unlikely to occur.

### Verification Process
1) Create a file with a column containing 2 epoch datetimes, one in standard notation and one in scientific notation
2) Add file to file importer
3) Try apply datetime attribute to field with formatter set to Epoch datetime

### Applicable Issues

#1723 
