### PR TITLE
Prevent auto-selecting plugins on the Data Access View.

### DIFF
--- a/CoreDataAccessView/src/au/gov/asd/tac/constellation/views/dataaccess/DataAccessViewTopComponent.java
+++ b/CoreDataAccessView/src/au/gov/asd/tac/constellation/views/dataaccess/DataAccessViewTopComponent.java
@@ -24,7 +24,6 @@ import au.gov.asd.tac.constellation.views.dataaccess.panes.DataAccessPane;
 import au.gov.asd.tac.constellation.views.dataaccess.utilities.DataAccessUtilities;
 import au.gov.asd.tac.constellation.views.qualitycontrol.daemon.QualityControlAutoVetter;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import javafx.application.Platform;
 import org.openide.awt.ActionID;
 import org.openide.awt.ActionReference;
@@ -68,6 +67,8 @@ public final class DataAccessViewTopComponent extends JavaFxTopComponent<DataAcc
     private final ExecutorService executorService = ConstellationGlobalThreadPool.getThreadPool().getFixedThreadPool();
     
     private final DataAccessPane dataAccessPane;
+    
+    private static boolean graphLoaded = false;
 
     /**
      * Create a new data access view.
@@ -145,14 +146,19 @@ public final class DataAccessViewTopComponent extends JavaFxTopComponent<DataAcc
 
     @Override
     protected void handleNewGraph(final Graph graph) {
+        graphLoaded = false;
         if (needsUpdate() && getDataAccessPane() != null) {
             getDataAccessPane().update(graph);
-            Platform.runLater(() -> 
-                DataAccessUtilities.loadDataAccessState(getDataAccessPane(), graph)
-            );
+            Platform.runLater(() -> {
+                DataAccessUtilities.loadDataAccessState(getDataAccessPane(), graph);
+                Platform.runLater(() -> graphLoaded = true); // nested runLater so it runs after all the other triggered processes for opening a graph
+            });
         }
     }
 
+    public static boolean isGraphLoaded() {
+        return graphLoaded;
+    }
     /**
      * This method is called from within the constructor to initialize the form.
      * WARNING: Do NOT modify this code. The content of this method is always

--- a/CoreDataAccessView/src/au/gov/asd/tac/constellation/views/dataaccess/DataAccessViewTopComponent.java
+++ b/CoreDataAccessView/src/au/gov/asd/tac/constellation/views/dataaccess/DataAccessViewTopComponent.java
@@ -68,8 +68,6 @@ public final class DataAccessViewTopComponent extends JavaFxTopComponent<DataAcc
     
     private final DataAccessPane dataAccessPane;
     
-    private static boolean graphLoaded = false;
-
     /**
      * Create a new data access view.
      */
