### PR TITLE
Enable/Disable QC Rules

### DIFF
--- a/CorePreferences/src/au/gov/asd/tac/constellation/preferences/ApplicationPreferenceKeys.java
+++ b/CorePreferences/src/au/gov/asd/tac/constellation/preferences/ApplicationPreferenceKeys.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2021 Australian Signals Directorate
+ * Copyright 2010-2022 Australian Signals Directorate
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -184,6 +184,11 @@ public final class ApplicationPreferenceKeys {
      * Quality Control View Priorities
      */
     public static final String RULE_PRIORITIES = "customRules";
+    
+    /**
+     * Quality Control View Rule Enabled Statuses
+     */
+    public static final String RULE_ENABLED_STATUSES = "enabledRules";
 
     /**
      * Default Font.

--- a/CoreQualityControlView/src/au/gov/asd/tac/constellation/views/qualitycontrol/QualityControlViewPane.java
+++ b/CoreQualityControlView/src/au/gov/asd/tac/constellation/views/qualitycontrol/QualityControlViewPane.java
@@ -412,7 +412,7 @@ public final class QualityControlViewPane extends BorderPane {
     private static void showPriorityDialog() {
         final ScrollPane rulesScrollPane = new ScrollPane();
         rulesScrollPane.setPrefHeight(240);
-        rulesScrollPane.setPrefWidth(700);
+        rulesScrollPane.setPrefWidth(750);
         rulesScrollPane.setVbarPolicy(ScrollPane.ScrollBarPolicy.ALWAYS);
         rulesScrollPane.setHbarPolicy(ScrollPane.ScrollBarPolicy.NEVER);
 

--- a/CoreQualityControlView/src/au/gov/asd/tac/constellation/views/qualitycontrol/QualityControlViewPane.java
+++ b/CoreQualityControlView/src/au/gov/asd/tac/constellation/views/qualitycontrol/QualityControlViewPane.java
@@ -117,6 +117,9 @@ public final class QualityControlViewPane extends BorderPane {
     private final TableColumn<QualityControlEvent, QualityControlEvent> reasonColumn;
     private final TableView<QualityControlEvent> qualityTable;
     private final FlowPane optionsPane;
+    
+    private static final String DISABLE = "Disable";
+    private static final String ENABLE = "Enable";
 
     public QualityControlViewPane() {
         readSerializedRulePriorities();
@@ -479,10 +482,10 @@ public final class QualityControlViewPane extends BorderPane {
                 resetButton.setText("Reset");
             });
             
-            final Button enableDisableButton = new Button(getEnablementStatuses().get(rule) ? "Disable" : "Enable");
+            final Button enableDisableButton = new Button(Boolean.TRUE.equals(getEnablementStatuses().get(rule)) ? DISABLE : ENABLE);
             enableDisableButton.setOnAction(event -> {
-                if ("Disable".equals(enableDisableButton.getText())) {
-                    enableDisableButton.setText("Enable");
+                if (DISABLE.equals(enableDisableButton.getText())) {
+                    enableDisableButton.setText(ENABLE);
                     ruleName.setTextFill(Color.GREY);
                     minorButton.setDisable(true);
                     mediumButton.setDisable(true);
@@ -491,7 +494,7 @@ public final class QualityControlViewPane extends BorderPane {
                     criticalButton.setDisable(true);
                     resetButton.setDisable(true);
                 } else {
-                    enableDisableButton.setText("Disable");
+                    enableDisableButton.setText(DISABLE);
                     ruleName.setTextFill(Color.color(0.196, 0.196, 0.196));
                     minorButton.setDisable(false);
                     mediumButton.setDisable(false);
@@ -524,7 +527,7 @@ public final class QualityControlViewPane extends BorderPane {
                     break;
             }
             
-            if (!getEnablementStatuses().get(rule)) {
+            if (Boolean.FALSE.equals(getEnablementStatuses().get(rule))) {
                 ruleName.setTextFill(Color.GREY);
                 minorButton.setDisable(true);
                 mediumButton.setDisable(true);
@@ -594,7 +597,7 @@ public final class QualityControlViewPane extends BorderPane {
                 getPriorities().put((QualityControlRule) tg.getUserData(), (QualityCategory) tg.getSelectedToggle().getUserData());
             }
             for (final Entry<QualityControlRule, Button> entry : ruleEnableButtons.entrySet()) {
-                final boolean enabled = "Disable".equals(entry.getValue().getText());
+                final boolean enabled = DISABLE.equals(entry.getValue().getText());
                 getEnablementStatuses().put(entry.getKey(), enabled);
                 entry.getKey().setEnabled(enabled);
             }
@@ -744,7 +747,7 @@ public final class QualityControlViewPane extends BorderPane {
         final Map<String, String> enableStringMap = JsonUtilities.getStringAsMap(FACTORY, PREFERENCES.get(ApplicationPreferenceKeys.RULE_ENABLED_STATUSES, ""));
         for (final Entry<String, String> entry : enableStringMap.entrySet()) {
             final QualityControlRule rule = QualityControlEvent.getRuleByString(entry.getKey());
-            final boolean enabled = Boolean.valueOf(entry.getValue());
+            final boolean enabled = Boolean.parseBoolean(entry.getValue());
             getEnablementStatuses().put(rule, enabled);
             rule.setEnabled(enabled);
         }

--- a/CoreQualityControlView/src/au/gov/asd/tac/constellation/views/qualitycontrol/daemon/QualityControlStateUpdater.java
+++ b/CoreQualityControlView/src/au/gov/asd/tac/constellation/views/qualitycontrol/daemon/QualityControlStateUpdater.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2021 Australian Signals Directorate
+ * Copyright 2010-2022 Australian Signals Directorate
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -76,8 +76,10 @@ public class QualityControlStateUpdater extends SimpleReadPlugin {
             if (!vertexList.isEmpty()) {
                 for (final QualityControlRule rule : QualityControlAutoVetter.getRules()) {
                     rule.clearResults();
-                    rule.executeRule(graph, vertexList);
-                    registeredRules.add(rule);
+                    if (rule.isEnabled()) {
+                        rule.executeRule(graph, vertexList);
+                        registeredRules.add(rule);
+                    }
                 }
             }
 

--- a/CoreQualityControlView/src/au/gov/asd/tac/constellation/views/qualitycontrol/rules/QualityControlRule.java
+++ b/CoreQualityControlView/src/au/gov/asd/tac/constellation/views/qualitycontrol/rules/QualityControlRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2021 Australian Signals Directorate
+ * Copyright 2010-2022 Australian Signals Directorate
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -109,12 +109,14 @@ public abstract class QualityControlRule {
     }
 
     protected Set<Integer> results;
+    private boolean enabled;
 
     /**
      * Construct a Rule.
      */
     protected QualityControlRule() {
         results = new HashSet<>();
+        enabled = true;
     }
 
     /**
@@ -147,12 +149,20 @@ public abstract class QualityControlRule {
      */
     public void executeRule(final GraphReadMethods graph, final List<Integer> vertexIds) {
         vertexIds.forEach(vxId -> {
-            if (this.executeRule(graph, vxId)) {
+            if (executeRule(graph, vxId)) {
                 results.add(vxId);
             }
         });
     }
 
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    public void setEnabled(final boolean enabled) {
+        this.enabled = enabled;
+    }
+    
     /**
      * Get the name of this Rule.
      *

--- a/CoreQualityControlView/src/au/gov/asd/tac/constellation/views/qualitycontrol/widget/DefaultQualityControlAutoButton.java
+++ b/CoreQualityControlView/src/au/gov/asd/tac/constellation/views/qualitycontrol/widget/DefaultQualityControlAutoButton.java
@@ -49,6 +49,9 @@ public final class DefaultQualityControlAutoButton extends QualityControlAutoBut
     public DefaultQualityControlAutoButton() {
         getStylesheets().add(JavafxStyleManager.getMainStyleSheet());
         setStyle(QUERY_RISK_DEFAULT_STYLE + BUTTON_STYLE + String.format("-fx-font-size:%d;", FontUtilities.getApplicationFontSize()));
+        
+        QualityControlViewPane.readSerializedRulePriorities();
+        QualityControlViewPane.readSerializedRuleEnabledStatuses();
 
         setOnAction(value -> SwingUtilities.invokeLater(() -> {
             final TopComponent qualityControlView = WindowManager.getDefault().findTopComponent(QualityControlViewTopComponent.class.getSimpleName());

--- a/CoreQualityControlView/test/unit/src/au/gov/asd/tac/constellation/views/qualitycontrol/daemon/QualityControlStateUpdaterNGTest.java
+++ b/CoreQualityControlView/test/unit/src/au/gov/asd/tac/constellation/views/qualitycontrol/daemon/QualityControlStateUpdaterNGTest.java
@@ -230,6 +230,94 @@ public class QualityControlStateUpdaterNGTest {
         // check equality of the rules
         assertEquals(registeredRules, expectedRegisteredRules);
     }
+    
+    @Test
+    public void testReadSelectedNodesWithDisabledRules() throws Exception {
+        System.out.println("read Selected Nodes With Disabled Rules");
+
+        graph = new DualGraph(SchemaFactoryUtilities.getSchemaFactory(VisualSchemaFactory.VISUAL_SCHEMA_ID).createSchema());
+        WritableGraph wg = graph.getWritableGraph("Add Elements", true);
+        try {
+            // Add X,Y,Z vertex attributes
+            attrX = VisualConcept.VertexAttribute.X.ensure(wg);
+            attrY = VisualConcept.VertexAttribute.Y.ensure(wg);
+            attrZ = VisualConcept.VertexAttribute.Z.ensure(wg);
+
+            // Add vertex and transaction SELECTED attributes
+            vSelectedAttrId = VisualConcept.VertexAttribute.SELECTED.ensure(wg);
+            tSelectedAttrId = VisualConcept.TransactionAttribute.SELECTED.ensure(wg);
+
+            // Add two vertices
+            vxId1 = wg.addVertex();
+            vxId2 = wg.addVertex();
+
+            // Add one transaction between the two vertices
+            txId1 = wg.addTransaction(vxId1, vxId2, false);
+
+            wg.setFloatValue(attrX, vxId1, 1.0f);
+            wg.setFloatValue(attrY, vxId1, 1.0f);
+            wg.setBooleanValue(vSelectedAttrId, vxId1, false);
+
+            wg.setFloatValue(attrX, vxId2, 2.0f);
+            wg.setFloatValue(attrY, vxId2, 2.0f);
+            wg.setBooleanValue(vSelectedAttrId, vxId1, true);
+
+            // Add vertex IDENTIFIER attribute and label each vertice.
+            vxIdentifierAttrId = VisualConcept.VertexAttribute.IDENTIFIER.ensure(wg);
+            wg.setStringValue(vxIdentifierAttrId, vxId1, "Vertex1");
+            wg.setStringValue(vxIdentifierAttrId, vxId2, "Vertex2");
+
+            // Add vertex TYPE attribute and set each type to unknown
+            typeAttrId = AnalyticConcept.VertexAttribute.TYPE.ensure(wg);
+            wg.setObjectValue(typeAttrId, vxId1, SchemaVertexType.unknownType());
+            wg.setObjectValue(typeAttrId, vxId2, SchemaVertexType.unknownType());
+
+        } finally {
+            wg.commit();
+        }
+
+        // Expected rules
+        final List<QualityControlRule> expectedRegisteredRules = new ArrayList<>(Lookup.getDefault().lookupAll(QualityControlRule.class));
+
+        // Disable all the rules
+        for (final QualityControlRule rule : expectedRegisteredRules) {
+            rule.setEnabled(false);
+        }
+
+        final List<QualityControlEvent> expectedQualityControlEvents = new ArrayList<>();
+        expectedQualityControlEvents.add(new QualityControlEvent(0, "Vertex1", SchemaVertexType.unknownType(), Collections.emptyList()));
+
+        // Call update state to trigger checking of rules
+        PluginExecution.withPlugin(new QualityControlStateUpdater()).executeNow(graph);
+
+        // get the state and events
+        final QualityControlState state = QualityControlAutoVetter.getInstance().getQualityControlState();
+        final List<QualityControlEvent> qualityControlEvents = state.getQualityControlEvents();
+        final List<QualityControlRule> registeredRules = state.getRegisteredRules();
+
+        // Loop all events and check equality for each item specifically. Testing equality of the list was taken literally.
+        assertEquals(qualityControlEvents.size(), expectedQualityControlEvents.size());
+        int i = 0;
+        for (QualityControlEvent event : expectedQualityControlEvents) {
+            if (qualityControlEvents.size() >= i) {
+                assertEquals(qualityControlEvents.get(i).getReasons(), event.getReasons());
+                assertEquals(qualityControlEvents.get(i).getQuality(), event.getQuality());
+                assertEquals(qualityControlEvents.get(i).getVertex(), event.getVertex());
+                assertEquals(qualityControlEvents.get(i).getRules(), event.getRules());
+                assertEquals(qualityControlEvents.get(i).getType(), event.getType());
+            }
+            i++;
+        }
+
+        // check equality of the rules
+        // since all the rules have been disabled, this should be empty
+        assertEquals(registeredRules, Collections.emptyList());
+        
+        // Enable all the rules again to clean up
+        for (final QualityControlRule rule : expectedRegisteredRules) {
+            rule.setEnabled(true);
+        }
+    }
 
     /**
      * Test of getName method, of class QualityControlStateUpdater.

--- a/CoreWhatsNewView/src/au/gov/asd/tac/constellation/views/whatsnew/whatsnew.txt
+++ b/CoreWhatsNewView/src/au/gov/asd/tac/constellation/views/whatsnew/whatsnew.txt
@@ -1,6 +1,10 @@
 == 3030-12-31 Getting Started
 <p>If you're new to Constellation, read the <a href="" helpId="au.gov.asd.tac.constellation.functionality.gettingstarted">getting started guide</a>.</p>
 
+== 2022-11-23 Quality Control Rules
+<p>Quality Control Rules can now be disabled and enabled from the Category Priority menu in the Quality Control View.</p>
+<p>Disabled rules will be ignored when determining the quality rating of a node.</p>
+
 == 2022-11-21 Datetime Formatters
 <p>Datetime formatters have been updated in the File and Database importers to allow single digit days and hours to be passed through most default formats.</p>
 <p>A few new formatters, which don't contain seconds, have been added to the default list.</p>


### PR DESCRIPTION
<!--

### Requirements

* Filling out the template is required. Any pull request that does not include
enough information to be reviewed in a timely manner may be closed at the
maintainers' discretion.
* All new code requires unit tests to ensure they work as expected and will
continue to work as new code is added in the future (regression testing).
* Make sure your branch name is prefixed by `feature`, `bugfix` or `release`
* Have you read Constellation's Code of Conduct? By filing an issue, you are
expected to comply with it, including treating everyone with respect:
https://github.com/constellation-app/constellation/blob/master/CODE_OF_CONDUCT.md

-->

### Prerequisites

- [x] Reviewed the [checklist](CHECKLIST.md)

- [ ] Reviewed feedback from the "Sonar Cloud" bot. Note that you have to wait
    for the "CI / Unit Tests") to complete first. Failed Unit tests can be 
    debugged by adding the label "verbose logging" to the GitHub PR.

### Description of the Change

Updated the quality control view category priority dialog to include an option to enable or disable a rule. Similar to the category priority change, this will be persistent between sessions. By default, all rules are enabled.

While I was at it, I also fixed an issue with the QC widget in Data access view where any changes to rules were only applied once the quality control view was opened (e.g. if DAV was opened and QCV was not, if you previously changed the Unknown rule category from minor to major, and that was the only rule flagged by a particular node, the widget would read as minor until you opened QCV and which point it would change to major). 

![qualityControlRuleDisable](https://user-images.githubusercontent.com/62311243/203463261-a5b01150-e20e-467e-811e-9dd05f868958.gif)

### Alternate Designs

<!--

Explain what other alternates were considered and why the proposed version was
selected.

-->

### Why Should This Be In Core?

Rule enabling/disabling is generic enough that it should be found in the framework

### Benefits

Users have more control over which rules are relevant to them. Bug fix

### Possible Drawbacks

Nil

### Verification Process

<!--

What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (e.g. buttons you clicked, text you typed,
commands you ran, etc.), and describe the results you observed.

-->

### Applicable Issues

#1151
