### PR TITLE
Prevent exception popup windows from being displayed when a notification was already shown.

### DIFF
--- a/CoreDataAccessView/src/au/gov/asd/tac/constellation/views/dataaccess/plugins/importing/file/GMLImportProcessor.java
+++ b/CoreDataAccessView/src/au/gov/asd/tac/constellation/views/dataaccess/plugins/importing/file/GMLImportProcessor.java
@@ -162,16 +162,16 @@ public class GMLImportProcessor implements GraphFileImportProcessor {
             final String errorMsg = "File " + filename + " not found";
             NotifyDisplayer.display(new NotifyDescriptor("Error:\n" + errorMsg, "Import GML File", DEFAULT_OPTION, 
                     NotifyDescriptor.ERROR_MESSAGE, new Object[]{NotifyDescriptor.OK_OPTION}, NotifyDescriptor.OK_OPTION));
-            final Throwable fnfex = new FileNotFoundException(NotifyDisplayer.BLOCK_POPUP_FLAG + errorMsg);
-            fnfex.setStackTrace(ex.getStackTrace());
-            LOGGER.log(Level.SEVERE, errorMsg, fnfex);
+            final Throwable fnfEx = new FileNotFoundException(NotifyDisplayer.BLOCK_POPUP_FLAG + errorMsg);
+            fnfEx.setStackTrace(ex.getStackTrace());
+            LOGGER.log(Level.SEVERE, errorMsg, fnfEx);
         } catch (final IOException ex) {
             final String errorMsg = "Error reading file " + filename;
             NotifyDisplayer.display(new NotifyDescriptor("Error:\n" + errorMsg, "Import GML File", DEFAULT_OPTION, 
                     NotifyDescriptor.ERROR_MESSAGE, new Object[]{NotifyDescriptor.OK_OPTION}, NotifyDescriptor.OK_OPTION));
-            final Throwable ioex = new IOException(NotifyDisplayer.BLOCK_POPUP_FLAG + errorMsg);
-            ioex.setStackTrace(ex.getStackTrace());
-            LOGGER.log(Level.SEVERE, errorMsg, ioex);
+            final Throwable ioEx = new IOException(NotifyDisplayer.BLOCK_POPUP_FLAG + errorMsg);
+            ioEx.setStackTrace(ex.getStackTrace());
+            LOGGER.log(Level.SEVERE, errorMsg, ioEx);
         }
 
         output.add(nodeRecords);

