### PR TITLE
Improved notification for File Not Found error when no file specified.

### DIFF
--- a/CoreDataAccessView/src/au/gov/asd/tac/constellation/views/dataaccess/plugins/importing/file/GMLImportProcessor.java
+++ b/CoreDataAccessView/src/au/gov/asd/tac/constellation/views/dataaccess/plugins/importing/file/GMLImportProcessor.java
@@ -37,6 +37,7 @@ import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javafx.stage.FileChooser.ExtensionFilter;
+import org.apache.commons.lang3.StringUtils;
 import org.openide.NotifyDescriptor;
 import static org.openide.NotifyDescriptor.DEFAULT_OPTION;
 import org.openide.util.lookup.ServiceProvider;
@@ -159,14 +160,14 @@ public class GMLImportProcessor implements GraphFileImportProcessor {
                         nodeIdToType.get(edgeRecords.get(i, GraphRecordStoreUtilities.DESTINATION + VisualConcept.VertexAttribute.IDENTIFIER)));
             }
         } catch (final FileNotFoundException ex) {
-            final String errorMsg = "File '" + filename + "' not found";
+            final String errorMsg = StringUtils.isEmpty(filename) ? "File not specified" : "File not found: " + filename;
             NotifyDisplayer.display(new NotifyDescriptor("Error:\n" + errorMsg, "Import GML File", DEFAULT_OPTION, 
                     NotifyDescriptor.ERROR_MESSAGE, new Object[]{NotifyDescriptor.OK_OPTION}, NotifyDescriptor.OK_OPTION));
             final Throwable fnfEx = new FileNotFoundException(NotifyDisplayer.BLOCK_POPUP_FLAG + errorMsg);
             fnfEx.setStackTrace(ex.getStackTrace());
             LOGGER.log(Level.SEVERE, errorMsg, fnfEx);
         } catch (final IOException ex) {
-            final String errorMsg = "Error reading file '" + filename + "'";
+            final String errorMsg = StringUtils.isEmpty(filename) ? "File not specified " : "Error reading file: " + filename;
             NotifyDisplayer.display(new NotifyDescriptor("Error:\n" + errorMsg, "Import GML File", DEFAULT_OPTION, 
                     NotifyDescriptor.ERROR_MESSAGE, new Object[]{NotifyDescriptor.OK_OPTION}, NotifyDescriptor.OK_OPTION));
             final Throwable ioEx = new IOException(NotifyDisplayer.BLOCK_POPUP_FLAG + errorMsg);

--- a/CoreDataAccessView/src/au/gov/asd/tac/constellation/views/dataaccess/plugins/importing/file/GraphMLImportProcessor.java
+++ b/CoreDataAccessView/src/au/gov/asd/tac/constellation/views/dataaccess/plugins/importing/file/GraphMLImportProcessor.java
@@ -39,6 +39,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import javafx.stage.FileChooser.ExtensionFilter;
 import javax.xml.transform.TransformerException;
+import org.apache.commons.lang3.StringUtils;
 import org.openide.NotifyDescriptor;
 import static org.openide.NotifyDescriptor.DEFAULT_OPTION;
 import org.openide.util.lookup.ServiceProvider;
@@ -225,7 +226,7 @@ public class GraphMLImportProcessor implements GraphFileImportProcessor {
                 }
             }
         } catch (final FileNotFoundException ex) {
-            final String errorMsg = "File '" + filename + "' not found";
+            final String errorMsg = StringUtils.isEmpty(filename) ? "File not specified" : "File not found: " + filename;
             NotifyDisplayer.display(new NotifyDescriptor("Error:\n" + errorMsg, "Import GraphML File", DEFAULT_OPTION, 
                     NotifyDescriptor.ERROR_MESSAGE, new Object[]{NotifyDescriptor.OK_OPTION}, NotifyDescriptor.OK_OPTION));
             final Throwable fnfEx = new FileNotFoundException(NotifyDisplayer.BLOCK_POPUP_FLAG + errorMsg);
@@ -234,7 +235,7 @@ public class GraphMLImportProcessor implements GraphFileImportProcessor {
         } catch (final TransformerException ex) {
             LOGGER.log(Level.SEVERE, ex.getLocalizedMessage(), ex);
         } catch (final IOException ex) {
-            final String errorMsg = "Error reading file '" + filename + "'";
+            final String errorMsg = StringUtils.isEmpty(filename) ? "File not specified " : "Error reading file: " + filename;
             NotifyDisplayer.display(new NotifyDescriptor("Error:\n" + errorMsg, "Import GraphML File", DEFAULT_OPTION, 
                     NotifyDescriptor.ERROR_MESSAGE, new Object[]{NotifyDescriptor.OK_OPTION}, NotifyDescriptor.OK_OPTION));
             final Throwable ioEx = new IOException(NotifyDisplayer.BLOCK_POPUP_FLAG + errorMsg);

--- a/CoreDataAccessView/src/au/gov/asd/tac/constellation/views/dataaccess/plugins/importing/file/PajekImportProcessor.java
+++ b/CoreDataAccessView/src/au/gov/asd/tac/constellation/views/dataaccess/plugins/importing/file/PajekImportProcessor.java
@@ -36,6 +36,7 @@ import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javafx.stage.FileChooser.ExtensionFilter;
+import org.apache.commons.lang3.StringUtils;
 import org.openide.NotifyDescriptor;
 import static org.openide.NotifyDescriptor.DEFAULT_OPTION;
 import org.openide.util.lookup.ServiceProvider;
@@ -131,14 +132,14 @@ public class PajekImportProcessor implements GraphFileImportProcessor {
                 }
             }
         } catch (final FileNotFoundException ex) {
-            final String errorMsg = "File '" + filename + "' not found";
+            final String errorMsg = StringUtils.isEmpty(filename) ? "File not specified" : "File not found: " + filename;
             NotifyDisplayer.display(new NotifyDescriptor("Error:\n" + errorMsg, "Import Pajek File", DEFAULT_OPTION, 
                     NotifyDescriptor.ERROR_MESSAGE, new Object[]{NotifyDescriptor.OK_OPTION}, NotifyDescriptor.OK_OPTION));
             final Throwable fnfEx = new FileNotFoundException(NotifyDisplayer.BLOCK_POPUP_FLAG + errorMsg);
             fnfEx.setStackTrace(ex.getStackTrace());
             LOGGER.log(Level.SEVERE, errorMsg, fnfEx);
         } catch (final IOException ex) {
-            final String errorMsg = "Error reading file '" + filename + "'";
+            final String errorMsg = StringUtils.isEmpty(filename) ? "File not specified " : "Error reading file: " + filename;
             NotifyDisplayer.display(new NotifyDescriptor("Error:\n" + errorMsg, "Import Pajek File", DEFAULT_OPTION, 
                     NotifyDescriptor.ERROR_MESSAGE, new Object[]{NotifyDescriptor.OK_OPTION}, NotifyDescriptor.OK_OPTION));
             final Throwable ioEx = new IOException(NotifyDisplayer.BLOCK_POPUP_FLAG + errorMsg);

--- a/CoreErrorReportView/src/au/gov/asd/tac/constellation/views/errorreport/ErrorReportDialog.java
+++ b/CoreErrorReportView/src/au/gov/asd/tac/constellation/views/errorreport/ErrorReportDialog.java
@@ -187,14 +187,17 @@ public class ErrorReportDialog {
     public void toggleExceptionDisplay() {
         showingDetails = !showingDetails;
         showHideButton.setText(showingDetails ? "Hide Details" : "Show Details");
+        final int headerLen = currentError.getHeading().length();
         if (showingDetails) {
             detailsBox.getChildren().remove(summaryLabel);
             detailsBox.getChildren().add(errorMsgArea);
-            dialog.setSize(new Dimension(575, 575));
+            final int prefHeight = 575 + Math.min(75, 25 * (headerLen / 125));
+            dialog.setSize(new Dimension(575, prefHeight));
         } else {
             detailsBox.getChildren().remove(errorMsgArea);
             detailsBox.getChildren().add(summaryLabel);
-            dialog.setSize(new Dimension(430, 230));
+            final int prefHeight = 225 + Math.min(75, 25 * (headerLen / 75));
+            dialog.setSize(new Dimension(430, prefHeight));
         }
     }
 
@@ -222,8 +225,10 @@ public class ErrorReportDialog {
         });
     }
 
