### PR TITLE
Removed some thread.sleeps from WebServer and Attribute Editor package

### DIFF
--- a/CoreAttributeEditorView/src/au/gov/asd/tac/constellation/views/attributeeditor/AttributeEditorTopComponent.java
+++ b/CoreAttributeEditorView/src/au/gov/asd/tac/constellation/views/attributeeditor/AttributeEditorTopComponent.java
@@ -24,9 +24,7 @@ import au.gov.asd.tac.constellation.graph.node.GraphNode;
 import au.gov.asd.tac.constellation.preferences.utilities.PreferenceUtilities;
 import au.gov.asd.tac.constellation.views.JavaFxTopComponent;
 import java.util.ArrayList;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.LinkedBlockingQueue;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.prefs.PreferenceChangeListener;
 import java.util.prefs.Preferences;
@@ -104,8 +102,6 @@ import org.openide.windows.TopComponent;
     "HINT_AttributeEditorTopComponent=Attribute Editor"
 })
 public final class AttributeEditorTopComponent extends JavaFxTopComponent<AttributeEditorPanel> implements GraphManagerListener, GraphChangeListener, UndoRedo.Provider, PreferenceChangeListener {
-    
-    private static final Logger LOGGER = Logger.getLogger(AttributeEditorTopComponent.class.getName());
 
     private static final String ATTRIBUTE_EDITOR_GRAPH_CHANGED_THREAD_NAME = "Attribute Editor Graph Changed Updater";
     private final AttributeEditorPanel attributePanel;
@@ -127,13 +123,13 @@ public final class AttributeEditorTopComponent extends JavaFxTopComponent<Attrib
 
             final ArrayList<Object> devNull = new ArrayList<>();
 
-            while (queue.size() > 0) {
-                    queue.drainTo(devNull);
+            while (!queue.isEmpty()) {
+                queue.drainTo(devNull);
             }
 
-                if (reader != null) {
-                    attributePanel.updateEditorPanel(reader.refreshAttributes());
-                }
+            if (reader != null) {
+                attributePanel.updateEditorPanel(reader.refreshAttributes());
+            }
 
         };
 

--- a/CoreAttributeEditorView/src/au/gov/asd/tac/constellation/views/attributeeditor/AttributeEditorTopComponent.java
+++ b/CoreAttributeEditorView/src/au/gov/asd/tac/constellation/views/attributeeditor/AttributeEditorTopComponent.java
@@ -124,29 +124,20 @@ public final class AttributeEditorTopComponent extends JavaFxTopComponent<Attrib
         setToolTipText(Bundle.HINT_AttributeEditorTopComponent());
 
         refreshRunnable = () -> {
-            try {
+
                 final ArrayList<Object> devNull = new ArrayList<>();
 
-                while (queue.drainTo(devNull) > 0) {
-                    Thread.sleep(50);
-                }
 
-                /*while (queue.size() > 0) {
+            while (queue.size() > 0) {
                     queue.drainTo(devNull);
-                }*/
+            }
 
                 if (reader != null) {
                     attributePanel.updateEditorPanel(reader.refreshAttributes());
                 }
-            } catch (final InterruptedException ex) {
-                LOGGER.log(Level.SEVERE, "Thread was interrupted");
-                Thread.currentThread().interrupt();
-            }
+
         };
 
-        CompletableFuture<void> future = CompletableFuture.runAsync(() -> {
-
-        });
 
         GraphManager.getDefault().addGraphManagerListener(AttributeEditorTopComponent.this);
         newActiveGraph(GraphManager.getDefault().getActiveGraph());

--- a/CoreAttributeEditorView/src/au/gov/asd/tac/constellation/views/attributeeditor/AttributeEditorTopComponent.java
+++ b/CoreAttributeEditorView/src/au/gov/asd/tac/constellation/views/attributeeditor/AttributeEditorTopComponent.java
@@ -24,6 +24,7 @@ import au.gov.asd.tac.constellation.graph.node.GraphNode;
 import au.gov.asd.tac.constellation.preferences.utilities.PreferenceUtilities;
 import au.gov.asd.tac.constellation.views.JavaFxTopComponent;
 import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.logging.Logger;
 import java.util.prefs.PreferenceChangeListener;