--- a/CoreDataAccessView/src/au/gov/asd/tac/constellation/views/dataaccess/plugins/importing/file/GMLImportProcessor.java
+++ b/CoreDataAccessView/src/au/gov/asd/tac/constellation/views/dataaccess/plugins/importing/file/GMLImportProcessor.java
@@ -159,14 +159,14 @@ public class GMLImportProcessor implements GraphFileImportProcessor {
                         nodeIdToType.get(edgeRecords.get(i, GraphRecordStoreUtilities.DESTINATION + VisualConcept.VertexAttribute.IDENTIFIER)));
             }
         } catch (final FileNotFoundException ex) {
-            final String errorMsg = "File " + filename + " not found";
+            final String errorMsg = "File '" + filename + "' not found";
             NotifyDisplayer.display(new NotifyDescriptor("Error:\n" + errorMsg, "Import GML File", DEFAULT_OPTION, 
                     NotifyDescriptor.ERROR_MESSAGE, new Object[]{NotifyDescriptor.OK_OPTION}, NotifyDescriptor.OK_OPTION));
             final Throwable fnfEx = new FileNotFoundException(NotifyDisplayer.BLOCK_POPUP_FLAG + errorMsg);
             fnfEx.setStackTrace(ex.getStackTrace());
             LOGGER.log(Level.SEVERE, errorMsg, fnfEx);
         } catch (final IOException ex) {
-            final String errorMsg = "Error reading file " + filename;
+            final String errorMsg = "Error reading file '" + filename + "'";
             NotifyDisplayer.display(new NotifyDescriptor("Error:\n" + errorMsg, "Import GML File", DEFAULT_OPTION, 
                     NotifyDescriptor.ERROR_MESSAGE, new Object[]{NotifyDescriptor.OK_OPTION}, NotifyDescriptor.OK_OPTION));
             final Throwable ioEx = new IOException(NotifyDisplayer.BLOCK_POPUP_FLAG + errorMsg);

--- a/CoreDataAccessView/src/au/gov/asd/tac/constellation/views/dataaccess/plugins/importing/file/GMLImportProcessor.java
+++ b/CoreDataAccessView/src/au/gov/asd/tac/constellation/views/dataaccess/plugins/importing/file/GMLImportProcessor.java
@@ -161,11 +161,15 @@ public class GMLImportProcessor implements GraphFileImportProcessor {
         } catch (final FileNotFoundException ex) {
             NotifyDisplayer.display(new NotifyDescriptor("Error:\n" + "File " + filename + " not found", "Import GML File", DEFAULT_OPTION, 
                     NotifyDescriptor.ERROR_MESSAGE, new Object[]{NotifyDescriptor.OK_OPTION}, NotifyDescriptor.OK_OPTION));
-            LOGGER.log(Level.SEVERE, ex, () -> "File " + filename + " not found");
+            final Throwable fnfex = new FileNotFoundException(NotifyDisplayer.BLOCK_POPUP_FLAG + "File " + filename + " not found");
+            fnfex.setStackTrace(ex.getStackTrace());
+            LOGGER.log(Level.SEVERE, "File " + filename + " not found", fnfex);
         } catch (final IOException ex) {
             NotifyDisplayer.display(new NotifyDescriptor("Error:\n" + "Error reading file " + filename, "Import GML File", DEFAULT_OPTION, 
                     NotifyDescriptor.ERROR_MESSAGE, new Object[]{NotifyDescriptor.OK_OPTION}, NotifyDescriptor.OK_OPTION));
-            LOGGER.log(Level.SEVERE, ex, () -> "Error reading file: " + filename);
+            final Throwable ioex = new IOException(NotifyDisplayer.BLOCK_POPUP_FLAG + "Error reading file: " + filename);
+            ioex.setStackTrace(ex.getStackTrace());
+            LOGGER.log(Level.SEVERE, "Error reading file: " + filename, ioex);
         }
 
         output.add(nodeRecords);

--- a/CoreDataAccessView/src/au/gov/asd/tac/constellation/views/dataaccess/plugins/importing/file/GMLImportProcessor.java
+++ b/CoreDataAccessView/src/au/gov/asd/tac/constellation/views/dataaccess/plugins/importing/file/GMLImportProcessor.java
@@ -159,17 +159,19 @@ public class GMLImportProcessor implements GraphFileImportProcessor {
                         nodeIdToType.get(edgeRecords.get(i, GraphRecordStoreUtilities.DESTINATION + VisualConcept.VertexAttribute.IDENTIFIER)));
             }
         } catch (final FileNotFoundException ex) {
-            NotifyDisplayer.display(new NotifyDescriptor("Error:\n" + "File " + filename + " not found", "Import GML File", DEFAULT_OPTION, 
+            final String errorMsg = "File " + filename + " not found";
+            NotifyDisplayer.display(new NotifyDescriptor("Error:\n" + errorMsg, "Import GML File", DEFAULT_OPTION, 
                     NotifyDescriptor.ERROR_MESSAGE, new Object[]{NotifyDescriptor.OK_OPTION}, NotifyDescriptor.OK_OPTION));
-            final Throwable fnfex = new FileNotFoundException(NotifyDisplayer.BLOCK_POPUP_FLAG + "File " + filename + " not found");
+            final Throwable fnfex = new FileNotFoundException(NotifyDisplayer.BLOCK_POPUP_FLAG + errorMsg);
             fnfex.setStackTrace(ex.getStackTrace());
-            LOGGER.log(Level.SEVERE, "File " + filename + " not found", fnfex);
+            LOGGER.log(Level.SEVERE, errorMsg, fnfex);
         } catch (final IOException ex) {
-            NotifyDisplayer.display(new NotifyDescriptor("Error:\n" + "Error reading file " + filename, "Import GML File", DEFAULT_OPTION, 
+            final String errorMsg = "Error reading file " + filename;
+            NotifyDisplayer.display(new NotifyDescriptor("Error:\n" + errorMsg, "Import GML File", DEFAULT_OPTION, 
                     NotifyDescriptor.ERROR_MESSAGE, new Object[]{NotifyDescriptor.OK_OPTION}, NotifyDescriptor.OK_OPTION));
-            final Throwable ioex = new IOException(NotifyDisplayer.BLOCK_POPUP_FLAG + "Error reading file: " + filename);
+            final Throwable ioex = new IOException(NotifyDisplayer.BLOCK_POPUP_FLAG + errorMsg);
             ioex.setStackTrace(ex.getStackTrace());
-            LOGGER.log(Level.SEVERE, "Error reading file: " + filename, ioex);
+            LOGGER.log(Level.SEVERE, errorMsg, ioex);
         }
 
         output.add(nodeRecords);

--- a/CoreDataAccessView/src/au/gov/asd/tac/constellation/views/dataaccess/plugins/importing/file/GraphMLImportProcessor.java
+++ b/CoreDataAccessView/src/au/gov/asd/tac/constellation/views/dataaccess/plugins/importing/file/GraphMLImportProcessor.java
@@ -225,19 +225,21 @@ public class GraphMLImportProcessor implements GraphFileImportProcessor {
                 }
             }
         } catch (final FileNotFoundException ex) {
-            NotifyDisplayer.display(new NotifyDescriptor("Error:\n" + "File " + filename + " not found", "Import GraphML File", DEFAULT_OPTION, 
+            final String errorMsg = "File " + filename + " not found";
+            NotifyDisplayer.display(new NotifyDescriptor("Error:\n" + errorMsg, "Import GraphML File", DEFAULT_OPTION, 
                     NotifyDescriptor.ERROR_MESSAGE, new Object[]{NotifyDescriptor.OK_OPTION}, NotifyDescriptor.OK_OPTION));
-            final Throwable fnfex = new FileNotFoundException(NotifyDisplayer.BLOCK_POPUP_FLAG + "File " + filename + " not found");
+            final Throwable fnfex = new FileNotFoundException(NotifyDisplayer.BLOCK_POPUP_FLAG + errorMsg);
             fnfex.setStackTrace(ex.getStackTrace());
-            LOGGER.log(Level.SEVERE, "File " + filename + " not found", fnfex);
+            LOGGER.log(Level.SEVERE, errorMsg, fnfex);
         } catch (final TransformerException ex) {
             LOGGER.log(Level.SEVERE, ex.getLocalizedMessage(), ex);
         } catch (final IOException ex) {
-            NotifyDisplayer.display(new NotifyDescriptor("Error:\n" + "Error reading file " + filename, "Import GraphML File", DEFAULT_OPTION, 
+            final String errorMsg = "Error reading file " + filename;
+            NotifyDisplayer.display(new NotifyDescriptor("Error:\n" + errorMsg, "Import GraphML File", DEFAULT_OPTION, 
                     NotifyDescriptor.ERROR_MESSAGE, new Object[]{NotifyDescriptor.OK_OPTION}, NotifyDescriptor.OK_OPTION));
-            final Throwable ioex = new IOException(NotifyDisplayer.BLOCK_POPUP_FLAG + "Error reading file: " + filename);
+            final Throwable ioex = new IOException(NotifyDisplayer.BLOCK_POPUP_FLAG + errorMsg);
             ioex.setStackTrace(ex.getStackTrace());
-            LOGGER.log(Level.SEVERE, "Error reading file: " + filename, ioex);
+            LOGGER.log(Level.SEVERE, errorMsg, ioex);
         }
 
         output.add(nodeRecords);

--- a/CoreDataAccessView/src/au/gov/asd/tac/constellation/views/dataaccess/plugins/importing/file/GraphMLImportProcessor.java
+++ b/CoreDataAccessView/src/au/gov/asd/tac/constellation/views/dataaccess/plugins/importing/file/GraphMLImportProcessor.java
@@ -228,18 +228,18 @@ public class GraphMLImportProcessor implements GraphFileImportProcessor {
             final String errorMsg = "File " + filename + " not found";
             NotifyDisplayer.display(new NotifyDescriptor("Error:\n" + errorMsg, "Import GraphML File", DEFAULT_OPTION, 
                     NotifyDescriptor.ERROR_MESSAGE, new Object[]{NotifyDescriptor.OK_OPTION}, NotifyDescriptor.OK_OPTION));
-            final Throwable fnfex = new FileNotFoundException(NotifyDisplayer.BLOCK_POPUP_FLAG + errorMsg);
-            fnfex.setStackTrace(ex.getStackTrace());
-            LOGGER.log(Level.SEVERE, errorMsg, fnfex);
+            final Throwable fnfEx = new FileNotFoundException(NotifyDisplayer.BLOCK_POPUP_FLAG + errorMsg);
+            fnfEx.setStackTrace(ex.getStackTrace());
+            LOGGER.log(Level.SEVERE, errorMsg, fnfEx);
         } catch (final TransformerException ex) {
             LOGGER.log(Level.SEVERE, ex.getLocalizedMessage(), ex);
         } catch (final IOException ex) {
             final String errorMsg = "Error reading file " + filename;
             NotifyDisplayer.display(new NotifyDescriptor("Error:\n" + errorMsg, "Import GraphML File", DEFAULT_OPTION, 
                     NotifyDescriptor.ERROR_MESSAGE, new Object[]{NotifyDescriptor.OK_OPTION}, NotifyDescriptor.OK_OPTION));
-            final Throwable ioex = new IOException(NotifyDisplayer.BLOCK_POPUP_FLAG + errorMsg);
-            ioex.setStackTrace(ex.getStackTrace());
-            LOGGER.log(Level.SEVERE, errorMsg, ioex);
+            final Throwable ioEx = new IOException(NotifyDisplayer.BLOCK_POPUP_FLAG + errorMsg);
+            ioEx.setStackTrace(ex.getStackTrace());
+            LOGGER.log(Level.SEVERE, errorMsg, ioEx);
         }
 
         output.add(nodeRecords);

--- a/CoreDataAccessView/src/au/gov/asd/tac/constellation/views/dataaccess/plugins/importing/file/GraphMLImportProcessor.java
+++ b/CoreDataAccessView/src/au/gov/asd/tac/constellation/views/dataaccess/plugins/importing/file/GraphMLImportProcessor.java
@@ -227,13 +227,17 @@ public class GraphMLImportProcessor implements GraphFileImportProcessor {
         } catch (final FileNotFoundException ex) {
             NotifyDisplayer.display(new NotifyDescriptor("Error:\n" + "File " + filename + " not found", "Import GraphML File", DEFAULT_OPTION, 
                     NotifyDescriptor.ERROR_MESSAGE, new Object[]{NotifyDescriptor.OK_OPTION}, NotifyDescriptor.OK_OPTION));
-            LOGGER.log(Level.SEVERE, ex, () -> "File " + filename + " not found");
+            final Throwable fnfex = new FileNotFoundException(NotifyDisplayer.BLOCK_POPUP_FLAG + "File " + filename + " not found");
+            fnfex.setStackTrace(ex.getStackTrace());
+            LOGGER.log(Level.SEVERE, "File " + filename + " not found", fnfex);
         } catch (final TransformerException ex) {
             LOGGER.log(Level.SEVERE, ex.getLocalizedMessage(), ex);
         } catch (final IOException ex) {
             NotifyDisplayer.display(new NotifyDescriptor("Error:\n" + "Error reading file " + filename, "Import GraphML File", DEFAULT_OPTION, 
                     NotifyDescriptor.ERROR_MESSAGE, new Object[]{NotifyDescriptor.OK_OPTION}, NotifyDescriptor.OK_OPTION));
-            LOGGER.log(Level.SEVERE, ex, () -> "Error reading file: " + filename);
+            final Throwable ioex = new IOException(NotifyDisplayer.BLOCK_POPUP_FLAG + "Error reading file: " + filename);
+            ioex.setStackTrace(ex.getStackTrace());
+            LOGGER.log(Level.SEVERE, "Error reading file: " + filename, ioex);
         }
 
         output.add(nodeRecords);

--- a/CoreDataAccessView/src/au/gov/asd/tac/constellation/views/dataaccess/plugins/importing/file/GraphMLImportProcessor.java
+++ b/CoreDataAccessView/src/au/gov/asd/tac/constellation/views/dataaccess/plugins/importing/file/GraphMLImportProcessor.java
@@ -225,7 +225,7 @@ public class GraphMLImportProcessor implements GraphFileImportProcessor {
                 }
             }
         } catch (final FileNotFoundException ex) {
-            final String errorMsg = "File " + filename + " not found";
+            final String errorMsg = "File '" + filename + "' not found";
             NotifyDisplayer.display(new NotifyDescriptor("Error:\n" + errorMsg, "Import GraphML File", DEFAULT_OPTION, 
                     NotifyDescriptor.ERROR_MESSAGE, new Object[]{NotifyDescriptor.OK_OPTION}, NotifyDescriptor.OK_OPTION));
             final Throwable fnfEx = new FileNotFoundException(NotifyDisplayer.BLOCK_POPUP_FLAG + errorMsg);
@@ -234,7 +234,7 @@ public class GraphMLImportProcessor implements GraphFileImportProcessor {
         } catch (final TransformerException ex) {
             LOGGER.log(Level.SEVERE, ex.getLocalizedMessage(), ex);
         } catch (final IOException ex) {
-            final String errorMsg = "Error reading file " + filename;
+            final String errorMsg = "Error reading file '" + filename + "'";
             NotifyDisplayer.display(new NotifyDescriptor("Error:\n" + errorMsg, "Import GraphML File", DEFAULT_OPTION, 
                     NotifyDescriptor.ERROR_MESSAGE, new Object[]{NotifyDescriptor.OK_OPTION}, NotifyDescriptor.OK_OPTION));
             final Throwable ioEx = new IOException(NotifyDisplayer.BLOCK_POPUP_FLAG + errorMsg);

--- a/CoreDataAccessView/src/au/gov/asd/tac/constellation/views/dataaccess/plugins/importing/file/PajekImportProcessor.java
+++ b/CoreDataAccessView/src/au/gov/asd/tac/constellation/views/dataaccess/plugins/importing/file/PajekImportProcessor.java
@@ -134,16 +134,16 @@ public class PajekImportProcessor implements GraphFileImportProcessor {
             final String errorMsg = "File " + filename + " not found";
             NotifyDisplayer.display(new NotifyDescriptor("Error:\n" + errorMsg, "Import Pajek File", DEFAULT_OPTION, 
                     NotifyDescriptor.ERROR_MESSAGE, new Object[]{NotifyDescriptor.OK_OPTION}, NotifyDescriptor.OK_OPTION));
-            final Throwable fnfex = new FileNotFoundException(NotifyDisplayer.BLOCK_POPUP_FLAG + errorMsg);
-            fnfex.setStackTrace(ex.getStackTrace());
-            LOGGER.log(Level.SEVERE, errorMsg, fnfex);
+            final Throwable fnfEx = new FileNotFoundException(NotifyDisplayer.BLOCK_POPUP_FLAG + errorMsg);
+            fnfEx.setStackTrace(ex.getStackTrace());
+            LOGGER.log(Level.SEVERE, errorMsg, fnfEx);
         } catch (final IOException ex) {
             final String errorMsg = "Error reading file " + filename;
             NotifyDisplayer.display(new NotifyDescriptor("Error:\n" + errorMsg, "Import Pajek File", DEFAULT_OPTION, 
                     NotifyDescriptor.ERROR_MESSAGE, new Object[]{NotifyDescriptor.OK_OPTION}, NotifyDescriptor.OK_OPTION));
-            final Throwable ioex = new IOException(NotifyDisplayer.BLOCK_POPUP_FLAG + errorMsg);
-            ioex.setStackTrace(ex.getStackTrace());
-            LOGGER.log(Level.SEVERE, errorMsg, ioex);
+            final Throwable ioEx = new IOException(NotifyDisplayer.BLOCK_POPUP_FLAG + errorMsg);
+            ioEx.setStackTrace(ex.getStackTrace());
+            LOGGER.log(Level.SEVERE, errorMsg, ioEx);
         }
     }
 }

--- a/CoreDataAccessView/src/au/gov/asd/tac/constellation/views/dataaccess/plugins/importing/file/PajekImportProcessor.java
+++ b/CoreDataAccessView/src/au/gov/asd/tac/constellation/views/dataaccess/plugins/importing/file/PajekImportProcessor.java
@@ -133,11 +133,15 @@ public class PajekImportProcessor implements GraphFileImportProcessor {
         } catch (final FileNotFoundException ex) {
             NotifyDisplayer.display(new NotifyDescriptor("Error:\n" + "File " + filename + " not found", "Import Pajek File", DEFAULT_OPTION, 
                     NotifyDescriptor.ERROR_MESSAGE, new Object[]{NotifyDescriptor.OK_OPTION}, NotifyDescriptor.OK_OPTION));
-            LOGGER.log(Level.SEVERE, ex, () -> "File " + filename + " not found");
+            final Throwable fnfex = new FileNotFoundException(NotifyDisplayer.BLOCK_POPUP_FLAG + "File " + filename + " not found");
+            fnfex.setStackTrace(ex.getStackTrace());
+            LOGGER.log(Level.SEVERE, "File " + filename + " not found", fnfex);
         } catch (final IOException ex) {
             NotifyDisplayer.display(new NotifyDescriptor("Error:\n" + "Error reading file " + filename, "Import Pajek File", DEFAULT_OPTION, 
                     NotifyDescriptor.ERROR_MESSAGE, new Object[]{NotifyDescriptor.OK_OPTION}, NotifyDescriptor.OK_OPTION));
-            LOGGER.log(Level.SEVERE, ex, () -> "Error reading file: " + filename);
+            final Throwable ioex = new IOException(NotifyDisplayer.BLOCK_POPUP_FLAG + "Error reading file: " + filename);
+            ioex.setStackTrace(ex.getStackTrace());
+            LOGGER.log(Level.SEVERE, "Error reading file: " + filename, ioex);
         }
     }
 }

--- a/CoreDataAccessView/src/au/gov/asd/tac/constellation/views/dataaccess/plugins/importing/file/PajekImportProcessor.java
+++ b/CoreDataAccessView/src/au/gov/asd/tac/constellation/views/dataaccess/plugins/importing/file/PajekImportProcessor.java
@@ -131,14 +131,14 @@ public class PajekImportProcessor implements GraphFileImportProcessor {
                 }
             }
         } catch (final FileNotFoundException ex) {
-            final String errorMsg = "File " + filename + " not found";
+            final String errorMsg = "File '" + filename + "' not found";
             NotifyDisplayer.display(new NotifyDescriptor("Error:\n" + errorMsg, "Import Pajek File", DEFAULT_OPTION, 
                     NotifyDescriptor.ERROR_MESSAGE, new Object[]{NotifyDescriptor.OK_OPTION}, NotifyDescriptor.OK_OPTION));
             final Throwable fnfEx = new FileNotFoundException(NotifyDisplayer.BLOCK_POPUP_FLAG + errorMsg);
             fnfEx.setStackTrace(ex.getStackTrace());
             LOGGER.log(Level.SEVERE, errorMsg, fnfEx);
         } catch (final IOException ex) {
-            final String errorMsg = "Error reading file " + filename;
+            final String errorMsg = "Error reading file '" + filename + "'";
             NotifyDisplayer.display(new NotifyDescriptor("Error:\n" + errorMsg, "Import Pajek File", DEFAULT_OPTION, 
                     NotifyDescriptor.ERROR_MESSAGE, new Object[]{NotifyDescriptor.OK_OPTION}, NotifyDescriptor.OK_OPTION));
             final Throwable ioEx = new IOException(NotifyDisplayer.BLOCK_POPUP_FLAG + errorMsg);

--- a/CoreDataAccessView/src/au/gov/asd/tac/constellation/views/dataaccess/plugins/importing/file/PajekImportProcessor.java
+++ b/CoreDataAccessView/src/au/gov/asd/tac/constellation/views/dataaccess/plugins/importing/file/PajekImportProcessor.java
@@ -131,17 +131,19 @@ public class PajekImportProcessor implements GraphFileImportProcessor {
                 }
             }
         } catch (final FileNotFoundException ex) {
-            NotifyDisplayer.display(new NotifyDescriptor("Error:\n" + "File " + filename + " not found", "Import Pajek File", DEFAULT_OPTION, 
+            final String errorMsg = "File " + filename + " not found";
+            NotifyDisplayer.display(new NotifyDescriptor("Error:\n" + errorMsg, "Import Pajek File", DEFAULT_OPTION, 
                     NotifyDescriptor.ERROR_MESSAGE, new Object[]{NotifyDescriptor.OK_OPTION}, NotifyDescriptor.OK_OPTION));
-            final Throwable fnfex = new FileNotFoundException(NotifyDisplayer.BLOCK_POPUP_FLAG + "File " + filename + " not found");
+            final Throwable fnfex = new FileNotFoundException(NotifyDisplayer.BLOCK_POPUP_FLAG + errorMsg);
             fnfex.setStackTrace(ex.getStackTrace());
-            LOGGER.log(Level.SEVERE, "File " + filename + " not found", fnfex);
+            LOGGER.log(Level.SEVERE, errorMsg, fnfex);
         } catch (final IOException ex) {
-            NotifyDisplayer.display(new NotifyDescriptor("Error:\n" + "Error reading file " + filename, "Import Pajek File", DEFAULT_OPTION, 
+            final String errorMsg = "Error reading file " + filename;
+            NotifyDisplayer.display(new NotifyDescriptor("Error:\n" + errorMsg, "Import Pajek File", DEFAULT_OPTION, 
                     NotifyDescriptor.ERROR_MESSAGE, new Object[]{NotifyDescriptor.OK_OPTION}, NotifyDescriptor.OK_OPTION));
-            final Throwable ioex = new IOException(NotifyDisplayer.BLOCK_POPUP_FLAG + "Error reading file: " + filename);
+            final Throwable ioex = new IOException(NotifyDisplayer.BLOCK_POPUP_FLAG + errorMsg);
             ioex.setStackTrace(ex.getStackTrace());
-            LOGGER.log(Level.SEVERE, "Error reading file: " + filename, ioex);
+            LOGGER.log(Level.SEVERE, errorMsg, ioex);
         }
     }
 }

--- a/CoreDataAccessView/src/au/gov/asd/tac/constellation/views/dataaccess/plugins/utility/SelectTopNPlugin.java
+++ b/CoreDataAccessView/src/au/gov/asd/tac/constellation/views/dataaccess/plugins/utility/SelectTopNPlugin.java
@@ -40,6 +40,7 @@ import au.gov.asd.tac.constellation.plugins.parameters.types.SingleChoiceParamet
 import au.gov.asd.tac.constellation.plugins.parameters.types.SingleChoiceParameterType.SingleChoiceParameterValue;
 import au.gov.asd.tac.constellation.plugins.templates.PluginTags;
 import au.gov.asd.tac.constellation.plugins.templates.SimpleQueryPlugin;
+import au.gov.asd.tac.constellation.utilities.gui.NotifyDisplayer;
 import au.gov.asd.tac.constellation.views.dataaccess.plugins.DataAccessPlugin;
 import au.gov.asd.tac.constellation.views.dataaccess.plugins.DataAccessPluginCoreType;
 import java.util.ArrayList;
@@ -211,15 +212,15 @@ public class SelectTopNPlugin extends SimpleQueryPlugin implements DataAccessPlu
         final int limit = parameters.getParameters().get(LIMIT_PARAMETER_ID).getIntegerValue();
 
         if (mode == null || (!mode.equals(NODE) && !mode.equals(TRANSACTION))) {
-            throw new PluginException(PluginNotificationLevel.ERROR, "Invalid mode value provided");
+            throw new PluginException(PluginNotificationLevel.ERROR, NotifyDisplayer.BLOCK_POPUP_FLAG + "Invalid mode value provided");
         }
 
         if (typeCategory == null) {
-            throw new PluginException(PluginNotificationLevel.ERROR, "Select a type category");
+            throw new PluginException(PluginNotificationLevel.ERROR, NotifyDisplayer.BLOCK_POPUP_FLAG + "Select a type category");
         }
 
         if (subTypes.isEmpty()) {
-            throw new PluginException(PluginNotificationLevel.ERROR, "Select some types to perform the calculation");
+            throw new PluginException(PluginNotificationLevel.ERROR, NotifyDisplayer.BLOCK_POPUP_FLAG + "Select some types to perform the calculation");
         }
 
         final int vertexLabelAttribute = VisualConcept.VertexAttribute.LABEL.get(graph);

--- a/CoreDataAccessView/src/au/gov/asd/tac/constellation/views/dataaccess/plugins/utility/SelectTopNPlugin.java
+++ b/CoreDataAccessView/src/au/gov/asd/tac/constellation/views/dataaccess/plugins/utility/SelectTopNPlugin.java
@@ -40,7 +40,6 @@ import au.gov.asd.tac.constellation.plugins.parameters.types.SingleChoiceParamet
 import au.gov.asd.tac.constellation.plugins.parameters.types.SingleChoiceParameterType.SingleChoiceParameterValue;
 import au.gov.asd.tac.constellation.plugins.templates.PluginTags;
 import au.gov.asd.tac.constellation.plugins.templates.SimpleQueryPlugin;
-import au.gov.asd.tac.constellation.utilities.gui.NotifyDisplayer;
 import au.gov.asd.tac.constellation.views.dataaccess.plugins.DataAccessPlugin;
 import au.gov.asd.tac.constellation.views.dataaccess.plugins.DataAccessPluginCoreType;
 import java.util.ArrayList;
@@ -212,15 +211,15 @@ public class SelectTopNPlugin extends SimpleQueryPlugin implements DataAccessPlu
         final int limit = parameters.getParameters().get(LIMIT_PARAMETER_ID).getIntegerValue();
 
         if (mode == null || (!mode.equals(NODE) && !mode.equals(TRANSACTION))) {
-            throw new PluginException(PluginNotificationLevel.ERROR, NotifyDisplayer.BLOCK_POPUP_FLAG + "Invalid mode value provided");
+            throw new PluginException(PluginNotificationLevel.ERROR, "Invalid mode value provided");
         }
 
         if (typeCategory == null) {
-            throw new PluginException(PluginNotificationLevel.ERROR, NotifyDisplayer.BLOCK_POPUP_FLAG + "Select a type category");
+            throw new PluginException(PluginNotificationLevel.ERROR, "Select a type category");
         }
 
         if (subTypes.isEmpty()) {
-            throw new PluginException(PluginNotificationLevel.ERROR, NotifyDisplayer.BLOCK_POPUP_FLAG + "Select some types to perform the calculation");
+            throw new PluginException(PluginNotificationLevel.ERROR, "Select some types to perform the calculation");
         }
 
         final int vertexLabelAttribute = VisualConcept.VertexAttribute.LABEL.get(graph);

--- a/CoreDataAccessView/test/unit/src/au/gov/asd/tac/constellation/views/dataaccess/plugins/importing/file/GMLImportProcessorNGTest.java
+++ b/CoreDataAccessView/test/unit/src/au/gov/asd/tac/constellation/views/dataaccess/plugins/importing/file/GMLImportProcessorNGTest.java
@@ -20,7 +20,13 @@ import au.gov.asd.tac.constellation.graph.processing.ProcessingException;
 import au.gov.asd.tac.constellation.graph.processing.RecordStore;
 import au.gov.asd.tac.constellation.plugins.parameters.PluginParameters;
 import au.gov.asd.tac.constellation.views.dataaccess.plugins.importing.ImportGraphFilePlugin;
+import java.io.BufferedReader;
 import java.io.File;
+import java.io.IOException;
+import org.mockito.Mockito;
+import static org.mockito.Mockito.when;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
 import static org.testng.Assert.assertEquals;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.AfterMethod;
@@ -150,7 +156,66 @@ public class GMLImportProcessorNGTest {
         // should be one row each node in the file
         assertEquals(output.size(), 4);
     }
+
+    /**
+     * Test of process method, of class GMLImportProcessor forcing FileNotFound exception
+     * @throws au.gov.asd.tac.constellation.graph.processing.ProcessingException
+     */
+    @Test
+    public void testProcessFileNotFoundException() throws ProcessingException {
+        System.out.println("processFileNotFoundException");
+        
+        // get the parameters for processing
+        final ImportGraphFilePlugin plugin = new ImportGraphFilePlugin();
+        final PluginParameters parameters = plugin.createParameters();
+        parameters.setBooleanValue("ImportGraphFilePlugin.retrieve_transactions", false);
+        
+        // use an invalid file name to generate FileNotFound exception
+        final File file = new File("xYz");
+        
+        final RecordStore output = new GraphRecordStore();
+        
+        final GMLImportProcessor instance = new GMLImportProcessor();
+        instance.process(parameters, file, output);
+        
+        // should have no output due to the File Not Found exception
+        assertEquals(output.size(), 0);
+    }
     
+    /**
+     * Test of process method, of class GMLImportProcessor forcing IO exception
+     * @throws au.gov.asd.tac.constellation.graph.processing.ProcessingException
+     */
+    @Test
+    public void testProcessIOException() throws ProcessingException, IOException {
+        System.out.println("processIOException");
+        
+        // get the parameters for processing
+        final ImportGraphFilePlugin plugin = new ImportGraphFilePlugin();
+        final PluginParameters parameters = plugin.createParameters();
+        parameters.setBooleanValue("ImportGraphFilePlugin.retrieve_transactions", false);
+        
+        final File file = new File(GMLImportProcessorNGTest.class.getResource("resources/test.gml").getPath());
+        
+        // Mock the buffered reader to always throw an IO exception when the readLine() method is called
+        Mockito.mockConstruction(BufferedReader.class, (mock, context) -> {
+            when(mock.readLine()).thenAnswer(new Answer(){
+                @Override
+                public Object answer(InvocationOnMock iom) throws Throwable {
+                    throw new IOException("mocked IO exception");
+                }
+            });
+        });
+
+        final RecordStore output = new GraphRecordStore();
+
+        final GMLImportProcessor instance = new GMLImportProcessor();
+        instance.process(parameters, file, output);
+
+        // should have no output due to the IO exception
+        assertEquals(output.size(), 0);
+    }
+
     /**
      * Test of process method, of class GMLImportProcessor. Importing nodes and transactions
      * @throws au.gov.asd.tac.constellation.graph.processing.ProcessingException

--- a/CoreDataAccessView/test/unit/src/au/gov/asd/tac/constellation/views/dataaccess/plugins/importing/file/GMLImportProcessorNGTest.java
+++ b/CoreDataAccessView/test/unit/src/au/gov/asd/tac/constellation/views/dataaccess/plugins/importing/file/GMLImportProcessorNGTest.java
@@ -169,7 +169,7 @@ public class GMLImportProcessorNGTest {
         System.out.println("processFileNotFoundException");
         
         // Mock the NotifyDisplayer to prevent dialogs from being displayed on screen
-        try (MockedStatic<NotifyDisplayer> notiDispMock = Mockito.mockStatic(NotifyDisplayer.class)) {
+        try (final MockedStatic<NotifyDisplayer> notiDispMock = Mockito.mockStatic(NotifyDisplayer.class)) {
             // get the parameters for processing
             final ImportGraphFilePlugin plugin = new ImportGraphFilePlugin();
             final PluginParameters parameters = plugin.createParameters();
@@ -196,11 +196,11 @@ public class GMLImportProcessorNGTest {
         
         // Mock the NotifyDisplayer to prevent dialogs from being displayed on screen
         // Mock the buffered reader to always throw an IO exception when the readLine() method is called
-        try (MockedStatic<NotifyDisplayer> notiDispMock = Mockito.mockStatic(NotifyDisplayer.class);
-                MockedConstruction<BufferedReader> mockedBufferedReader = Mockito.mockConstruction(BufferedReader.class, (mock, context) -> {
+        try (final MockedStatic<NotifyDisplayer> notiDispMock = Mockito.mockStatic(NotifyDisplayer.class);
+                final MockedConstruction<BufferedReader> mockedBufferedReader = Mockito.mockConstruction(BufferedReader.class, (mock, context) -> {
                     when(mock.readLine()).thenAnswer(new Answer(){
                         @Override
-                        public Object answer(InvocationOnMock iom) throws Throwable {
+                        public Object answer(final InvocationOnMock iom) throws Throwable {
                             throw new IOException("mocked IO exception");
                         }
                     });

--- a/CoreDataAccessView/test/unit/src/au/gov/asd/tac/constellation/views/dataaccess/plugins/importing/file/GMLImportProcessorNGTest.java
+++ b/CoreDataAccessView/test/unit/src/au/gov/asd/tac/constellation/views/dataaccess/plugins/importing/file/GMLImportProcessorNGTest.java
@@ -183,40 +183,40 @@ public class GMLImportProcessorNGTest {
         assertEquals(output.size(), 0);
     }
     
-    /**
-     * Test of process method, of class GMLImportProcessor forcing IO exception
-     * @throws au.gov.asd.tac.constellation.graph.processing.ProcessingException
-     */
-    @Test
-    public void testProcessIOException() throws ProcessingException, IOException {
-        System.out.println("processIOException");
-        
-        // get the parameters for processing
-        final ImportGraphFilePlugin plugin = new ImportGraphFilePlugin();
-        final PluginParameters parameters = plugin.createParameters();
-        parameters.setBooleanValue("ImportGraphFilePlugin.retrieve_transactions", false);
-        
-        final File file = new File(GMLImportProcessorNGTest.class.getResource("resources/test.gml").getPath());
-        
-        // Mock the buffered reader to always throw an IO exception when the readLine() method is called
-        try(MockedConstruction<BufferedReader> mockedBufferedReader = Mockito.mockConstruction(BufferedReader.class, (mock, context) -> {
-                when(mock.readLine()).thenAnswer(new Answer(){
-                    @Override
-                    public Object answer(InvocationOnMock iom) throws Throwable {
-                        throw new IOException("mocked IO exception");
-                    }
-                });
-            }))
-        {
-            final RecordStore output = new GraphRecordStore();
-
-            final GMLImportProcessor instance = new GMLImportProcessor();
-            instance.process(parameters, file, output);
-
-            // should have no output due to the IO exception
-            assertEquals(output.size(), 0);
-        }
-    }
+//    /**
+//     * Test of process method, of class GMLImportProcessor forcing IO exception
+//     * @throws au.gov.asd.tac.constellation.graph.processing.ProcessingException
+//     */
+//    @Test
+//    public void testProcessIOException() throws ProcessingException, IOException {
+//        System.out.println("processIOException");
+//        
+//        // get the parameters for processing
+//        final ImportGraphFilePlugin plugin = new ImportGraphFilePlugin();
+//        final PluginParameters parameters = plugin.createParameters();
+//        parameters.setBooleanValue("ImportGraphFilePlugin.retrieve_transactions", false);
+//        
+//        final File file = new File(GMLImportProcessorNGTest.class.getResource("resources/test.gml").getPath());
+//        
+//        // Mock the buffered reader to always throw an IO exception when the readLine() method is called
+//        try (MockedConstruction<BufferedReader> mockedBufferedReader = Mockito.mockConstruction(BufferedReader.class, (mock, context) -> {
+//                when(mock.readLine()).thenAnswer(new Answer(){
+//                    @Override
+//                    public Object answer(InvocationOnMock iom) throws Throwable {
+//                        throw new IOException("mocked IO exception");
+//                    }
+//                });
+//            }))
+//        {
+//            final RecordStore output = new GraphRecordStore();
+//
+//            final GMLImportProcessor instance = new GMLImportProcessor();
+//            instance.process(parameters, file, output);
+//
+//            // should have no output due to the IO exception
+//            assertEquals(output.size(), 0);
+//        }
+//    }
 
     /**
      * Test of process method, of class GMLImportProcessor. Importing nodes and transactions

--- a/CoreDataAccessView/test/unit/src/au/gov/asd/tac/constellation/views/dataaccess/plugins/importing/file/GraphMLImportProcessorNGTest.java
+++ b/CoreDataAccessView/test/unit/src/au/gov/asd/tac/constellation/views/dataaccess/plugins/importing/file/GraphMLImportProcessorNGTest.java
@@ -171,7 +171,7 @@ public class GraphMLImportProcessorNGTest {
         System.out.println("processFileNotFoundException");
 
         // Mock the NotifyDisplayer to prevent dialogs from being displayed on screen
-        try (MockedStatic<NotifyDisplayer> notiDispMock = Mockito.mockStatic(NotifyDisplayer.class)) {        
+        try (final MockedStatic<NotifyDisplayer> notiDispMock = Mockito.mockStatic(NotifyDisplayer.class)) {        
             // get the parameters for processing
             final ImportGraphFilePlugin plugin = new ImportGraphFilePlugin();
             final PluginParameters parameters = plugin.createParameters();
@@ -198,11 +198,11 @@ public class GraphMLImportProcessorNGTest {
         
         // Mock the NotifyDisplayer to prevent dialogs from being displayed on screen
         // Mock the buffered reader to always throw an IO exception when the readLine() method is called
-        try (MockedStatic<NotifyDisplayer> notiDispMock = Mockito.mockStatic(NotifyDisplayer.class);
-                MockedConstruction<XmlUtilities> mockedXmlUtils = Mockito.mockConstruction(XmlUtilities.class, (mock, context) -> {
+        try (final MockedStatic<NotifyDisplayer> notiDispMock = Mockito.mockStatic(NotifyDisplayer.class);
+                final MockedConstruction<XmlUtilities> mockedXmlUtils = Mockito.mockConstruction(XmlUtilities.class, (mock, context) -> {
                     when(mock.read(any(InputStream.class), any(Boolean.class))).thenAnswer(new Answer(){
                         @Override
-                        public Object answer(InvocationOnMock iom) throws Throwable {
+                        public Object answer(final InvocationOnMock iom) throws Throwable {
                             throw new IOException("mocked IO exception");
                         }
                     });

--- a/CoreDataAccessView/test/unit/src/au/gov/asd/tac/constellation/views/dataaccess/plugins/importing/file/GraphMLImportProcessorNGTest.java
+++ b/CoreDataAccessView/test/unit/src/au/gov/asd/tac/constellation/views/dataaccess/plugins/importing/file/GraphMLImportProcessorNGTest.java
@@ -185,40 +185,40 @@ public class GraphMLImportProcessorNGTest {
         assertEquals(output.size(), 0);
     }
 
-    /**
-     * Test of process method, of class GraphMLImportProcessor forcing IO exception
-     * @throws au.gov.asd.tac.constellation.graph.processing.ProcessingException
-     */
-    @Test
-    public void testProcessIOException() throws ProcessingException {
-        System.out.println("processIOException");
-        
-        // get the parameters for processing
-        final ImportGraphFilePlugin plugin = new ImportGraphFilePlugin();
-        final PluginParameters parameters = plugin.createParameters();
-        parameters.setBooleanValue("ImportGraphFilePlugin.retrieve_transactions", false);
-        
-        final File file = new File(GraphMLImportProcessorNGTest.class.getResource("resources/test.graphml").getPath());
-        
-        // Mock the XmlUtilities class to always throw an IO exception when the read(*, *) method is called
-        try(MockedConstruction<XmlUtilities> mockedXmlUtils = Mockito.mockConstruction(XmlUtilities.class, (mock, context) -> {
-                when(mock.read(any(InputStream.class), any(Boolean.class))).thenAnswer(new Answer(){
-                    @Override
-                    public Object answer(InvocationOnMock iom) throws Throwable {
-                        throw new IOException("mocked IO exception");
-                    }
-                });
-            })) 
-        {
-            final RecordStore output = new GraphRecordStore();
-
-            final GraphMLImportProcessor instance = new GraphMLImportProcessor();
-            instance.process(parameters, file, output);
-
-            // should have no output due to the IO exception
-            assertEquals(output.size(), 0);
-        }
-    }
+//    /**
+//     * Test of process method, of class GraphMLImportProcessor forcing IO exception
+//     * @throws au.gov.asd.tac.constellation.graph.processing.ProcessingException
+//     */
+//    @Test
+//    public void testProcessIOException() throws ProcessingException {
+//        System.out.println("processIOException");
+//        
+//        // get the parameters for processing
+//        final ImportGraphFilePlugin plugin = new ImportGraphFilePlugin();
+//        final PluginParameters parameters = plugin.createParameters();
+//        parameters.setBooleanValue("ImportGraphFilePlugin.retrieve_transactions", false);
+//        
+//        final File file = new File(GraphMLImportProcessorNGTest.class.getResource("resources/test.graphml").getPath());
+//        
+//        // Mock the XmlUtilities class to always throw an IO exception when the read(*, *) method is called
+//        try (MockedConstruction<XmlUtilities> mockedXmlUtils = Mockito.mockConstruction(XmlUtilities.class, (mock, context) -> {
+//                when(mock.read(any(InputStream.class), any(Boolean.class))).thenAnswer(new Answer(){
+//                    @Override
+//                    public Object answer(InvocationOnMock iom) throws Throwable {
+//                        throw new IOException("mocked IO exception");
+//                    }
+//                });
+//            })) 
+//        {
+//            final RecordStore output = new GraphRecordStore();
+//
+//            final GraphMLImportProcessor instance = new GraphMLImportProcessor();
+//            instance.process(parameters, file, output);
+//
+//            // should have no output due to the IO exception
+//            assertEquals(output.size(), 0);
+//        }
+//    }
 
     /**
      * Test of process method, of class GraphMLImportProcessor. Importing nodes and transactions

--- a/CoreDataAccessView/test/unit/src/au/gov/asd/tac/constellation/views/dataaccess/plugins/importing/file/GraphMLImportProcessorNGTest.java
+++ b/CoreDataAccessView/test/unit/src/au/gov/asd/tac/constellation/views/dataaccess/plugins/importing/file/GraphMLImportProcessorNGTest.java
@@ -20,10 +20,12 @@ import au.gov.asd.tac.constellation.graph.processing.ProcessingException;
 import au.gov.asd.tac.constellation.graph.processing.RecordStore;
 import au.gov.asd.tac.constellation.plugins.parameters.PluginParameters;
 import au.gov.asd.tac.constellation.utilities.gui.NotifyDisplayer;
+import au.gov.asd.tac.constellation.utilities.xml.XmlUtilities;
 import au.gov.asd.tac.constellation.views.dataaccess.plugins.importing.ImportGraphFilePlugin;
-import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
+import static org.mockito.ArgumentMatchers.any;
 import org.mockito.MockedConstruction;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
@@ -197,14 +199,14 @@ public class GraphMLImportProcessorNGTest {
         // Mock the NotifyDisplayer to prevent dialogs from being displayed on screen
         // Mock the buffered reader to always throw an IO exception when the readLine() method is called
         try (MockedStatic<NotifyDisplayer> notiDispMock = Mockito.mockStatic(NotifyDisplayer.class);
-                MockedConstruction<BufferedReader> mockedBufferedReader = Mockito.mockConstruction(BufferedReader.class, (mock, context) -> {
-                    when(mock.readLine()).thenAnswer(new Answer(){
+                MockedConstruction<XmlUtilities> mockedXmlUtils = Mockito.mockConstruction(XmlUtilities.class, (mock, context) -> {
+                    when(mock.read(any(InputStream.class), any(Boolean.class))).thenAnswer(new Answer(){
                         @Override
                         public Object answer(InvocationOnMock iom) throws Throwable {
                             throw new IOException("mocked IO exception");
                         }
                     });
-                })                
+                })
             ) {
             // get the parameters for processing
             final ImportGraphFilePlugin plugin = new ImportGraphFilePlugin();

--- a/CoreDataAccessView/test/unit/src/au/gov/asd/tac/constellation/views/dataaccess/plugins/importing/file/GraphMLImportProcessorNGTest.java
+++ b/CoreDataAccessView/test/unit/src/au/gov/asd/tac/constellation/views/dataaccess/plugins/importing/file/GraphMLImportProcessorNGTest.java
@@ -19,13 +19,13 @@ import au.gov.asd.tac.constellation.graph.processing.GraphRecordStore;
 import au.gov.asd.tac.constellation.graph.processing.ProcessingException;
 import au.gov.asd.tac.constellation.graph.processing.RecordStore;
 import au.gov.asd.tac.constellation.plugins.parameters.PluginParameters;
-import au.gov.asd.tac.constellation.utilities.xml.XmlUtilities;
+import au.gov.asd.tac.constellation.utilities.gui.NotifyDisplayer;
 import au.gov.asd.tac.constellation.views.dataaccess.plugins.importing.ImportGraphFilePlugin;
+import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
-import java.io.InputStream;
-import static org.mockito.ArgumentMatchers.any;
 import org.mockito.MockedConstruction;
+import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import static org.mockito.Mockito.when;
 import org.mockito.invocation.InvocationOnMock;
@@ -167,58 +167,59 @@ public class GraphMLImportProcessorNGTest {
     @Test
     public void testProcessFileNotFoundException() throws ProcessingException {
         System.out.println("processFileNotFoundException");
-        
-        // get the parameters for processing
-        final ImportGraphFilePlugin plugin = new ImportGraphFilePlugin();
-        final PluginParameters parameters = plugin.createParameters();
-        parameters.setBooleanValue("ImportGraphFilePlugin.retrieve_transactions", false);
-        
-        // use an invalid file name to generate FileNotFound exception
-        final File file = new File("xYz");
-        
-        final RecordStore output = new GraphRecordStore();
-        
-        final GraphMLImportProcessor instance = new GraphMLImportProcessor();
-        instance.process(parameters, file, output);
-        
-        // should have no output due to the File Not Found exception
-        assertEquals(output.size(), 0);
+
+        // Mock the NotifyDisplayer to prevent dialogs from being displayed on screen
+        try (MockedStatic<NotifyDisplayer> notiDispMock = Mockito.mockStatic(NotifyDisplayer.class)) {        
+            // get the parameters for processing
+            final ImportGraphFilePlugin plugin = new ImportGraphFilePlugin();
+            final PluginParameters parameters = plugin.createParameters();
+            parameters.setBooleanValue("ImportGraphFilePlugin.retrieve_transactions", false);
+
+            // use an invalid file name to generate FileNotFound exception
+            final File file = new File("xYz");
+            final RecordStore output = new GraphRecordStore();
+            final GraphMLImportProcessor instance = new GraphMLImportProcessor();
+            instance.process(parameters, file, output);
+
+            // should have no output due to the File Not Found exception
+            assertEquals(output.size(), 0);
+        }
     }
 
-//    /**
-//     * Test of process method, of class GraphMLImportProcessor forcing IO exception
-//     * @throws au.gov.asd.tac.constellation.graph.processing.ProcessingException
-//     */
-//    @Test
-//    public void testProcessIOException() throws ProcessingException {
-//        System.out.println("processIOException");
-//        
-//        // get the parameters for processing
-//        final ImportGraphFilePlugin plugin = new ImportGraphFilePlugin();
-//        final PluginParameters parameters = plugin.createParameters();
-//        parameters.setBooleanValue("ImportGraphFilePlugin.retrieve_transactions", false);
-//        
-//        final File file = new File(GraphMLImportProcessorNGTest.class.getResource("resources/test.graphml").getPath());
-//        
-//        // Mock the XmlUtilities class to always throw an IO exception when the read(*, *) method is called
-//        try (MockedConstruction<XmlUtilities> mockedXmlUtils = Mockito.mockConstruction(XmlUtilities.class, (mock, context) -> {
-//                when(mock.read(any(InputStream.class), any(Boolean.class))).thenAnswer(new Answer(){
-//                    @Override
-//                    public Object answer(InvocationOnMock iom) throws Throwable {
-//                        throw new IOException("mocked IO exception");
-//                    }
-//                });
-//            })) 
-//        {
-//            final RecordStore output = new GraphRecordStore();
-//
-//            final GraphMLImportProcessor instance = new GraphMLImportProcessor();
-//            instance.process(parameters, file, output);
-//
-//            // should have no output due to the IO exception
-//            assertEquals(output.size(), 0);
-//        }
-//    }
+    /**
+     * Test of process method, of class GraphMLImportProcessor forcing IO exception
+     * @throws au.gov.asd.tac.constellation.graph.processing.ProcessingException
+     */
+    @Test
+    public void testProcessIOException() throws ProcessingException {
+        System.out.println("processIOException");
+        
+        // Mock the NotifyDisplayer to prevent dialogs from being displayed on screen
+        // Mock the buffered reader to always throw an IO exception when the readLine() method is called
+        try (MockedStatic<NotifyDisplayer> notiDispMock = Mockito.mockStatic(NotifyDisplayer.class);
+                MockedConstruction<BufferedReader> mockedBufferedReader = Mockito.mockConstruction(BufferedReader.class, (mock, context) -> {
+                    when(mock.readLine()).thenAnswer(new Answer(){
+                        @Override
+                        public Object answer(InvocationOnMock iom) throws Throwable {
+                            throw new IOException("mocked IO exception");
+                        }
+                    });
+                })                
+            ) {
+            // get the parameters for processing
+            final ImportGraphFilePlugin plugin = new ImportGraphFilePlugin();
+            final PluginParameters parameters = plugin.createParameters();
+            parameters.setBooleanValue("ImportGraphFilePlugin.retrieve_transactions", false);
+
+            final File file = new File(GraphMLImportProcessorNGTest.class.getResource("resources/test.graphml").getPath());
+            final RecordStore output = new GraphRecordStore();
+            final GraphMLImportProcessor instance = new GraphMLImportProcessor();
+            instance.process(parameters, file, output);
+
+            // should have no output due to the IO exception
+            assertEquals(output.size(), 0);
+        }
+    }
 
     /**
      * Test of process method, of class GraphMLImportProcessor. Importing nodes and transactions

--- a/CoreDataAccessView/test/unit/src/au/gov/asd/tac/constellation/views/dataaccess/plugins/importing/file/PajekImportProcessorNGTest.java
+++ b/CoreDataAccessView/test/unit/src/au/gov/asd/tac/constellation/views/dataaccess/plugins/importing/file/PajekImportProcessorNGTest.java
@@ -183,40 +183,40 @@ public class PajekImportProcessorNGTest {
         assertEquals(output.size(), 0);
     }
     
-    /**
-     * Test of process method, of class PajekImportProcessor forcing IO exception
-     * @throws au.gov.asd.tac.constellation.graph.processing.ProcessingException
-     */
-    @Test
-    public void testProcessIOException() throws ProcessingException {
-        System.out.println("processIOException");
-        
-        // get the parameters for processing
-        final ImportGraphFilePlugin plugin = new ImportGraphFilePlugin();
-        final PluginParameters parameters = plugin.createParameters();
-        parameters.setBooleanValue("ImportGraphFilePlugin.retrieve_transactions", false);
-        
-        final File file = new File(PajekImportProcessorNGTest.class.getResource("resources/test.net").getPath());
-
-        // Mock the buffered reader to always throw an IO exception when the readLine() method is called
-        try(MockedConstruction<BufferedReader> mockedBufferedReader = Mockito.mockConstruction(BufferedReader.class, (mock, context) -> {
-                when(mock.readLine()).thenAnswer(new Answer(){
-                    @Override
-                    public Object answer(InvocationOnMock iom) throws Throwable {
-                        throw new IOException("mocked IO exception");
-                    }
-                });
-            }))
-        {        
-            final RecordStore output = new GraphRecordStore();
-
-            final PajekImportProcessor instance = new PajekImportProcessor();
-            instance.process(parameters, file, output);
-
-            // should have no output due to the IO exception
-            assertEquals(output.size(), 0);
-        }
-    }
+//    /**
+//     * Test of process method, of class PajekImportProcessor forcing IO exception
+//     * @throws au.gov.asd.tac.constellation.graph.processing.ProcessingException
+//     */
+//    @Test
+//    public void testProcessIOException() throws ProcessingException {
+//        System.out.println("processIOException");
+//        
+//        // get the parameters for processing
+//        final ImportGraphFilePlugin plugin = new ImportGraphFilePlugin();
+//        final PluginParameters parameters = plugin.createParameters();
+//        parameters.setBooleanValue("ImportGraphFilePlugin.retrieve_transactions", false);
+//        
+//        final File file = new File(PajekImportProcessorNGTest.class.getResource("resources/test.net").getPath());
+//
+//        // Mock the buffered reader to always throw an IO exception when the readLine() method is called
+//        try (MockedConstruction<BufferedReader> mockedBufferedReader = Mockito.mockConstruction(BufferedReader.class, (mock, context) -> {
+//                when(mock.readLine()).thenAnswer(new Answer(){
+//                    @Override
+//                    public Object answer(InvocationOnMock iom) throws Throwable {
+//                        throw new IOException("mocked IO exception");
+//                    }
+//                });
+//            }))
+//        {
+//            final RecordStore output = new GraphRecordStore();
+//
+//            final PajekImportProcessor instance = new PajekImportProcessor();
+//            instance.process(parameters, file, output);
+//
+//            // should have no output due to the IO exception
+//            assertEquals(output.size(), 0);
+//        }
+//    }
     
     /**
      * Test of process method, of class PajekImportProcessor. Importing nodes and transactions

--- a/CoreDataAccessView/test/unit/src/au/gov/asd/tac/constellation/views/dataaccess/plugins/importing/file/PajekImportProcessorNGTest.java
+++ b/CoreDataAccessView/test/unit/src/au/gov/asd/tac/constellation/views/dataaccess/plugins/importing/file/PajekImportProcessorNGTest.java
@@ -20,7 +20,13 @@ import au.gov.asd.tac.constellation.graph.processing.ProcessingException;
 import au.gov.asd.tac.constellation.graph.processing.RecordStore;
 import au.gov.asd.tac.constellation.plugins.parameters.PluginParameters;
 import au.gov.asd.tac.constellation.views.dataaccess.plugins.importing.ImportGraphFilePlugin;
+import java.io.BufferedReader;
 import java.io.File;
+import java.io.IOException;
+import org.mockito.Mockito;
+import static org.mockito.Mockito.when;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
 import static org.testng.Assert.assertEquals;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.AfterMethod;
@@ -149,6 +155,65 @@ public class PajekImportProcessorNGTest {
         
         // should be one row each node in the file
         assertEquals(output.size(), 4);
+    }
+    
+    /**
+     * Test of process method, of class PajekImportProcessor forcing FileNotFound exception
+     * @throws au.gov.asd.tac.constellation.graph.processing.ProcessingException
+     */
+    @Test
+    public void testProcessFileNotFoundException() throws ProcessingException {
+        System.out.println("processFileNotFoundException");
+        
+        // get the parameters for processing
+        final ImportGraphFilePlugin plugin = new ImportGraphFilePlugin();
+        final PluginParameters parameters = plugin.createParameters();
+        parameters.setBooleanValue("ImportGraphFilePlugin.retrieve_transactions", false);
+        
+        // use an invalid file name to generate FileNotFound exception
+        final File file = new File("xYz");
+        
+        final RecordStore output = new GraphRecordStore();
+        
+        final PajekImportProcessor instance = new PajekImportProcessor();
+        instance.process(parameters, file, output);
+        
+        // should have no output due to the File Not Found exception
+        assertEquals(output.size(), 0);
+    }
+    
+    /**
+     * Test of process method, of class PajekImportProcessor forcing IO exception
+     * @throws au.gov.asd.tac.constellation.graph.processing.ProcessingException
+     */
+    @Test
+    public void testProcessIOException() throws ProcessingException {
+        System.out.println("processIOException");
+        
+        // get the parameters for processing
+        final ImportGraphFilePlugin plugin = new ImportGraphFilePlugin();
+        final PluginParameters parameters = plugin.createParameters();
+        parameters.setBooleanValue("ImportGraphFilePlugin.retrieve_transactions", false);
+        
+        final File file = new File(PajekImportProcessorNGTest.class.getResource("resources/test.net").getPath());
+
+        // Mock the buffered reader to always throw an IO exception when the readLine() method is called
+        Mockito.mockConstruction(BufferedReader.class, (mock, context) -> {
+            when(mock.readLine()).thenAnswer(new Answer(){
+                @Override
+                public Object answer(InvocationOnMock iom) throws Throwable {
+                    throw new IOException("mocked IO exception");
+                }
+            });
+        });
+        
+        final RecordStore output = new GraphRecordStore();
+        
+        final PajekImportProcessor instance = new PajekImportProcessor();
+        instance.process(parameters, file, output);
+        
+        // should have no output due to the IO exception
+        assertEquals(output.size(), 0);
     }
     
     /**

--- a/CoreDataAccessView/test/unit/src/au/gov/asd/tac/constellation/views/dataaccess/plugins/importing/file/PajekImportProcessorNGTest.java
+++ b/CoreDataAccessView/test/unit/src/au/gov/asd/tac/constellation/views/dataaccess/plugins/importing/file/PajekImportProcessorNGTest.java
@@ -19,11 +19,13 @@ import au.gov.asd.tac.constellation.graph.processing.GraphRecordStore;
 import au.gov.asd.tac.constellation.graph.processing.ProcessingException;
 import au.gov.asd.tac.constellation.graph.processing.RecordStore;
 import au.gov.asd.tac.constellation.plugins.parameters.PluginParameters;
+import au.gov.asd.tac.constellation.utilities.gui.NotifyDisplayer;
 import au.gov.asd.tac.constellation.views.dataaccess.plugins.importing.ImportGraphFilePlugin;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
 import org.mockito.MockedConstruction;
+import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import static org.mockito.Mockito.when;
 import org.mockito.invocation.InvocationOnMock;
@@ -166,57 +168,58 @@ public class PajekImportProcessorNGTest {
     public void testProcessFileNotFoundException() throws ProcessingException {
         System.out.println("processFileNotFoundException");
         
-        // get the parameters for processing
-        final ImportGraphFilePlugin plugin = new ImportGraphFilePlugin();
-        final PluginParameters parameters = plugin.createParameters();
-        parameters.setBooleanValue("ImportGraphFilePlugin.retrieve_transactions", false);
-        
-        // use an invalid file name to generate FileNotFound exception
-        final File file = new File("xYz");
-        
-        final RecordStore output = new GraphRecordStore();
-        
-        final PajekImportProcessor instance = new PajekImportProcessor();
-        instance.process(parameters, file, output);
-        
-        // should have no output due to the File Not Found exception
-        assertEquals(output.size(), 0);
+        // Mock the NotifyDisplayer to prevent dialogs from being displayed on screen
+        try (MockedStatic<NotifyDisplayer> notiDispMock = Mockito.mockStatic(NotifyDisplayer.class)) {
+            // get the parameters for processing
+            final ImportGraphFilePlugin plugin = new ImportGraphFilePlugin();
+            final PluginParameters parameters = plugin.createParameters();
+            parameters.setBooleanValue("ImportGraphFilePlugin.retrieve_transactions", false);
+
+            // use an invalid file name to generate FileNotFound exception
+            final File file = new File("xYz");
+            final RecordStore output = new GraphRecordStore();
+            final PajekImportProcessor instance = new PajekImportProcessor();
+            instance.process(parameters, file, output);
+
+            // should have no output due to the File Not Found exception
+            assertEquals(output.size(), 0);
+        }
     }
     
-//    /**
-//     * Test of process method, of class PajekImportProcessor forcing IO exception
-//     * @throws au.gov.asd.tac.constellation.graph.processing.ProcessingException
-//     */
-//    @Test
-//    public void testProcessIOException() throws ProcessingException {
-//        System.out.println("processIOException");
-//        
-//        // get the parameters for processing
-//        final ImportGraphFilePlugin plugin = new ImportGraphFilePlugin();
-//        final PluginParameters parameters = plugin.createParameters();
-//        parameters.setBooleanValue("ImportGraphFilePlugin.retrieve_transactions", false);
-//        
-//        final File file = new File(PajekImportProcessorNGTest.class.getResource("resources/test.net").getPath());
-//
-//        // Mock the buffered reader to always throw an IO exception when the readLine() method is called
-//        try (MockedConstruction<BufferedReader> mockedBufferedReader = Mockito.mockConstruction(BufferedReader.class, (mock, context) -> {
-//                when(mock.readLine()).thenAnswer(new Answer(){
-//                    @Override
-//                    public Object answer(InvocationOnMock iom) throws Throwable {
-//                        throw new IOException("mocked IO exception");
-//                    }
-//                });
-//            }))
-//        {
-//            final RecordStore output = new GraphRecordStore();
-//
-//            final PajekImportProcessor instance = new PajekImportProcessor();
-//            instance.process(parameters, file, output);
-//
-//            // should have no output due to the IO exception
-//            assertEquals(output.size(), 0);
-//        }
-//    }
+    /**
+     * Test of process method, of class PajekImportProcessor forcing IO exception
+     * @throws au.gov.asd.tac.constellation.graph.processing.ProcessingException
+     */
+    @Test
+    public void testProcessIOException() throws ProcessingException {
+        System.out.println("processIOException");
+        
+        // Mock the NotifyDisplayer to prevent dialogs from being displayed on screen
+        // Mock the buffered reader to always throw an IO exception when the readLine() method is called
+        try (MockedStatic<NotifyDisplayer> notiDispMock = Mockito.mockStatic(NotifyDisplayer.class);
+                MockedConstruction<BufferedReader> mockedBufferedReader = Mockito.mockConstruction(BufferedReader.class, (mock, context) -> {
+                    when(mock.readLine()).thenAnswer(new Answer(){
+                        @Override
+                        public Object answer(InvocationOnMock iom) throws Throwable {
+                            throw new IOException("mocked IO exception");
+                        }
+                    });
+                })                
+            ) {
+            // get the parameters for processing
+            final ImportGraphFilePlugin plugin = new ImportGraphFilePlugin();
+            final PluginParameters parameters = plugin.createParameters();
+            parameters.setBooleanValue("ImportGraphFilePlugin.retrieve_transactions", false);
+
+            final File file = new File(PajekImportProcessorNGTest.class.getResource("resources/test.net").getPath());
+            final RecordStore output = new GraphRecordStore();
+            final PajekImportProcessor instance = new PajekImportProcessor();
+            instance.process(parameters, file, output);
+
+            // should have no output due to the IO exception
+            assertEquals(output.size(), 0);
+        }
+    }
     
     /**
      * Test of process method, of class PajekImportProcessor. Importing nodes and transactions

--- a/CoreDataAccessView/test/unit/src/au/gov/asd/tac/constellation/views/dataaccess/plugins/importing/file/PajekImportProcessorNGTest.java
+++ b/CoreDataAccessView/test/unit/src/au/gov/asd/tac/constellation/views/dataaccess/plugins/importing/file/PajekImportProcessorNGTest.java
@@ -23,6 +23,7 @@ import au.gov.asd.tac.constellation.views.dataaccess.plugins.importing.ImportGra
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
+import org.mockito.MockedConstruction;
 import org.mockito.Mockito;
 import static org.mockito.Mockito.when;
 import org.mockito.invocation.InvocationOnMock;
@@ -198,22 +199,23 @@ public class PajekImportProcessorNGTest {
         final File file = new File(PajekImportProcessorNGTest.class.getResource("resources/test.net").getPath());
 
         // Mock the buffered reader to always throw an IO exception when the readLine() method is called
-        Mockito.mockConstruction(BufferedReader.class, (mock, context) -> {
-            when(mock.readLine()).thenAnswer(new Answer(){
-                @Override
-                public Object answer(InvocationOnMock iom) throws Throwable {
-                    throw new IOException("mocked IO exception");
-                }
-            });
-        });
-        
-        final RecordStore output = new GraphRecordStore();
-        
-        final PajekImportProcessor instance = new PajekImportProcessor();
-        instance.process(parameters, file, output);
-        
-        // should have no output due to the IO exception
-        assertEquals(output.size(), 0);
+        try(MockedConstruction<BufferedReader> mockedBufferedReader = Mockito.mockConstruction(BufferedReader.class, (mock, context) -> {
+                when(mock.readLine()).thenAnswer(new Answer(){
+                    @Override
+                    public Object answer(InvocationOnMock iom) throws Throwable {
+                        throw new IOException("mocked IO exception");
+                    }
+                });
+            }))
+        {        
+            final RecordStore output = new GraphRecordStore();
+
+            final PajekImportProcessor instance = new PajekImportProcessor();
+            instance.process(parameters, file, output);
+
+            // should have no output due to the IO exception
+            assertEquals(output.size(), 0);
+        }
     }
     
     /**

--- a/CoreDataAccessView/test/unit/src/au/gov/asd/tac/constellation/views/dataaccess/plugins/importing/file/PajekImportProcessorNGTest.java
+++ b/CoreDataAccessView/test/unit/src/au/gov/asd/tac/constellation/views/dataaccess/plugins/importing/file/PajekImportProcessorNGTest.java
@@ -169,7 +169,7 @@ public class PajekImportProcessorNGTest {
         System.out.println("processFileNotFoundException");
         
         // Mock the NotifyDisplayer to prevent dialogs from being displayed on screen
-        try (MockedStatic<NotifyDisplayer> notiDispMock = Mockito.mockStatic(NotifyDisplayer.class)) {
+        try (final MockedStatic<NotifyDisplayer> notiDispMock = Mockito.mockStatic(NotifyDisplayer.class)) {
             // get the parameters for processing
             final ImportGraphFilePlugin plugin = new ImportGraphFilePlugin();
             final PluginParameters parameters = plugin.createParameters();
@@ -196,11 +196,11 @@ public class PajekImportProcessorNGTest {
         
         // Mock the NotifyDisplayer to prevent dialogs from being displayed on screen
         // Mock the buffered reader to always throw an IO exception when the readLine() method is called
-        try (MockedStatic<NotifyDisplayer> notiDispMock = Mockito.mockStatic(NotifyDisplayer.class);
-                MockedConstruction<BufferedReader> mockedBufferedReader = Mockito.mockConstruction(BufferedReader.class, (mock, context) -> {
+        try (final MockedStatic<NotifyDisplayer> notiDispMock = Mockito.mockStatic(NotifyDisplayer.class);
+                final MockedConstruction<BufferedReader> mockedBufferedReader = Mockito.mockConstruction(BufferedReader.class, (mock, context) -> {
                     when(mock.readLine()).thenAnswer(new Answer(){
                         @Override
-                        public Object answer(InvocationOnMock iom) throws Throwable {
+                        public Object answer(final InvocationOnMock iom) throws Throwable {
                             throw new IOException("mocked IO exception");
                         }
                     });

--- a/CoreErrorReportView/src/au/gov/asd/tac/constellation/views/errorreport/ErrorReportEntry.java
+++ b/CoreErrorReportView/src/au/gov/asd/tac/constellation/views/errorreport/ErrorReportEntry.java
@@ -88,6 +88,10 @@ public class ErrorReportEntry {
         return summaryHeading;
     }
 
+    public void setSummaryHeading(final String revisedSummary) {
+        summaryHeading = revisedSummary;
+    }
+    
     public void incrementOccurrences() {
         occurrences++;
         lastDate = new Date();
@@ -168,11 +172,14 @@ public class ErrorReportEntry {
     public String toString() {
         return "[ErrorReportEntry:[id=" + entryId + "]"
                 + ", [header=" + heading + "]"
+                + ", [summaryHeading=" + summaryHeading + "]"
                 + ", [errorLevel=" + errorLevel.getName() + "]"
+                + ", [errorData_length=" + errorData.length() + "]"
                 + ", [occurrences=" + occurrences + "]"
                 + ", [lastDate=" + lastDate + "]"
                 + ", [lastPopupDate=" + lastPopupDate + "]"
                 + ", [preventRepeatedPopups=" + preventRepeatedPopups + "]"
+                + ", [expanded=" + expanded + "]"
                 + ", [dialog=" + dialog + "]"
                 + "]";
     }

--- a/CoreErrorReportView/src/au/gov/asd/tac/constellation/views/errorreport/ErrorReportEntry.java
+++ b/CoreErrorReportView/src/au/gov/asd/tac/constellation/views/errorreport/ErrorReportEntry.java
@@ -170,17 +170,17 @@ public class ErrorReportEntry {
     
     @Override
     public String toString() {
-        return "[ErrorReportEntry:[id=" + entryId + "]"
-                + ", [header=" + heading + "]"
-                + ", [summaryHeading=" + summaryHeading + "]"
-                + ", [errorLevel=" + errorLevel.getName() + "]"
-                + ", [errorData_length=" + errorData.length() + "]"
-                + ", [occurrences=" + occurrences + "]"
-                + ", [lastDate=" + lastDate + "]"
-                + ", [lastPopupDate=" + lastPopupDate + "]"
-                + ", [preventRepeatedPopups=" + preventRepeatedPopups + "]"
-                + ", [expanded=" + expanded + "]"
-                + ", [dialog=" + dialog + "]"
+        return "[ErrorReportEntry:[id=" + getEntryId() + "]"
+                + ", [header=" + getHeading() + "]"
+                + ", [summaryHeading=" + getSummaryHeading() + "]"
+                + ", [errorLevel=" + getErrorLevel().getName() + "]"
+                + ", [errorData_length=" + getErrorData().length() + "]"
+                + ", [occurrences=" + getOccurrences() + "]"
+                + ", [lastDate=" + getLastDate() + "]"
+                + ", [lastPopupDate=" + getLastPopupDate() + "]"
+                + ", [preventRepeatedPopups=" + isBlockRepeatedPopups() + "]"
+                + ", [expanded=" + isExpanded() + "]"
+                + ", [dialog=" + getDialog() + "]"
                 + "]";
     }
 }

--- a/CoreErrorReportView/src/au/gov/asd/tac/constellation/views/errorreport/ErrorReportSessionData.java
+++ b/CoreErrorReportView/src/au/gov/asd/tac/constellation/views/errorreport/ErrorReportSessionData.java
@@ -78,6 +78,7 @@ public class ErrorReportSessionData {
                     ere.incrementOccurrences();
                     ere.setExpanded(true);
                     ere.setHeading(entry.getHeading());
+                    ere.setSummaryHeading(entry.getSummaryHeading());
                     foundMatch = true;
                     if (i > 0) {
                         // move updated entry to the top

--- a/CoreErrorReportView/test/unit/src/au/gov/asd/tac/constellation/views/errorreport/ErrorReportFullSuiteNGTest.java
+++ b/CoreErrorReportView/test/unit/src/au/gov/asd/tac/constellation/views/errorreport/ErrorReportFullSuiteNGTest.java
@@ -220,6 +220,7 @@ public class ErrorReportFullSuiteNGTest {
         ertcInstance.setReportsExpanded(false);
         ertcInstance.refreshSessionErrors();
         final ErrorReportEntry checkEntry = ertcInstance.findActiveEntryWithId(storedList.get(0).getEntryId());
+        System.out.println("\n>>>> Check ErrorReportEntry : " + checkEntry.toString());
         assertFalse(checkEntry.isExpanded());
         
         dismissPopups(storedList);

--- a/CoreFunctionality/src/au/gov/asd/tac/constellation/functionality/ConstellationErrorManager.java
+++ b/CoreFunctionality/src/au/gov/asd/tac/constellation/functionality/ConstellationErrorManager.java
@@ -39,15 +39,15 @@ public class ConstellationErrorManager extends Handler {
             final StringBuilder errorMsg = new StringBuilder();
             final Level errLevel = errorRecord.getLevel();
             final String errorSummary = errorRecord.getThrown().toString();
-            final int firstColon = errorSummary.indexOf(":");
+            final int firstColon = errorSummary.indexOf(SeparatorConstants.COLON);
             String extractedMessage = firstColon != -1 ? errorSummary.substring(firstColon + 2) : "";
             final boolean autoBlockPopup = extractedMessage.startsWith(NotifyDisplayer.BLOCK_POPUP_FLAG);
             if (autoBlockPopup) {
                 extractedMessage = extractedMessage.substring(NotifyDisplayer.BLOCK_POPUP_FLAG.length());
             }
-            final int prevDotPos = errorSummary.substring(0, (firstColon != -1 ? firstColon : errorSummary.length())).lastIndexOf(".");
+            final int prevDotPos = errorSummary.substring(0, (firstColon != -1 ? firstColon : errorSummary.length())).lastIndexOf(SeparatorConstants.PERIOD);
             final String exceptionType = errorSummary.substring(prevDotPos + 1, (firstColon != -1 ? firstColon : errorSummary.length()));
-            String recordHeader = "".equals(extractedMessage) ? exceptionType : extractedMessage;
+            String recordHeader = extractedMessage.isEmpty() ? exceptionType : extractedMessage;
             String revisedSummary = errorSummary.substring(0, firstColon + 1) 
                                     + errorSummary.substring(firstColon + 1 + (autoBlockPopup ? NotifyDisplayer.BLOCK_POPUP_FLAG.length() : 0));
             if (!revisedSummary.endsWith(SeparatorConstants.NEWLINE)) {

--- a/CoreFunctionality/src/au/gov/asd/tac/constellation/functionality/ConstellationErrorManager.java
+++ b/CoreFunctionality/src/au/gov/asd/tac/constellation/functionality/ConstellationErrorManager.java
@@ -48,12 +48,15 @@ public class ConstellationErrorManager extends Handler {
             final int prevDotPos = errorSummary.substring(0, (firstColon != -1 ? firstColon : errorSummary.length())).lastIndexOf(".");
             final String exceptionType = errorSummary.substring(prevDotPos + 1, (firstColon != -1 ? firstColon : errorSummary.length()));
             String recordHeader = "".equals(extractedMessage) ? exceptionType : extractedMessage;
-            String revisedSummary = errorSummary.substring(0, firstColon + 1) + errorSummary.substring(firstColon + 1 + (autoBlockPopup ? NotifyDisplayer.BLOCK_POPUP_FLAG.length() : 0));
+            String revisedSummary = errorSummary.substring(0, firstColon + 1) 
+                                    + errorSummary.substring(firstColon + 1 + (autoBlockPopup ? NotifyDisplayer.BLOCK_POPUP_FLAG.length() : 0));
             if (!revisedSummary.endsWith(SeparatorConstants.NEWLINE)) {
                 revisedSummary += SeparatorConstants.NEWLINE;
             }
             if (elems == null || elems.length == 0) {
-                errorMsg.append(" >> No stacktrace available for error:").append(SeparatorConstants.NEWLINE).append(" >> ").append(recordHeader);
+                errorMsg.append(" >> No stacktrace available for error:")
+                        .append(SeparatorConstants.NEWLINE).append(" >> ")
+                        .append(recordHeader);
             } else {
                 for (int i = 0; i < elems.length; i++) {
                     errorMsg.append(elems[i].toString())
@@ -64,8 +67,9 @@ public class ConstellationErrorManager extends Handler {
                 recordHeader += SeparatorConstants.NEWLINE;
             }
 
-            final ErrorReportEntry repEntry = new ErrorReportEntry(errLevel, recordHeader, revisedSummary, errorMsg.toString(), 
-                                                                   ErrorReportSessionData.getNextEntryId());
+            final ErrorReportEntry repEntry = new ErrorReportEntry( errLevel, recordHeader, 
+                                                                    revisedSummary, errorMsg.toString(), 
+                                                                    ErrorReportSessionData.getNextEntryId());
             if (autoBlockPopup) {
                 repEntry.setBlockRepeatedPopups(true);
                 repEntry.setLastPopupDate(new Date());

--- a/CoreFunctionality/src/au/gov/asd/tac/constellation/functionality/ConstellationErrorManager.java
+++ b/CoreFunctionality/src/au/gov/asd/tac/constellation/functionality/ConstellationErrorManager.java
@@ -47,7 +47,7 @@ public class ConstellationErrorManager extends Handler {
             }
             final int prevDotPos = errorSummary.substring(0, (firstColon != -1 ? firstColon : errorSummary.length())).lastIndexOf(".");
             final String exceptionType = errorSummary.substring(prevDotPos + 1, (firstColon != -1 ? firstColon : errorSummary.length()));
-            String recordHeader = extractedMessage.equals("") ? exceptionType : extractedMessage;
+            String recordHeader = "".equals(extractedMessage) ? exceptionType : extractedMessage;
             String revisedSummary = errorSummary.substring(0, firstColon + 1) + errorSummary.substring(firstColon + 1 + (autoBlockPopup ? NotifyDisplayer.BLOCK_POPUP_FLAG.length() : 0));
             if (!revisedSummary.endsWith(SeparatorConstants.NEWLINE)) {
                 revisedSummary += SeparatorConstants.NEWLINE;

--- a/CoreFunctionality/test/unit/src/au/gov/asd/tac/constellation/functionality/ConstellationErrorManagerNGTest.java
+++ b/CoreFunctionality/test/unit/src/au/gov/asd/tac/constellation/functionality/ConstellationErrorManagerNGTest.java
@@ -15,6 +15,7 @@
  */
 package au.gov.asd.tac.constellation.functionality;
 
+import au.gov.asd.tac.constellation.utilities.gui.NotifyDisplayer;
 import au.gov.asd.tac.constellation.views.errorreport.ErrorReportDialogManager;
 import au.gov.asd.tac.constellation.views.errorreport.ErrorReportEntry;
 import au.gov.asd.tac.constellation.views.errorreport.ErrorReportSessionData;
@@ -52,10 +53,10 @@ public class ConstellationErrorManagerNGTest {
         LOGGER.setLevel(Level.ALL);
         
         // generate exception log messages
-        simulateException(Level.SEVERE);
-        simulateException(Level.WARNING);
-        simulateException(Level.INFO);
-        simulateException(Level.FINE);
+        simulateException(Level.SEVERE, false);
+        simulateException(Level.WARNING, false);
+        simulateException(Level.INFO, false);
+        simulateException(Level.FINE, false);
 
         LOGGER.log(Level.INFO, "\n ------- start wait for data ... {0}", new Date());
         boolean dataAvailable = waitForDataToBeAvailable(Level.SEVERE, 1);
@@ -71,7 +72,7 @@ public class ConstellationErrorManagerNGTest {
         confirmEntryOccurrences(Level.SEVERE, 1);
         
         // NOTE: the following 2 calls NEED to be on the SAME LINE to generate identical stack traces
-        simulateException(Level.SEVERE); simulateException(Level.SEVERE);
+        simulateException(Level.SEVERE, false); simulateException(Level.SEVERE, false);
         
         LOGGER.log(Level.INFO, "\n ------- 2.start wait for data ... {0}", new Date());
         dataAvailable = waitForDataToBeAvailable(Level.SEVERE, 2);
@@ -81,11 +82,14 @@ public class ConstellationErrorManagerNGTest {
         // confirm correct number of entries and occurrences
         confirmExceptionStored(Level.SEVERE, 2);
         confirmEntryOccurrences(Level.SEVERE, 2);
+        
+        simulateException(Level.SEVERE, true);
+        confirmExceptionStored(Level.SEVERE, 3);
     }
     
-    private void simulateException(final Level logLevel){
+    private void simulateException(final Level logLevel, final boolean autoBlockPopup){
         LOGGER.log(Level.INFO, "\n ------- simulating {0} exception", logLevel.getName());
-        final Exception e = new Exception("Something totally not unexpected happened !");
+        final Exception e = new Exception((autoBlockPopup ? NotifyDisplayer.BLOCK_POPUP_FLAG : "") + "Something totally not unexpected happened !");
         LOGGER.log(logLevel, "Simulating a " + logLevel.getName() + " exception !", e);
         LOGGER.info("\n ------- simulated.");
     }

--- a/CoreGraphNode/src/au/gov/asd/tac/constellation/graph/node/plugins/DefaultPluginEnvironment.java
+++ b/CoreGraphNode/src/au/gov/asd/tac/constellation/graph/node/plugins/DefaultPluginEnvironment.java
@@ -432,7 +432,12 @@ public class DefaultPluginEnvironment extends PluginEnvironment {
             interaction.notify(PluginNotificationLevel.INFO, message);
             LOGGER.log(Level.INFO, message, ex);
         } else if (ex instanceof PluginException) {
-            final String displayMessage =  ex.getLocalizedMessage() == null ? "null" : ex.getLocalizedMessage().startsWith(NotifyDisplayer.BLOCK_POPUP_FLAG) ? ex.getLocalizedMessage().substring(NotifyDisplayer.BLOCK_POPUP_FLAG.length()): ex.getLocalizedMessage();
+            final String displayMessage;
+            if (ex.getLocalizedMessage() == null) {
+                displayMessage = "null";
+            } else {
+                displayMessage = ex.getLocalizedMessage().startsWith(NotifyDisplayer.BLOCK_POPUP_FLAG) ? ex.getLocalizedMessage().substring(NotifyDisplayer.BLOCK_POPUP_FLAG.length()): ex.getLocalizedMessage();
+            }
             interaction.notify(level, displayMessage);
             final PluginException nonPopupEx = new PluginException(PluginNotificationLevel.ERROR, NotifyDisplayer.BLOCK_POPUP_FLAG + displayMessage);
             nonPopupEx.setStackTrace(ex.getStackTrace() != null ? ex.getStackTrace() : new StackTraceElement[]{});

--- a/CoreGraphNode/src/au/gov/asd/tac/constellation/graph/node/plugins/DefaultPluginEnvironment.java
+++ b/CoreGraphNode/src/au/gov/asd/tac/constellation/graph/node/plugins/DefaultPluginEnvironment.java
@@ -432,10 +432,10 @@ public class DefaultPluginEnvironment extends PluginEnvironment {
             interaction.notify(PluginNotificationLevel.INFO, message);
             LOGGER.log(Level.INFO, message, ex);
         } else if (ex instanceof PluginException) {
-            final String displayMessage =  ex.getLocalizedMessage().startsWith(NotifyDisplayer.BLOCK_POPUP_FLAG) ? ex.getLocalizedMessage().substring(NotifyDisplayer.BLOCK_POPUP_FLAG.length()): ex.getLocalizedMessage();
+            final String displayMessage =  ex.getLocalizedMessage() == null ? "null" : ex.getLocalizedMessage().startsWith(NotifyDisplayer.BLOCK_POPUP_FLAG) ? ex.getLocalizedMessage().substring(NotifyDisplayer.BLOCK_POPUP_FLAG.length()): ex.getLocalizedMessage();
             interaction.notify(level, displayMessage);
             final PluginException nonPopupEx = new PluginException(PluginNotificationLevel.ERROR, NotifyDisplayer.BLOCK_POPUP_FLAG + displayMessage);
-            nonPopupEx.setStackTrace(ex.getStackTrace());
+            nonPopupEx.setStackTrace(ex.getStackTrace() != null ? ex.getStackTrace() : new StackTraceElement[]{});
             LOGGER.log(Level.INFO, String.format("Plugin exception caught in %s", pluginName), nonPopupEx);
         } else {
             final String message = String.format("Unexpected exception caught in %s", pluginName);

--- a/CoreGraphNode/src/au/gov/asd/tac/constellation/graph/node/plugins/DefaultPluginEnvironment.java
+++ b/CoreGraphNode/src/au/gov/asd/tac/constellation/graph/node/plugins/DefaultPluginEnvironment.java
@@ -31,11 +31,11 @@ import au.gov.asd.tac.constellation.plugins.parameters.PluginParameters;
 import au.gov.asd.tac.constellation.plugins.reporting.GraphReport;
 import au.gov.asd.tac.constellation.plugins.reporting.GraphReportManager;
 import au.gov.asd.tac.constellation.plugins.reporting.PluginReport;
+import au.gov.asd.tac.constellation.utilities.gui.NotifyDisplayer;
 import au.gov.asd.tac.constellation.utilities.threadpool.ConstellationGlobalThreadPool;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -432,8 +432,11 @@ public class DefaultPluginEnvironment extends PluginEnvironment {
             interaction.notify(PluginNotificationLevel.INFO, message);
             LOGGER.log(Level.INFO, message, ex);
         } else if (ex instanceof PluginException) {
-            interaction.notify(level, ex.getLocalizedMessage());
-            LOGGER.log(Level.INFO, String.format("Plugin exception caught in %s", pluginName), ex);
+            final String displayMessage =  ex.getLocalizedMessage().startsWith(NotifyDisplayer.BLOCK_POPUP_FLAG) ? ex.getLocalizedMessage().substring(NotifyDisplayer.BLOCK_POPUP_FLAG.length()): ex.getLocalizedMessage();
+            interaction.notify(level, displayMessage);
+            final PluginException nonPopupEx = new PluginException(PluginNotificationLevel.ERROR, NotifyDisplayer.BLOCK_POPUP_FLAG + displayMessage);
+            nonPopupEx.setStackTrace(ex.getStackTrace());
+            LOGGER.log(Level.INFO, String.format("Plugin exception caught in %s", pluginName), nonPopupEx);
         } else {
             final String message = String.format("Unexpected exception caught in %s", pluginName);
             switch (level) {

--- a/CoreImportExportPlugins/src/au/gov/asd/tac/constellation/plugins/importexport/TemplateUtilities.java
+++ b/CoreImportExportPlugins/src/au/gov/asd/tac/constellation/plugins/importexport/TemplateUtilities.java
@@ -72,7 +72,7 @@ public class TemplateUtilities {
             final String message = String.format("Missing field '%s' in the template. Add the missing field"
                     + " manually or use a new template.", fieldName);
             NotifyDisplayer.displayAlert(LOAD_TEMPLATE, "Template Error", message, Alert.AlertType.ERROR);
-            throw new NoSuchElementException(message);
+            throw new NoSuchElementException(NotifyDisplayer.BLOCK_POPUP_FLAG + message);
         }
     }
 

--- a/CoreImportExportPlugins/src/au/gov/asd/tac/constellation/plugins/importexport/delimited/DelimitedImportController.java
+++ b/CoreImportExportPlugins/src/au/gov/asd/tac/constellation/plugins/importexport/delimited/DelimitedImportController.java
@@ -203,9 +203,9 @@ public class DelimitedImportController extends ImportController {
             } catch (final FileNotFoundException ex) {
                 final String warningMsg = "The following file could not be found "
                         + "and has been excluded from the import set:\n  " + sampleFile.getPath();
-                final Throwable fnfex = new FileNotFoundException(NotifyDisplayer.BLOCK_POPUP_FLAG + warningMsg);
-                fnfex.setStackTrace(ex.getStackTrace());
-                LOGGER.log(Level.INFO, warningMsg, fnfex);
+                final Throwable fnfEx = new FileNotFoundException(NotifyDisplayer.BLOCK_POPUP_FLAG + warningMsg);
+                fnfEx.setStackTrace(ex.getStackTrace());
+                LOGGER.log(Level.INFO, warningMsg, fnfEx);
                 NotifyDisplayer.displayAlert("Delimited File Import", "Invalid file selected",
                         warningMsg, Alert.AlertType.WARNING);
                 files.remove(sampleFile);
@@ -213,9 +213,9 @@ public class DelimitedImportController extends ImportController {
             } catch (final IOException ex) {
                 final String warningMsg = "The following file could not be parsed and has "
                         + "been excluded from the import set:\n  " + sampleFile.getPath();
-                final Throwable ioex = new IOException(NotifyDisplayer.BLOCK_POPUP_FLAG + warningMsg);
-                ioex.setStackTrace(ex.getStackTrace());
-                LOGGER.log(Level.INFO, warningMsg, ioex);
+                final Throwable ioEx = new IOException(NotifyDisplayer.BLOCK_POPUP_FLAG + warningMsg);
+                ioEx.setStackTrace(ex.getStackTrace());
+                LOGGER.log(Level.INFO, warningMsg, ioEx);
                 NotifyDisplayer.displayAlert("Delimited File Import", "Invalid file selected", warningMsg,
                         Alert.AlertType.WARNING);
                 files.remove(sampleFile);

--- a/CoreImportExportPlugins/src/au/gov/asd/tac/constellation/plugins/importexport/delimited/DelimitedImportController.java
+++ b/CoreImportExportPlugins/src/au/gov/asd/tac/constellation/plugins/importexport/delimited/DelimitedImportController.java
@@ -203,7 +203,9 @@ public class DelimitedImportController extends ImportController {
             } catch (final FileNotFoundException ex) {
                 final String warningMsg = "The following file could not be found "
                         + "and has been excluded from the import set:\n  " + sampleFile.getPath();
-                LOGGER.log(Level.INFO, warningMsg, ex);
+                final Throwable fnfex = new FileNotFoundException(NotifyDisplayer.BLOCK_POPUP_FLAG + warningMsg);
+                fnfex.setStackTrace(ex.getStackTrace());
+                LOGGER.log(Level.INFO, warningMsg, fnfex);
                 NotifyDisplayer.displayAlert("Delimited File Import", "Invalid file selected",
                         warningMsg, Alert.AlertType.WARNING);
                 files.remove(sampleFile);
@@ -211,7 +213,9 @@ public class DelimitedImportController extends ImportController {
             } catch (final IOException ex) {
                 final String warningMsg = "The following file could not be parsed and has "
                         + "been excluded from the import set:\n  " + sampleFile.getPath();
-                LOGGER.log(Level.INFO, warningMsg, ex);
+                final Throwable ioex = new IOException(NotifyDisplayer.BLOCK_POPUP_FLAG + warningMsg);
+                ioex.setStackTrace(ex.getStackTrace());
+                LOGGER.log(Level.INFO, warningMsg, ioex);
                 NotifyDisplayer.displayAlert("Delimited File Import", "Invalid file selected", warningMsg,
                         Alert.AlertType.WARNING);
                 files.remove(sampleFile);

--- a/CoreImportExportPlugins/src/au/gov/asd/tac/constellation/plugins/importexport/delimited/ImportDelimitedIO.java
+++ b/CoreImportExportPlugins/src/au/gov/asd/tac/constellation/plugins/importexport/delimited/ImportDelimitedIO.java
@@ -200,7 +200,9 @@ public final class ImportDelimitedIO {
             } catch (final IOException ex) {
                 NotifyDisplayer.display(String.format("Can't save import definition: %s", ex.getMessage()),
                         NotifyDescriptor.ERROR_MESSAGE);
-                LOGGER.log(Level.WARNING, ex.getMessage(), ex);
+                final Throwable ioex = new IOException(NotifyDisplayer.BLOCK_POPUP_FLAG + ex.getMessage());
+                ioex.setStackTrace(ex.getStackTrace());
+                LOGGER.log(Level.WARNING, ex.getMessage(), ioex);
             }
         }
     }

--- a/CoreImportExportPlugins/src/au/gov/asd/tac/constellation/plugins/importexport/delimited/ImportDelimitedIO.java
+++ b/CoreImportExportPlugins/src/au/gov/asd/tac/constellation/plugins/importexport/delimited/ImportDelimitedIO.java
@@ -200,9 +200,9 @@ public final class ImportDelimitedIO {
             } catch (final IOException ex) {
                 NotifyDisplayer.display(String.format("Can't save import definition: %s", ex.getMessage()),
                         NotifyDescriptor.ERROR_MESSAGE);
-                final Throwable ioex = new IOException(NotifyDisplayer.BLOCK_POPUP_FLAG + ex.getMessage());
-                ioex.setStackTrace(ex.getStackTrace());
-                LOGGER.log(Level.WARNING, ex.getMessage(), ioex);
+                final Throwable ioEx = new IOException(NotifyDisplayer.BLOCK_POPUP_FLAG + ex.getMessage());
+                ioEx.setStackTrace(ex.getStackTrace());
+                LOGGER.log(Level.WARNING, ex.getMessage(), ioEx);
             }
         }
     }

--- a/CoreImportExportPlugins/src/au/gov/asd/tac/constellation/plugins/importexport/translator/ScriptAttributeTranslator.java
+++ b/CoreImportExportPlugins/src/au/gov/asd/tac/constellation/plugins/importexport/translator/ScriptAttributeTranslator.java
@@ -101,7 +101,9 @@ public class ScriptAttributeTranslator extends AttributeTranslator {
                 savedLanguage = null;
                 savedScript = null;
                 parameters.getParameters().get(SCRIPT_PARAMETER_ID).setStringValue(DEFAULT_SCRIPT);
-                LOGGER.log(Level.SEVERE, ex.getLocalizedMessage(), ex);
+                final Throwable screx = new ScriptException(NotifyDisplayer.BLOCK_POPUP_FLAG + ex.getLocalizedMessage());
+                screx.setStackTrace(ex.getStackTrace());
+                LOGGER.log(Level.SEVERE, ex.getLocalizedMessage(), screx);
                 NotifyDisplayer.display(ex.getMessage(), NotifyDescriptor.ERROR_MESSAGE);
                 return value;
             }

--- a/CoreImportExportPlugins/src/au/gov/asd/tac/constellation/plugins/importexport/translator/ScriptAttributeTranslator.java
+++ b/CoreImportExportPlugins/src/au/gov/asd/tac/constellation/plugins/importexport/translator/ScriptAttributeTranslator.java
@@ -101,9 +101,9 @@ public class ScriptAttributeTranslator extends AttributeTranslator {
                 savedLanguage = null;
                 savedScript = null;
                 parameters.getParameters().get(SCRIPT_PARAMETER_ID).setStringValue(DEFAULT_SCRIPT);
-                final Throwable screx = new ScriptException(NotifyDisplayer.BLOCK_POPUP_FLAG + ex.getLocalizedMessage());
-                screx.setStackTrace(ex.getStackTrace());
-                LOGGER.log(Level.SEVERE, ex.getLocalizedMessage(), screx);
+                final Throwable scrEx = new ScriptException(NotifyDisplayer.BLOCK_POPUP_FLAG + ex.getLocalizedMessage());
+                scrEx.setStackTrace(ex.getStackTrace());
+                LOGGER.log(Level.SEVERE, ex.getLocalizedMessage(), scrEx);
                 NotifyDisplayer.display(ex.getMessage(), NotifyDescriptor.ERROR_MESSAGE);
                 return value;
             }

--- a/CoreInteractiveGraph/src/au/gov/asd/tac/constellation/graph/interaction/plugins/io/AutosaveStartup.java
+++ b/CoreInteractiveGraph/src/au/gov/asd/tac/constellation/graph/interaction/plugins/io/AutosaveStartup.java
@@ -92,14 +92,14 @@ public final class AutosaveStartup implements Runnable {
 
                                             AutosaveUtilities.deleteAutosave(f);
                                         } catch (GraphParseException | IOException ex) {
-                                            final Throwable gpioex;
+                                            final Throwable gpioEx;
                                             if (ex instanceof IOException) {
-                                                gpioex = new IOException(NotifyDisplayer.BLOCK_POPUP_FLAG + GRAPH_LOAD_ERROR);
+                                                gpioEx = new IOException(NotifyDisplayer.BLOCK_POPUP_FLAG + GRAPH_LOAD_ERROR);
                                             } else {
-                                                gpioex = new GraphParseException(NotifyDisplayer.BLOCK_POPUP_FLAG + GRAPH_LOAD_ERROR);
+                                                gpioEx = new GraphParseException(NotifyDisplayer.BLOCK_POPUP_FLAG + GRAPH_LOAD_ERROR);
                                             }
-                                            gpioex.setStackTrace(ex.getStackTrace());
-                                            LOGGER.log(Level.WARNING, GRAPH_LOAD_ERROR, gpioex);
+                                            gpioEx.setStackTrace(ex.getStackTrace());
+                                            LOGGER.log(Level.WARNING, GRAPH_LOAD_ERROR, gpioEx);
                                             NotifyDisplayer.display("Error loading graph: " + ex.getMessage(), NotifyDescriptor.ERROR_MESSAGE);
                                         }
                                     }

--- a/CoreInteractiveGraph/src/au/gov/asd/tac/constellation/graph/interaction/plugins/io/AutosaveStartup.java
+++ b/CoreInteractiveGraph/src/au/gov/asd/tac/constellation/graph/interaction/plugins/io/AutosaveStartup.java
@@ -91,7 +91,14 @@ public final class AutosaveStartup implements Runnable {
 
                                             AutosaveUtilities.deleteAutosave(f);
                                         } catch (GraphParseException | IOException ex) {
-                                            LOGGER.log(Level.WARNING, "Error loading graph", ex);
+                                            final Throwable gpioex;
+                                            if (ex instanceof IOException) {
+                                                gpioex = new IOException(NotifyDisplayer.BLOCK_POPUP_FLAG + "Error loading graph");
+                                            } else {
+                                                gpioex = new GraphParseException(NotifyDisplayer.BLOCK_POPUP_FLAG + "Error loading graph");
+                                            }
+                                            gpioex.setStackTrace(ex.getStackTrace());
+                                            LOGGER.log(Level.WARNING, "Error loading graph", gpioex);
                                             NotifyDisplayer.display("Error loading graph: " + ex.getMessage(), NotifyDescriptor.ERROR_MESSAGE);
                                         }
                                     }

--- a/CoreInteractiveGraph/src/au/gov/asd/tac/constellation/graph/interaction/plugins/io/AutosaveStartup.java
+++ b/CoreInteractiveGraph/src/au/gov/asd/tac/constellation/graph/interaction/plugins/io/AutosaveStartup.java
@@ -47,6 +47,7 @@ import org.openide.windows.OnShowing;
 public final class AutosaveStartup implements Runnable {
 
     private static final String AUTOSAVE_THREAD_NAME = "Autosave Startup";
+    private static final String GRAPH_LOAD_ERROR = "Error Loading Graph";
     private static final Logger LOGGER = Logger.getLogger(AutosaveStartup.class.getName());
     /**
      * The number of milliseconds after which we purge old autosaves.
@@ -93,12 +94,12 @@ public final class AutosaveStartup implements Runnable {
                                         } catch (GraphParseException | IOException ex) {
                                             final Throwable gpioex;
                                             if (ex instanceof IOException) {
-                                                gpioex = new IOException(NotifyDisplayer.BLOCK_POPUP_FLAG + "Error loading graph");
+                                                gpioex = new IOException(NotifyDisplayer.BLOCK_POPUP_FLAG + GRAPH_LOAD_ERROR);
                                             } else {
-                                                gpioex = new GraphParseException(NotifyDisplayer.BLOCK_POPUP_FLAG + "Error loading graph");
+                                                gpioex = new GraphParseException(NotifyDisplayer.BLOCK_POPUP_FLAG + GRAPH_LOAD_ERROR);
                                             }
                                             gpioex.setStackTrace(ex.getStackTrace());
-                                            LOGGER.log(Level.WARNING, "Error loading graph", gpioex);
+                                            LOGGER.log(Level.WARNING, GRAPH_LOAD_ERROR, gpioex);
                                             NotifyDisplayer.display("Error loading graph: " + ex.getMessage(), NotifyDescriptor.ERROR_MESSAGE);
                                         }
                                     }

--- a/CoreUtilities/src/au/gov/asd/tac/constellation/utilities/gui/NotifyDisplayer.java
+++ b/CoreUtilities/src/au/gov/asd/tac/constellation/utilities/gui/NotifyDisplayer.java
@@ -39,6 +39,8 @@ import org.openide.awt.NotificationDisplayer;
 public class NotifyDisplayer {
 
     private static final Logger LOGGER = Logger.getLogger(NotifyDisplayer.class.getName());
+    
+    public static final String BLOCK_POPUP_FLAG = "## ";
 
     /**
      * Utility display method to show a dialog to the user.

--- a/CoreUtilities/src/au/gov/asd/tac/constellation/utilities/gui/NotifyDisplayer.java
+++ b/CoreUtilities/src/au/gov/asd/tac/constellation/utilities/gui/NotifyDisplayer.java
@@ -40,7 +40,7 @@ public class NotifyDisplayer {
 
     private static final Logger LOGGER = Logger.getLogger(NotifyDisplayer.class.getName());
     
-    public static final String BLOCK_POPUP_FLAG = "## ";
+    public static final String BLOCK_POPUP_FLAG = "!^ ";
 
     /**
      * Utility display method to show a dialog to the user.


### PR DESCRIPTION
<!--

### Requirements

* Filling out the template is required. Any pull request that does not include
enough information to be reviewed in a timely manner may be closed at the
maintainers' discretion.
* All new code requires unit tests to ensure they work as expected and will
continue to work as new code is added in the future (regression testing).
* Make sure your branch name is prefixed by `feature`, `bugfix` or `release`
* Have you read Constellation's Code of Conduct? By filing an issue, you are
expected to comply with it, including treating everyone with respect:
https://github.com/constellation-app/constellation/blob/master/CODE_OF_CONDUCT.md

-->

### Prerequisites

- [ ] Reviewed the [checklist](CHECKLIST.md)

- [ ] Reviewed feedback from the "Sonar Cloud" bot. Note that you have to wait
    for the "CI / Unit Tests") to complete first. Failed Unit tests can be 
    debugged by adding the label "verbose logging" to the GitHub PR.

### Description of the Change

Addresses issues raised in #1641 

When a plugin shows a notification to the user, it should no longer show an exception popup as well.

This is achieved by setting a block-popups flag on the Error Report that is generated when the exception is logged.

Note that this Pull Request only covers plugins that are part of the core "constellation" repo.
There will be a separate Pull Request for the plugins that are defined in the "constellation-adaptors" repo.

<!--

We must be able to understand the design of your change from this description.
If we can't get a good idea of what the code will be doing from the description
here, the pull request may be closed at the maintainers' discretion. Keep in
mind that the maintainer reviewing this PR may not be familiar with or have
worked with the code here recently, so please walk us through the concepts.

-->

### Alternate Designs
None
<!--

Explain what other alternates were considered and why the proposed version was
selected.

-->

### Why Should This Be In Core?

It should be a consistent standard across the product to have notification popups without an accompanying exception dialog.

<!--

Explain why this functionality should be in Constellation Core as opposed to a
different module suite. Note that this question is more applicable when adding
new functionality. If this change is a minor update to an existing file then it
is understood that this change has to be to this module suite and a response
and therefore a response to this question is not required.

-->

### Benefits

Improved user experience.
No need to show an exception dialog as well as a simple notification when that notification alone will suffice.

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks
None

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process

Test these core plugins (from those listed in #1641):
* Import from GraphML file
* Import from GML file
* Import from Pajek file
* Extract types from text
* Utility > Select Top Node and the Import Options

Trying to run each plugin without completing the required details should cause a notification to be displayed.
For many cases, there should also be an Error Report generated and listed in the Error Report View.
For errors with an associated Error Report entry, confirm that the block-popups icon is showing on those entries.

Note that some plugins will throw an INFO severity level error.
The Error Report View will not show INFO popups by default. 
The default behaviour can be set in the Report Settings control.
<!--

What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (e.g. buttons you clicked, text you typed,
commands you ran, etc.), and describe the results you observed.

-->

### Applicable Issues

#1641 
<!-- Link any applicable issues here -->
