### PR TITLE
Allow GIF and JPG images to be added  as icons

### DIFF
--- a/CoreAttributeEditorView/src/au/gov/asd/tac/constellation/views/attributeeditor/editors/IconEditorFactory.java
+++ b/CoreAttributeEditorView/src/au/gov/asd/tac/constellation/views/attributeeditor/editors/IconEditorFactory.java
@@ -171,19 +171,33 @@ public class IconEditorFactory extends AttributeValueEditorFactory<Constellation
             refreshIconList(iconFile);
         }
 
-        private List<File> pngWalk(File path) {
+        /**
+         * Search for all valid icons, starting at the supplied path.
+         * @param path Path to search for icons.
+         * @return List of all icon files found.
+         */
+        private List<File> iconWalk(File path) {
             final List<File> files = new ArrayList<>();
-            pngWalk(path, files);
+            iconWalk(path, files);
             return files;
         }
 
-        private List<File> pngWalk(final File path, final List<File> files) {
+        /**
+         * Navigate through all files in path and its subdirectories, adding any
+         * files found to match icon file types to the list of icons returned.
+         * @param path Path to search for icons.
+         * @param files Files already found.
+         * @return Complete list of all icon files found (new + those passed in).
+         */
+        private List<File> iconWalk(final File path, final List<File> files) {
             final List<File> addedFiles = new ArrayList<>();
             for (final File f : path.listFiles()) {
                 if (f.isDirectory()) {
                     addedFiles.add(f);
                 } else {
-                    if (StringUtils.endsWithIgnoreCase(f.getAbsolutePath(), FileExtensionConstants.PNG)) {
+                    if (StringUtils.endsWithIgnoreCase(f.getAbsolutePath(), FileExtensionConstants.JPG) ||
+                        StringUtils.endsWithIgnoreCase(f.getAbsolutePath(), FileExtensionConstants.GIF) ||
+                        StringUtils.endsWithIgnoreCase(f.getAbsolutePath(), FileExtensionConstants.PNG)) {
                         addedFiles.add(f);
                     }
                 }
@@ -191,7 +205,7 @@ public class IconEditorFactory extends AttributeValueEditorFactory<Constellation
 
             addedFiles.forEach(file -> {
                 if (file.isDirectory()) {
-                    pngWalk(file, files);
+                    iconWalk(file, files);
                 } else {
                     files.add(file);
                 }
@@ -282,7 +296,7 @@ public class IconEditorFactory extends AttributeValueEditorFactory<Constellation
 
             addFilesButton.setOnAction(event -> FileChooser.openMultiDialog(getIconEditorFileChooser()).thenAccept(optionalFiles -> optionalFiles.ifPresent(files -> addIcons(files))));
 
-            addDirButton.setOnAction(event -> FileChooser.openOpenDialog(getIconEditorFolderChooser()).thenAccept(optionalFolder -> optionalFolder.ifPresent(folder -> addIcons(pngWalk(folder)))));
+            addDirButton.setOnAction(event -> FileChooser.openOpenDialog(getIconEditorFolderChooser()).thenAccept(optionalFolder -> optionalFolder.ifPresent(folder -> addIcons(iconWalk(folder)))));
 
             removeButton.setOnAction(event -> {
                 final boolean iconRemoved = IconManager.removeIcon(listView.getSelectionModel().getSelectedItem());
@@ -309,12 +323,16 @@ public class IconEditorFactory extends AttributeValueEditorFactory<Constellation
                         @Override
                         public boolean accept(final File file) {
                             final String name = file.getName();
-                            return (file.isFile() && StringUtils.endsWithIgnoreCase(name, FileExtensionConstants.PNG)) || file.isDirectory();
+                            final boolean imageFilename = (
+                                    StringUtils.endsWithIgnoreCase(name, FileExtensionConstants.JPG) ||
+                                    StringUtils.endsWithIgnoreCase(name, FileExtensionConstants.GIF) ||
+                                    StringUtils.endsWithIgnoreCase(name, FileExtensionConstants.PNG));
+                            return ((file.isFile() && imageFilename) || file.isDirectory());
                         }
 
                         @Override
                         public String getDescription() {
-                            return "Image Files (" + FileExtensionConstants.PNG + ")";
+                            return "Image Files (*" + FileExtensionConstants.JPG + ";*" + FileExtensionConstants.GIF + ";*" + FileExtensionConstants.PNG + ")";
                         }
                     });
         }

--- a/CoreAttributeEditorView/test/unit/src/au/gov/asd/tac/constellation/views/attributeeditor/editors/IconEditorFactoryNGTest.java
+++ b/CoreAttributeEditorView/test/unit/src/au/gov/asd/tac/constellation/views/attributeeditor/editors/IconEditorFactoryNGTest.java
@@ -89,7 +89,7 @@ public class IconEditorFactoryNGTest {
         System.out.println("getIconEditorFileChooser");
 
         final String fileChooserTitle = "Add New Icon(s)";
-        final String fileChooserDescription = "Image Files (" + FileExtensionConstants.PNG + ")";
+        final String fileChooserDescription = "Image Files (*" + FileExtensionConstants.JPG + ";*" + FileExtensionConstants.GIF + ";*" + FileExtensionConstants.PNG + ")";
 
         final IconEditor instance = (IconEditor) new IconEditorFactory().createEditor(
                 mock(EditOperation.class),


### PR DESCRIPTION
### Prerequisites

- [X] Reviewed the [checklist](CHECKLIST.md)

- [X] Reviewed feedback from the "Sonar Cloud" bot. Note that you have to wait
    for the "CI / Unit Tests") to complete first. Failed Unit tests can be 
    debugged by adding the label "verbose logging" to the GitHub PR.

### Description of the Change

Allow .GIF and .JPG files to be imported as icons. This mean code in the attribute editor that allows icons to be imported is modified to not just lock down to PNGs. 
Existing cvode allows these files to be stored as custom icons in star files and places copies of impoorted files into icon folder.

### Alternate Designs

nil

### Why Should This Be In Core?

Increase the types of images that can be icons

### Benefits

As above

### Possible Drawbacks

None known

### Verification Process

Repeat steps documented in this tickets problem description, but confirm that GIF of JPG files can nw be added, either individually, or by directory.

### Applicable Issues

#1768