@@ -121,7 +122,7 @@ public final class AttributeEditorTopComponent extends JavaFxTopComponent<Attrib
 
         refreshRunnable = () -> {
 
-            final ArrayList<Object> devNull = new ArrayList<>();
+            final List<Object> devNull = new ArrayList<>();
 
             while (!queue.isEmpty()) {
                 queue.drainTo(devNull);

--- a/CoreAttributeEditorView/src/au/gov/asd/tac/constellation/views/attributeeditor/AttributeEditorTopComponent.java
+++ b/CoreAttributeEditorView/src/au/gov/asd/tac/constellation/views/attributeeditor/AttributeEditorTopComponent.java
@@ -24,6 +24,7 @@ import au.gov.asd.tac.constellation.graph.node.GraphNode;
 import au.gov.asd.tac.constellation.preferences.utilities.PreferenceUtilities;
 import au.gov.asd.tac.constellation.views.JavaFxTopComponent;
 import java.util.ArrayList;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -125,9 +126,14 @@ public final class AttributeEditorTopComponent extends JavaFxTopComponent<Attrib
         refreshRunnable = () -> {
             try {
                 final ArrayList<Object> devNull = new ArrayList<>();
+
                 while (queue.drainTo(devNull) > 0) {
                     Thread.sleep(50);
                 }
+
+                /*while (queue.size() > 0) {
+                    queue.drainTo(devNull);
+                }*/
 
                 if (reader != null) {
                     attributePanel.updateEditorPanel(reader.refreshAttributes());
@@ -137,6 +143,10 @@ public final class AttributeEditorTopComponent extends JavaFxTopComponent<Attrib
                 Thread.currentThread().interrupt();
             }
         };
+
+        CompletableFuture<void> future = CompletableFuture.runAsync(() -> {
+
+        });
 
         GraphManager.getDefault().addGraphManagerListener(AttributeEditorTopComponent.this);
         newActiveGraph(GraphManager.getDefault().getActiveGraph());

--- a/CoreAttributeEditorView/src/au/gov/asd/tac/constellation/views/attributeeditor/AttributeEditorTopComponent.java
+++ b/CoreAttributeEditorView/src/au/gov/asd/tac/constellation/views/attributeeditor/AttributeEditorTopComponent.java
@@ -125,8 +125,7 @@ public final class AttributeEditorTopComponent extends JavaFxTopComponent<Attrib
 
         refreshRunnable = () -> {
 
-                final ArrayList<Object> devNull = new ArrayList<>();
-
+            final ArrayList<Object> devNull = new ArrayList<>();
 
             while (queue.size() > 0) {
                     queue.drainTo(devNull);

--- a/CorePluginReporterView/src/au/gov/asd/tac/constellation/views/pluginreporter/panes/PluginReportTimeUpdater.java
+++ b/CorePluginReporterView/src/au/gov/asd/tac/constellation/views/pluginreporter/panes/PluginReportTimeUpdater.java
@@ -58,6 +58,7 @@ public class PluginReportTimeUpdater {
         @Override
         public void run() {
             setName(PLUGIN_REPORTER_THREAD_NAME);
+
             while (true) {
                 try {
                     Thread.sleep(1000);

--- a/CoreWebServer/src/au/gov/asd/tac/constellation/webserver/restapi/RestServiceUtilities.java
+++ b/CoreWebServer/src/au/gov/asd/tac/constellation/webserver/restapi/RestServiceUtilities.java
@@ -175,8 +175,8 @@ public class RestServiceUtilities {
 
         return CompletableFuture.supplyAsync(() -> {
             while (true) {
-                if (GraphManager.getDefault().getActiveGraph() != null) {
-                    final Graph newGraph = GraphManager.getDefault().getActiveGraph();
+                final Graph newGraph = GraphManager.getDefault().getActiveGraph();
+                if (newGraph != null) {
                     final String newId = newGraph != null ? newGraph.getId() : null;
                     if ((existingId == null && newId != null) || (existingId != null && newId != null && !existingId.equals(newId))) {
                         // - there was no existing graph, and the new graph is active, or

--- a/CoreWebServer/src/au/gov/asd/tac/constellation/webserver/restapi/RestServiceUtilities.java
+++ b/CoreWebServer/src/au/gov/asd/tac/constellation/webserver/restapi/RestServiceUtilities.java
@@ -177,8 +177,8 @@ public class RestServiceUtilities {
             while (true) {
                 final Graph newGraph = GraphManager.getDefault().getActiveGraph();
                 if (newGraph != null) {
-                    final String newId = newGraph != null ? newGraph.getId() : null;
-                    if ((existingId == null && newId != null) || (existingId != null && newId != null && !existingId.equals(newId))) {
+                    final String newId = newGraph.getId();
+                    if (existingId == null || (existingId != null && !existingId.equals(newId))) {
                         // - there was no existing graph, and the new graph is active, or
                         // - there was an existing graph, and the active graph is not the existing graph.
                         // - we assume the user hasn't interfered by manually switching to another graph at the same time.

--- a/CoreWebServer/src/au/gov/asd/tac/constellation/webserver/restapi/RestServiceUtilities.java
+++ b/CoreWebServer/src/au/gov/asd/tac/constellation/webserver/restapi/RestServiceUtilities.java
@@ -28,7 +28,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
 
 /**
  * Various helper functions for REST services.
@@ -174,22 +173,20 @@ public class RestServiceUtilities {
      */
     public static CompletableFuture<String> waitForGraphChange(final String existingId) {
 
-        CompletableFuture<String> checkIfGraphAvailable = CompletableFuture.supplyAsync(() -> {
-                while (true) {
-                    if (GraphManager.getDefault().getActiveGraph() != null) {
-                        final Graph newGraph = GraphManager.getDefault().getActiveGraph();
-                        final String newId = newGraph != null ? newGraph.getId() : null;
-                        if ((existingId == null && newId != null) || (existingId != null && newId != null && !existingId.equals(newId))) {
-                            // - there was no existing graph, and the new graph is active, or
-                            // - there was an existing graph, and the active graph is not the existing graph.
-                            // - we assume the user hasn't interfered by manually switching to another graph at the same time.
-                            //
-                            return newId;
-                        }
+        return CompletableFuture.supplyAsync(() -> {
+            while (true) {
+                if (GraphManager.getDefault().getActiveGraph() != null) {
+                    final Graph newGraph = GraphManager.getDefault().getActiveGraph();
+                    final String newId = newGraph != null ? newGraph.getId() : null;
+                    if ((existingId == null && newId != null) || (existingId != null && newId != null && !existingId.equals(newId))) {
+                        // - there was no existing graph, and the new graph is active, or
+                        // - there was an existing graph, and the active graph is not the existing graph.
+                        // - we assume the user hasn't interfered by manually switching to another graph at the same time.
+                        //
+                        return newId;
                     }
                 }
+            }
         });
-
-        return checkIfGraphAvailable;
     }
 }

--- a/CoreWebServer/src/au/gov/asd/tac/constellation/webserver/services/NewGraph.java
+++ b/CoreWebServer/src/au/gov/asd/tac/constellation/webserver/services/NewGraph.java
@@ -134,7 +134,7 @@ public class NewGraph extends RestService {
             }
         } catch (final InterruptedException ex) {
             Thread.currentThread().interrupt();
-            LOGGER.log(Level.SEVERE, "Thread interrupted");
+            LOGGER.log(Level.SEVERE, "Thread interrupted", ex);
         } catch (final ExecutionException | TimeoutException ex) {
             throw new RestServiceException(ex);
         }

--- a/CoreWebServer/src/au/gov/asd/tac/constellation/webserver/services/NewGraph.java
+++ b/CoreWebServer/src/au/gov/asd/tac/constellation/webserver/services/NewGraph.java
@@ -122,18 +122,16 @@ public class NewGraph extends RestService {
             newId = RestServiceUtilities.waitForGraphChange(existingId).get(10, TimeUnit.SECONDS);
         } catch (final InterruptedException ex) {
             Thread.currentThread().interrupt();
-        } catch (final ExecutionException ex) {
-            throw new RestServiceException(ex);
-        } catch (final TimeoutException ex) {
+        } catch (final ExecutionException | TimeoutException ex) {
             throw new RestServiceException(ex);
         }
 
         if (!newId.isBlank() && !newId.isEmpty()) {
-        final ObjectMapper mapper = new ObjectMapper();
-        final ObjectNode root = mapper.createObjectNode();
-        root.put("id", newId);
-        root.put("name", GraphNode.getGraphNode(newId).getDisplayName());
-        root.put("schema", schemaName);
+            final ObjectMapper mapper = new ObjectMapper();
+            final ObjectNode root = mapper.createObjectNode();
+            root.put("id", newId);
+            root.put("name", GraphNode.getGraphNode(newId).getDisplayName());
+            root.put("schema", schemaName);
             mapper.writeValue(out, root);
         }
     }

--- a/CoreWebServer/src/au/gov/asd/tac/constellation/webserver/services/NewGraph.java
+++ b/CoreWebServer/src/au/gov/asd/tac/constellation/webserver/services/NewGraph.java
@@ -116,23 +116,25 @@ public class NewGraph extends RestService {
         final String graphName = SchemaFactoryUtilities.getSchemaFactory(schemaName).getLabel().trim().toLowerCase();
         GraphOpener.getDefault().openGraph(dualGraph, graphName);
 
-        final String newId;
+        String newId = "";
 
         try {
             newId = RestServiceUtilities.waitForGraphChange(existingId).get(10, TimeUnit.SECONDS);
-        } catch (InterruptedException ex) {
+        } catch (final InterruptedException ex) {
+            Thread.currentThread().interrupt();
+        } catch (final ExecutionException ex) {
             throw new RestServiceException(ex);
-        } catch (ExecutionException ex) {
-            throw new RestServiceException(ex);
-        } catch (TimeoutException ex) {
+        } catch (final TimeoutException ex) {
             throw new RestServiceException(ex);
         }
 
+        if (!newId.isBlank() && !newId.isEmpty()) {
         final ObjectMapper mapper = new ObjectMapper();
         final ObjectNode root = mapper.createObjectNode();
         root.put("id", newId);
         root.put("name", GraphNode.getGraphNode(newId).getDisplayName());
         root.put("schema", schemaName);
-        mapper.writeValue(out, root);
+            mapper.writeValue(out, root);
+        }
     }
 }

--- a/CoreWebServer/src/au/gov/asd/tac/constellation/webserver/services/OpenGraph.java
+++ b/CoreWebServer/src/au/gov/asd/tac/constellation/webserver/services/OpenGraph.java
@@ -122,7 +122,7 @@ public class OpenGraph extends RestService {
             throw new RestServiceException(HTTP_UNPROCESSABLE_ENTITY, ex.getMessage());
         } catch (final InterruptedException ex) {
             Thread.currentThread().interrupt();
-            LOGGER.log(Level.SEVERE, "This thread has been interrupted");
+            LOGGER.log(Level.SEVERE, "This thread has been interrupted", ex);
         } catch (final ExecutionException | TimeoutException ex) {
             throw new RestServiceException(ex);
         }

--- a/CoreWebServer/src/au/gov/asd/tac/constellation/webserver/services/OpenGraph.java
+++ b/CoreWebServer/src/au/gov/asd/tac/constellation/webserver/services/OpenGraph.java
@@ -105,11 +105,7 @@ public class OpenGraph extends RestService {
             final Graph g = new GraphJsonReader().readGraphZip(fnam, new HandleIoProgress(String.format("Loading graph %s...", fnam)));
             GraphOpener.getDefault().openGraph(g, name, false);
 
-            final String newId;
-
-            newId = RestServiceUtilities.waitForGraphChange(existingId).get(10, TimeUnit.SECONDS);
-
-
+            final String newId = RestServiceUtilities.waitForGraphChange(existingId).get(10, TimeUnit.SECONDS);
             final Graph graph = GraphNode.getGraphNode(newId).getGraph();
 
             final ObjectMapper mapper = new ObjectMapper();

--- a/CoreWebServer/src/au/gov/asd/tac/constellation/webserver/services/OpenGraph.java
+++ b/CoreWebServer/src/au/gov/asd/tac/constellation/webserver/services/OpenGraph.java
@@ -39,6 +39,8 @@ import java.io.OutputStream;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import org.apache.commons.lang3.StringUtils;
 import org.openide.util.lookup.ServiceProvider;
 
@@ -52,6 +54,8 @@ import org.openide.util.lookup.ServiceProvider;
  */
 @ServiceProvider(service = RestService.class)
 public class OpenGraph extends RestService {
+
+    private static final Logger LOGGER = Logger.getLogger(OpenGraph.class.getName());
 
     private static final String NAME = "open_graph";
     private static final String FILE_PARAMETER_ID = "filename";
@@ -118,6 +122,7 @@ public class OpenGraph extends RestService {
             throw new RestServiceException(HTTP_UNPROCESSABLE_ENTITY, ex.getMessage());
         } catch (final InterruptedException ex) {
             Thread.currentThread().interrupt();
+            LOGGER.log(Level.SEVERE, "This thread has been interrupted");
         } catch (final ExecutionException | TimeoutException ex) {
             throw new RestServiceException(ex);
         }

--- a/CoreWebServer/src/au/gov/asd/tac/constellation/webserver/services/OpenGraph.java
+++ b/CoreWebServer/src/au/gov/asd/tac/constellation/webserver/services/OpenGraph.java
@@ -120,11 +120,11 @@ public class OpenGraph extends RestService {
             mapper.writeValue(out, root);
         } catch (final GraphParseException | FileNotFoundException ex) {
             throw new RestServiceException(HTTP_UNPROCESSABLE_ENTITY, ex.getMessage());
-        } catch (InterruptedException ex) {
+        } catch (final InterruptedException ex) {
+            Thread.currentThread().interrupt();
+        } catch (final ExecutionException ex) {
             throw new RestServiceException(ex);
-        } catch (ExecutionException ex) {
-            throw new RestServiceException(ex);
-        } catch (TimeoutException ex) {
+        } catch (final TimeoutException ex) {
             throw new RestServiceException(ex);
         }
     }

--- a/CoreWebServer/src/au/gov/asd/tac/constellation/webserver/services/OpenGraph.java
+++ b/CoreWebServer/src/au/gov/asd/tac/constellation/webserver/services/OpenGraph.java
@@ -122,9 +122,7 @@ public class OpenGraph extends RestService {
             throw new RestServiceException(HTTP_UNPROCESSABLE_ENTITY, ex.getMessage());
         } catch (final InterruptedException ex) {
             Thread.currentThread().interrupt();
-        } catch (final ExecutionException ex) {
-            throw new RestServiceException(ex);
-        } catch (final TimeoutException ex) {
+        } catch (final ExecutionException | TimeoutException ex) {
             throw new RestServiceException(ex);
         }
     }


### PR DESCRIPTION
<!--

### Requirements

* Filling out the template is required. Any pull request that does not include
enough information to be reviewed in a timely manner may be closed at the
maintainers' discretion.
* All new code requires unit tests to ensure they work as expected and will
continue to work as new code is added in the future (regression testing).
* Make sure your branch name is prefixed by `feature`, `bugfix` or `release`
* Have you read Constellation's Code of Conduct? By filing an issue, you are
expected to comply with it, including treating everyone with respect:
https://github.com/constellation-app/constellation/blob/master/CODE_OF_CONDUCT.md

-->

### Prerequisites

- [ X] Reviewed the [checklist](CHECKLIST.md)

- [ ] Reviewed feedback from the "Sonar Cloud" bot. Note that you have to wait
    for the "CI / Unit Tests") to complete first. Failed Unit tests can be 
    debugged by adding the label "verbose logging" to the GitHub PR.

### Description of the Change

<!--

We must be able to understand the design of your change from this description.
If we can't get a good idea of what the code will be doing from the description
here, the pull request may be closed at the maintainers' discretion. Keep in
mind that the maintainer reviewing this PR may not be familiar with or have
worked with the code here recently, so please walk us through the concepts.

-->
The thread.sleep() in the attribute editor has been removed since a similar effect can be reached without it. The RestServiceUtilities class has had a thread.sleep replaced with a CompletableFuture.

After some investigation:

Data access view - the thread.sleep() here seems to be an intentional thing where the user can choose to sleep the thread for a certain period of time.

Graph Node - It is unclear how to make this any better. The sleep is in the DefaultPluginInteraction class

Core Interactive Graph - The sleep is in the Animation class. The sleep is used pause the thread after each frame of the animation is displayed. Since each animation runs on its own thread I don't think the sleep affects performance much since nothing else will be running on that thread.

Open GL display - Cannot find the Thread.sleep() in this

Plugin Reporter View - I did draft some changes for this where a sleep isn't used but they were all less efficient than using the sleep. When I find a better solution I will comeback for this. The sleep is in the PluginReportTimeUpdater class.

Table View - Unclear on how to improve things, seems like the last guy was unsure about it as well. This one is in the top component.

Testing - The thread.sleeps here are not directly inside a loop so they are probably being called from a loop somewhere else. When searching for the usages of the function containing the sleeps no results are found. I have been told that these are used with experimental stuff and is important to keep.

Web server - this looks like it can be improved. The sleep is in the FileListener class. Need to learn more about it.
### Alternate Designs

<!--

Explain what other alternates were considered and why the proposed version was
selected.

-->

### Why Should This Be In Core?

<!--

Explain why this functionality should be in Constellation Core as opposed to a
different module suite. Note that this question is more applicable when adding
new functionality. If this change is a minor update to an existing file then it
is understood that this change has to be to this module suite and a response
and therefore a response to this question is not required.

-->
Small performance benefit
### Benefits

<!-- What benefits will be realized by the code change? -->
Unsure if user will feel things since so little has changed but theoretically AttributeEditor and RestServiceUtilities should perform better
### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->
Things become slower and I have to start from square one again.
### Verification Process

<!--

What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (e.g. buttons you clicked, text you typed,
commands you ran, etc.), and describe the results you observed.

-->
Still need to verify. This one will probably need a few more go's.
### Applicable Issues

<!-- Link any applicable issues here -->
#653 