### PR TITLE
Find View Run Time Error 

### DIFF
--- a/CoreFindView/src/au/gov/asd/tac/constellation/views/find2/state/FindViewStateIoProvider.java
+++ b/CoreFindView/src/au/gov/asd/tac/constellation/views/find2/state/FindViewStateIoProvider.java
@@ -82,7 +82,10 @@ public class FindViewStateIoProvider extends AbstractGraphIOProvider {
                     selectedAttributes.add(null);
                 } else {
                     int attributeInt = writableGraph.getAttribute(graphElement, selectedAttributesArray.get(i).asText());
-                    selectedAttributes.add(new GraphAttribute(writableGraph, attributeInt));
+                    // Only add the attribute to the selected attributes list if it exists in the graph
+                    if (attributeInt >= 0) {
+                        selectedAttributes.add(new GraphAttribute(writableGraph, attributeInt));
+                    }
                 }
             }
 


### PR DESCRIPTION
<!--

### Requirements

* Filling out the template is required. Any pull request that does not include
enough information to be reviewed in a timely manner may be closed at the
maintainers' discretion.
* All new code requires unit tests to ensure they work as expected and will
continue to work as new code is added in the future (regression testing).
* Make sure your branch name is prefixed by `feature`, `bugfix` or `release`
* Have you read Constellation's Code of Conduct? By filing an issue, you are
expected to comply with it, including treating everyone with respect:
https://github.com/constellation-app/constellation/blob/master/CODE_OF_CONDUCT.md

-->

### Prerequisites

- [x] Reviewed the [checklist](CHECKLIST.md)

- [x] Reviewed feedback from the "Sonar Cloud" bot. Note that you have to wait
    for the "CI / Unit Tests") to complete first. Failed Unit tests can be 
    debugged by adding the label "verbose logging" to the GitHub PR.

### Description of the Change
This run time error was caused by the new find view attempting to pre-fill the selected attributes drop down with all the attributes that were previously used in a search even if those attributes no longer exist on the graph. 

The error is reproducible by opening the attached graph below or by doing the following on release version 2.9:
1. Creating a new graph and adding a new custom node attribute.
2. Use the new find view to search with this custom attribute selected in selected attributes.
3. Close the new find view and delete the custom attribute
4. Close and reopen the graph (this should throw the index out of bounds)

[greg.and.Sarah.3.zip](https://github.com/constellation-app/constellation/files/10429716/greg.and.Sarah.3.zip)

The new find view only updates the selected attributes list when it is open so if there are attributes deleted after performing a search and the graph is saved and closed before the find view has been reopened, then the next time the graph is open it will attempt to pre-fill the drop down list with what was saved in the find view state the last time it was used. This fix ensures attributes are only added to the list if they exist on the graph. 

<!--

We must be able to understand the design of your change from this description.
If we can't get a good idea of what the code will be doing from the description
here, the pull request may be closed at the maintainers' discretion. Keep in
mind that the maintainer reviewing this PR may not be familiar with or have
worked with the code here recently, so please walk us through the concepts.

-->

### Why Should This Be In Core?
Bug fix in core.
<!--

Explain why this functionality should be in Constellation Core as opposed to a
different module suite. Note that this question is more applicable when adding
new functionality. If this change is a minor update to an existing file then it
is understood that this change has to be to this module suite and a response
and therefore a response to this question is not required.

-->

### Verification Process
Checking that the error is no longer thrown when doing the above steps. 
<!--

What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (e.g. buttons you clicked, text you typed,
commands you ran, etc.), and describe the results you observed.

-->

### Applicable Issues
#1798 
<!-- Link any applicable issues here -->