@@ -146,7 +144,7 @@ public final class DataAccessViewTopComponent extends JavaFxTopComponent<DataAcc
 
     @Override
     protected void handleNewGraph(final Graph graph) {
-        DataAccessViewTopComponent.setGraphLoaded(false);
+        System.setProperty("dav.graph.ready", Boolean.FALSE.toString());
         if (needsUpdate() && getDataAccessPane() != null) {
             getDataAccessPane().update(graph);
             Platform.runLater(() ->
@@ -154,17 +152,9 @@ public final class DataAccessViewTopComponent extends JavaFxTopComponent<DataAcc
             );
         }
         Platform.runLater(() ->
-                // nested runLater so it runs after all the other triggered processes for opening a graph
-                Platform.runLater(() -> DataAccessViewTopComponent.setGraphLoaded(true))
+                // nested runLater so it runs after all the other triggered processes for opening a graph have been run
+                Platform.runLater(() -> System.setProperty("dav.graph.ready", Boolean.TRUE.toString()))
         );
-    }
-
-    public static boolean isGraphLoaded() {
-        return graphLoaded;
-    }
-    
-    public static void setGraphLoaded(final boolean isLoaded) {
-        graphLoaded = isLoaded;
     }
     
     /**

--- a/CoreDataAccessView/src/au/gov/asd/tac/constellation/views/dataaccess/DataAccessViewTopComponent.java
+++ b/CoreDataAccessView/src/au/gov/asd/tac/constellation/views/dataaccess/DataAccessViewTopComponent.java
@@ -146,19 +146,27 @@ public final class DataAccessViewTopComponent extends JavaFxTopComponent<DataAcc
 
     @Override
     protected void handleNewGraph(final Graph graph) {
-        graphLoaded = false;
+        DataAccessViewTopComponent.setGraphLoaded(false);
         if (needsUpdate() && getDataAccessPane() != null) {
             getDataAccessPane().update(graph);
-            Platform.runLater(() -> {
-                DataAccessUtilities.loadDataAccessState(getDataAccessPane(), graph);
-                Platform.runLater(() -> graphLoaded = true); // nested runLater so it runs after all the other triggered processes for opening a graph
-            });
+            Platform.runLater(() ->
+                DataAccessUtilities.loadDataAccessState(getDataAccessPane(), graph)
+            );
         }
+        Platform.runLater(() ->
+                // nested runLater so it runs after all the other triggered processes for opening a graph
+                Platform.runLater(() -> DataAccessViewTopComponent.setGraphLoaded(true))
+        );
     }
 
     public static boolean isGraphLoaded() {
         return graphLoaded;
     }
+    
+    public static void setGraphLoaded(final boolean isLoaded) {
+        graphLoaded = isLoaded;
+    }
+    
     /**
      * This method is called from within the constructor to initialize the form.
      * WARNING: Do NOT modify this code. The content of this method is always

--- a/CoreDataAccessView/src/au/gov/asd/tac/constellation/views/dataaccess/panes/DataSourceTitledPane.java
+++ b/CoreDataAccessView/src/au/gov/asd/tac/constellation/views/dataaccess/panes/DataSourceTitledPane.java
@@ -25,7 +25,6 @@ import au.gov.asd.tac.constellation.plugins.parameters.types.ActionParameterType
 import au.gov.asd.tac.constellation.utilities.color.ConstellationColor;
 import au.gov.asd.tac.constellation.utilities.icon.UserInterfaceIconProvider;
 import au.gov.asd.tac.constellation.utilities.threadpool.ConstellationGlobalThreadPool;
-import au.gov.asd.tac.constellation.views.dataaccess.DataAccessViewTopComponent;
 import au.gov.asd.tac.constellation.views.dataaccess.plugins.DataAccessPlugin;
 import au.gov.asd.tac.constellation.views.dataaccess.plugins.DataAccessPluginCoreType;
 import au.gov.asd.tac.constellation.views.dataaccess.utilities.DataAccessPreferenceUtilities;
@@ -130,8 +129,9 @@ public class DataSourceTitledPane extends TitledPane implements PluginParameters
     
     @Override
     public void validityChanged(final boolean allowEnabling) {
-        if (!DataAccessViewTopComponent.isGraphLoaded()) {
-            return;
+        if (System.getProperty("dav.graph.ready") == null || 
+            System.getProperty("dav.graph.ready").equals(Boolean.FALSE.toString())) {
+                return;
         }
         final boolean isEnabled = parametersCreated && allowEnabling;
         enabled.setSelected(isEnabled);

--- a/CoreDataAccessView/src/au/gov/asd/tac/constellation/views/dataaccess/panes/DataSourceTitledPane.java
+++ b/CoreDataAccessView/src/au/gov/asd/tac/constellation/views/dataaccess/panes/DataSourceTitledPane.java
@@ -25,6 +25,7 @@ import au.gov.asd.tac.constellation.plugins.parameters.types.ActionParameterType
 import au.gov.asd.tac.constellation.utilities.color.ConstellationColor;
 import au.gov.asd.tac.constellation.utilities.icon.UserInterfaceIconProvider;
 import au.gov.asd.tac.constellation.utilities.threadpool.ConstellationGlobalThreadPool;
+import au.gov.asd.tac.constellation.views.dataaccess.DataAccessViewTopComponent;
 import au.gov.asd.tac.constellation.views.dataaccess.plugins.DataAccessPlugin;
 import au.gov.asd.tac.constellation.views.dataaccess.plugins.DataAccessPluginCoreType;
 import au.gov.asd.tac.constellation.views.dataaccess.utilities.DataAccessPreferenceUtilities;
@@ -32,7 +33,6 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javafx.application.Platform;
@@ -130,7 +130,10 @@ public class DataSourceTitledPane extends TitledPane implements PluginParameters
     
     @Override
     public void validityChanged(final boolean allowEnabling) {
-        final boolean isEnabled = parametersCreated && allowEnabling && enabled.isSelected();
+        if (!DataAccessViewTopComponent.isGraphLoaded()) {
+            return;
+        }
+        final boolean isEnabled = parametersCreated && allowEnabling;
         enabled.setSelected(isEnabled);
         if (enabled.isSelected()) {
             while (getStyleClass().contains(MATCHED_STYLE)) {

--- a/CoreDataAccessView/src/au/gov/asd/tac/constellation/views/dataaccess/panes/DataSourceTitledPane.java
+++ b/CoreDataAccessView/src/au/gov/asd/tac/constellation/views/dataaccess/panes/DataSourceTitledPane.java
@@ -129,8 +129,8 @@ public class DataSourceTitledPane extends TitledPane implements PluginParameters
     }
     
     @Override
-    public void validityChanged(boolean isEnabled) {
-        isEnabled = parametersCreated && isEnabled;
+    public void validityChanged(final boolean allowEnabling) {
+        final boolean isEnabled = parametersCreated && allowEnabling && enabled.isSelected();
         enabled.setSelected(isEnabled);
         if (enabled.isSelected()) {
             while (getStyleClass().contains(MATCHED_STYLE)) {

--- a/CoreDataAccessView/src/au/gov/asd/tac/constellation/views/dataaccess/panes/DataSourceTitledPane.java
+++ b/CoreDataAccessView/src/au/gov/asd/tac/constellation/views/dataaccess/panes/DataSourceTitledPane.java
@@ -129,9 +129,9 @@ public class DataSourceTitledPane extends TitledPane implements PluginParameters
     
     @Override
     public void validityChanged(final boolean allowEnabling) {
-        if (System.getProperty("dav.graph.ready") == null || 
-            System.getProperty("dav.graph.ready").equals(Boolean.FALSE.toString())) {
-                return;
+        if (System.getProperty("dav.graph.ready") == null
+                || System.getProperty("dav.graph.ready").equals(Boolean.FALSE.toString())) {
+            return;
         }
         final boolean isEnabled = parametersCreated && allowEnabling;
         enabled.setSelected(isEnabled);


### PR DESCRIPTION

### Prerequisites

- [ ] Reviewed the [checklist](CHECKLIST.md)

- [ ] Reviewed feedback from the "Sonar Cloud" bot. Note that you have to wait
    for the "CI / Unit Tests") to complete first. Failed Unit tests can be 
    debugged by adding the label "verbose logging" to the GitHub PR.

### Description of the Change

Opening and closing graphs should not auto-select plugins in the Data Access View.

### Alternate Designs

N/A

### Why Should This Be In Core?

To have the application perform in an expected manner.

### Benefits

To prevent unexpected plugins being selected without any user interaction.

### Possible Drawbacks

None

### Verification Process

Expand all Data Access View plugins.
Ensure they are all unselected.
Open a new graph.
Confirm that none of the plugins have been auto-selected.

### Applicable Issues

#1829 
