### PR TITLE
Workflow plugins thread pool

### DIFF
--- a/CoreDataAccessView/src/au/gov/asd/tac/constellation/views/dataaccess/templates/WorkflowQueryPlugin.java
+++ b/CoreDataAccessView/src/au/gov/asd/tac/constellation/views/dataaccess/templates/WorkflowQueryPlugin.java
@@ -39,7 +39,6 @@ import au.gov.asd.tac.constellation.plugins.parameters.types.IntegerParameterTyp
 import au.gov.asd.tac.constellation.plugins.templates.SimpleEditPlugin;
 import au.gov.asd.tac.constellation.plugins.templates.SimplePlugin;
 import au.gov.asd.tac.constellation.utilities.text.SeparatorConstants;
-import au.gov.asd.tac.constellation.utilities.threadpool.ConstellationGlobalThreadPool;
 import au.gov.asd.tac.constellation.views.dataaccess.GlobalParameters;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -93,7 +92,9 @@ public abstract class WorkflowQueryPlugin extends SimplePlugin {
         // create a service for executing jobs, limiting concurrent executions to the max concurrent plugins parameter.
         final int maxConcurrentPlugins = parameters.getIntegerValue(MAX_CONCURRENT_PLUGINS_PARAMETER_ID);
 
-        final ExecutorService workflowExecutor = ConstellationGlobalThreadPool.getThreadPool().getFixedThreadPool();
+        // Note that we are not using the global thread pool here so that we can further limit the number of concurrent plugins we can run at once
+        // via the max concurrent plugins parameter
+        final ExecutorService workflowExecutor = Executors.newFixedThreadPool(maxConcurrentPlugins);
 
         // schedule a job for each batch, where the job is to execute the defined workflow
         final List<Future<?>> workerPlugins = new ArrayList<>();

--- a/CoreGraphNode/src/au/gov/asd/tac/constellation/graph/node/plugins/DefaultPluginEnvironment.java
+++ b/CoreGraphNode/src/au/gov/asd/tac/constellation/graph/node/plugins/DefaultPluginEnvironment.java
@@ -53,7 +53,7 @@ public class DefaultPluginEnvironment extends PluginEnvironment {
 
     private static final String THREAD_POOL_NAME = "Default Plugin Environment";
 
-    private final ExecutorService pluginExecutor = ConstellationGlobalThreadPool.getThreadPool().getDefaultPluginEnvPool();
+    private final ExecutorService pluginExecutor = ConstellationGlobalThreadPool.getThreadPool().getCachedThreadPool();
 
     private static final String GRAPH_NULL_WARNING_MESSAGE = "{0} plugin was executed on a graph which was null";
 

--- a/CoreUtilities/src/au/gov/asd/tac/constellation/utilities/threadpool/ConstellationGlobalThreadPool.java
+++ b/CoreUtilities/src/au/gov/asd/tac/constellation/utilities/threadpool/ConstellationGlobalThreadPool.java
@@ -31,7 +31,6 @@ public class ConstellationGlobalThreadPool {
     private ScheduledExecutorService scheduledExecutorService = null;
     private ExecutorService fixedThreadPool = null;
     private ExecutorService cachedThreadPool = null;
-    private ExecutorService defaultPluginEnvironmentPool = null;
 
     private ConstellationGlobalThreadPool() {
     }
@@ -79,7 +78,7 @@ public class ConstellationGlobalThreadPool {
     /**
      * Creates only 1 CachedThreadPool
      *
-     * @return a CachedThradPool object
+     * @return a CachedThreadPool object
      */
     public ExecutorService getCachedThreadPool() {
         if (cachedThreadPool == null) {
@@ -88,19 +87,4 @@ public class ConstellationGlobalThreadPool {
 
         return cachedThreadPool;
     }
-
-    /**
-     * Also creates a cached thread pool however this is only used by the
-     * default plugin environment
-     *
-     * @return A CachedThreadPool object
-     */
-    public ExecutorService getDefaultPluginEnvPool() {
-        if (defaultPluginEnvironmentPool == null) {
-            defaultPluginEnvironmentPool = Executors.newCachedThreadPool();
-        }
-
-        return defaultPluginEnvironmentPool;
-    }
-
 }

--- a/CoreUtilities/test/unit/src/au/gov/asd/tac/constellation/utilities/threadpool/ConstellationGlobalThreadPoolNGTest.java
+++ b/CoreUtilities/test/unit/src/au/gov/asd/tac/constellation/utilities/threadpool/ConstellationGlobalThreadPoolNGTest.java
@@ -119,19 +119,4 @@ public class ConstellationGlobalThreadPoolNGTest {
         ExecutorService e2 = ConstellationGlobalThreadPool.getThreadPool().getCachedThreadPool();
         assertEquals(e1 == e2, true);
     }
-
-    /**
-     * Test of getDefaultPluginEnvPool method, of class
-     * ConstellationGlobalThreadPool.
-     *
-     * Same purpose as the tests above
-     */
-    @Test
-    public void testGetDefaultPluginEnvPool() {
-        System.out.println("getDefaultPluginEnvPool");
-        ExecutorService dep1 = ConstellationGlobalThreadPool.getThreadPool().getDefaultPluginEnvPool();
-        ExecutorService dep2 = ConstellationGlobalThreadPool.getThreadPool().getDefaultPluginEnvPool();
-        assertEquals(dep1 == dep2, true);
-    }
-
 }


### PR DESCRIPTION
<!--

### Requirements

* Filling out the template is required. Any pull request that does not include
enough information to be reviewed in a timely manner may be closed at the
maintainers' discretion.
* All new code requires unit tests to ensure they work as expected and will
continue to work as new code is added in the future (regression testing).
* Make sure your branch name is prefixed by `feature`, `bugfix` or `release`
* Have you read Constellation's Code of Conduct? By filing an issue, you are
expected to comply with it, including treating everyone with respect:
https://github.com/constellation-app/constellation/blob/master/CODE_OF_CONDUCT.md

-->

### Prerequisites

- [x] Reviewed the [checklist](CHECKLIST.md)

- [ ] Reviewed feedback from the "Sonar Cloud" bot. Note that you have to wait
    for the "CI / Unit Tests") to complete first. Failed Unit tests can be 
    debugged by adding the label "verbose logging" to the GitHub PR.

### Description of the Change

Reverted back to having `WorkflowQueryPlugin` create its own thread pool of size `maxConcurrentPlugins`.

While I was at it, I realised that with the default plugin environment thread pool, we had 2 cached thread pools which isn't really necessary in this case as neither pool was being shutdown or terminated and a cached thread pool can have up to `Integer.MAX_VALUE` threads (which we're unlikely to ever hit unless something has gone very wrong). So I've removed the pool specifically for the `DefaultPluginEnvironment` and moved that to using the other cached thread pool.

### Alternate Designs

I considered simply removing the shutdown call in the `WorkflowQueryPlugin` but the fact that we had moved to using the global thread pool meant that we were no longer using the max concurrent plugins parameter which ideally we wanted to be using. If we wanted to use the max concurrent plugins as well, we could've applied a semaphore to limit the number threads we could use from the global pool but this seemed to be more effort than it was worth. Ultimately decided that it made the most sense (and was easiest) to just make workflow query plugins an exception to using the global thread pool given its usage requirement.

### Why Should This Be In Core?

Bug fixes

### Benefits

Less bugs

### Possible Drawbacks

Nil

### Verification Process

Apply the steps to produce from the original ticket

### Applicable Issues

#1844
