### PR TITLE
Use the system dependent File separator in the resource path.

### DIFF
--- a/CoreHelp/src/au/gov/asd/tac/constellation/help/utilities/Generator.java
+++ b/CoreHelp/src/au/gov/asd/tac/constellation/help/utilities/Generator.java
@@ -136,9 +136,9 @@ public class Generator implements Runnable {
         final URL url = new URL(pathLoc);
         final URI uri = url.toURI();
         final Path path = Paths.get(uri);
-        final int jarIx = path.toString().lastIndexOf('\\');
+        final int jarIx = path.toString().lastIndexOf(File.separator);
         final String newPath = jarIx > -1 ? path.toString().substring(0, jarIx) : "";
-        return newPath != null ? newPath + "\\ext" : "";
+        return newPath != null ? newPath + File.separator + "ext" : "";
     }
 
 }


### PR DESCRIPTION

### Prerequisites

- [ ] Reviewed the [checklist](CHECKLIST.md)

- [ ] Reviewed feedback from the "Sonar Cloud" bot. Note that you have to wait
    for the "CI / Unit Tests") to complete first. Failed Unit tests can be 
    debugged by adding the label "verbose logging" to the GitHub PR.

### Description of the Change

There is an issue on Linux where trying to access help pages throws an IndexOutOfBound Exception.
This is caused by a hard coded path separator being used when getting the resource path.
It should be using the system dependent File.separator

### Alternate Designs

N/A

### Why Should This Be In Core?

Core functionality

### Benefits

Core functionality

### Possible Drawbacks

N/A

### Verification Process

Install on Linux and access the help pages.
Click on any question mark icon in constellation to retrieve the related help page.

### Applicable Issues