-    public void updateDialogSettings(final boolean isModal, final boolean autoClose) {        
-        dialog.setSize(new Dimension(430, 230));
+    public void updateDialogSettings(final boolean isModal, final boolean autoClose) {
+        final int headerLen = currentError.getHeading().length();
+        final int prefHeight = 225 + Math.min(75, 25 * (headerLen / 75));
+        dialog.setSize(new Dimension(430, prefHeight));
         dialog.setEnabled(true);
         dialog.setModal(isModal);
         dialog.setVisible(true);

--- a/CoreErrorReportView/src/au/gov/asd/tac/constellation/views/errorreport/ErrorReportSessionData.java
+++ b/CoreErrorReportView/src/au/gov/asd/tac/constellation/views/errorreport/ErrorReportSessionData.java
@@ -15,6 +15,7 @@
  */
 package au.gov.asd.tac.constellation.views.errorreport;
 
+import au.gov.asd.tac.constellation.utilities.text.SeparatorConstants;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Date;
@@ -60,13 +61,13 @@ public class ErrorReportSessionData {
             // check for a repeated exception from the same constellation source, but compare only the top portion
             // of the stacktrace, as there are cases where different threads can generate the same exception,
             // but have a different origin (thread number) in their stack trace
-            final String[] comparisonLines = entry.getErrorData().split("\n");
+            final String[] comparisonLines = entry.getErrorData().split(SeparatorConstants.NEWLINE);
             final StringBuilder sb = new StringBuilder();
             final String[] constyLines = extractMatchingLines(comparisonLines, ".constellation.");
             if (comparisonLines.length > 7) {
                 final int topNlines = 2 + comparisonLines.length / 4;
                 for (int i = 0; i < topNlines; i++) {
-                    sb.append(comparisonLines[i]).append("\n");
+                    sb.append(comparisonLines[i]).append(SeparatorConstants.NEWLINE);
                 }
             } else {
                 sb.append(entry.getErrorData());
@@ -78,6 +79,7 @@ public class ErrorReportSessionData {
                 for (final String constyLine : constyLines) {
                     if (!sessionErrors.get(i).getErrorData().contains(constyLine)) {
                         allConstyLinesMatch = false;
+                        break;
                     }
                 }
                 if (allConstyLinesMatch && sessionErrors.get(i).getErrorLevel().equals(entry.getErrorLevel()) && sessionErrors.get(i).getErrorData().startsWith(comparisonData)) {
@@ -107,10 +109,10 @@ public class ErrorReportSessionData {
         final StringBuilder destination = new StringBuilder();
         for (int i = 0; i< sourceLines.length; i++) {
             if (sourceLines[i].contains(patternToMatch)) {
-                destination.append(sourceLines[i]).append("\n");
+                destination.append(sourceLines[i]).append(SeparatorConstants.NEWLINE);
             }
         }
-        return destination.toString().split("\n");
+        return destination.toString().split(SeparatorConstants.NEWLINE);
     }
     
     public void removeEntry(final double entryId) {


### PR DESCRIPTION


### Prerequisites

- [ ] Reviewed the [checklist](CHECKLIST.md)

- [ ] Reviewed feedback from the "Sonar Cloud" bot. Note that you have to wait
    for the "CI / Unit Tests") to complete first. Failed Unit tests can be 
    debugged by adding the label "verbose logging" to the GitHub PR.

### Description of the Change

Updated the "File not Found" notification when running a plugin from the Data Access View without specifying a filename. It should only pop up a single message informing the user that they haven't specified which file to use.

Also tightened the matching criteria used in the Error Report view, as there were similar exceptions from the data access plugins being grouped together, when they shouldn't be.

### Alternate Designs

N/A

### Why Should This Be In Core?

Improved user experience

### Benefits

Improved user experience

### Possible Drawbacks

N/A

### Verification Process

In the Data Access View, select (click the checkbox for) Import from Graph file.
Click the Go button
Confirm that you see a single popup window saying "File not specified" and no other popup windows.
There should be a corresponding exception logged in the Error Report View.

### Applicable Issues

#1839 
