### PR TITLE
Notes view autosave no longer removes changes on notes being edited

### DIFF
--- a/CoreNotesView/src/au/gov/asd/tac/constellation/views/notes/NotesViewPane.java
+++ b/CoreNotesView/src/au/gov/asd/tac/constellation/views/notes/NotesViewPane.java
@@ -584,8 +584,8 @@ public class NotesViewPane extends BorderPane {
         
         Platform.runLater(() -> {
             boolean foundNoteInEdit = false;
-            for (int i = 0; i < notesToRender.size(); i++) {
-                if (notesToRender.get(i).getEditMode()) {
+            for (final NotesViewEntry entry : notesToRender) {
+                if (entry.getEditMode()) {
                     foundNoteInEdit = true;
                     break;
                 }

--- a/CoreNotesView/src/au/gov/asd/tac/constellation/views/notes/NotesViewPane.java
+++ b/CoreNotesView/src/au/gov/asd/tac/constellation/views/notes/NotesViewPane.java
@@ -583,16 +583,26 @@ public class NotesViewPane extends BorderPane {
         }
         
         Platform.runLater(() -> {
-            notesListVBox.getChildren().removeAll(notesListVBox.getChildren());
-
-            if (CollectionUtils.isNotEmpty(notesToRender)) {
-                notesToRender.sort(Comparator.comparing(NotesViewEntry::getDateTime));
-                notesToRender.forEach(note -> createNote(note));
+            boolean foundNoteInEdit = false;
+            for (int i = 0; i < notesToRender.size(); i++) {
+                if (notesToRender.get(i).getEditMode()) {
+                    foundNoteInEdit = true;
+                    break;
+                }
             }
-            notesListScrollPane.applyCss();
-            notesListScrollPane.layout();
-            // Keeps the scroll bar at the bottom?
-            notesListScrollPane.setVvalue(notesListScrollPane.getVmax());
+
+            if (!foundNoteInEdit) {
+                notesListVBox.getChildren().removeAll(notesListVBox.getChildren());
+
+                if (CollectionUtils.isNotEmpty(notesToRender)) {
+                    notesToRender.sort(Comparator.comparing(NotesViewEntry::getDateTime));
+                    notesToRender.forEach(note -> createNote(note));
+                }
+                notesListScrollPane.applyCss();
+                notesListScrollPane.layout();
+                // Keeps the scroll bar at the bottom?
+                notesListScrollPane.setVvalue(notesListScrollPane.getVmax());
+            }
         });
     }
 

--- a/CoreNotesView/src/au/gov/asd/tac/constellation/views/notes/state/NotesViewEntry.java
+++ b/CoreNotesView/src/au/gov/asd/tac/constellation/views/notes/state/NotesViewEntry.java
@@ -40,7 +40,11 @@ public class NotesViewEntry implements PluginReportListener {
     private List<Integer> transactionsSelected;
     private List<String> tags = new ArrayList<>();
     private boolean editMode;
+    private boolean wasInEditMode = false;
     private boolean isShowing = true;
+
+    private String tempContent = "";
+    private String tempTitle = "";
 
     public NotesViewEntry(final String dateTime, final String noteTitle, final String noteContent, final boolean userCreated, final boolean graphAttribute, final String nodeColour) {
         this.dateTime = dateTime;
@@ -148,6 +152,31 @@ public class NotesViewEntry implements PluginReportListener {
         this.id = id;
 
     }
+
+    public boolean checkIfWasInEditMode() {
+        return wasInEditMode;
+    }
+
+    public void setWasInEditMode(boolean wasInEditMode) {
+        this.wasInEditMode = wasInEditMode;
+    }
+
+    public String getTempContent() {
+        return tempContent;
+    }
+
+    public void setTempContent(String tempContent) {
+        this.tempContent = tempContent;
+    }
+
+    public String getTempTitle() {
+        return tempTitle;
+    }
+
+    public void setTempTitle(String tempTitle) {
+        this.tempTitle = tempTitle;
+    }
+
 
     @Override
     public void pluginReportChanged(final PluginReport pluginReport) {

--- a/CoreNotesView/src/au/gov/asd/tac/constellation/views/notes/state/NotesViewEntry.java
+++ b/CoreNotesView/src/au/gov/asd/tac/constellation/views/notes/state/NotesViewEntry.java
@@ -157,7 +157,7 @@ public class NotesViewEntry implements PluginReportListener {
         return wasInEditMode;
     }
 
-    public void setWasInEditMode(boolean wasInEditMode) {
+    public void setWasInEditMode(final boolean wasInEditMode) {
         this.wasInEditMode = wasInEditMode;
     }
 
@@ -165,7 +165,7 @@ public class NotesViewEntry implements PluginReportListener {
         return tempContent;
     }
 
-    public void setTempContent(String tempContent) {
+    public void setTempContent(final String tempContent) {
         this.tempContent = tempContent;
     }
 
@@ -173,7 +173,7 @@ public class NotesViewEntry implements PluginReportListener {
         return tempTitle;
     }
 
-    public void setTempTitle(String tempTitle) {
+    public void setTempTitle(final String tempTitle) {
         this.tempTitle = tempTitle;
     }
 

--- a/CoreNotesView/src/au/gov/asd/tac/constellation/views/notes/state/NotesViewEntry.java
+++ b/CoreNotesView/src/au/gov/asd/tac/constellation/views/notes/state/NotesViewEntry.java
@@ -43,13 +43,16 @@ public class NotesViewEntry implements PluginReportListener {
     private boolean wasInEditMode = false;
     private boolean isShowing = true;
 
-    private String tempContent = "";
-    private String tempTitle = "";
+    private String tempContent;
+    private String tempTitle;
 
     public NotesViewEntry(final String dateTime, final String noteTitle, final String noteContent, final boolean userCreated, final boolean graphAttribute, final String nodeColour) {
         this.dateTime = dateTime;
         this.noteTitle = noteTitle;
         this.noteContent = noteContent;
+
+        tempContent = "";
+        tempTitle = "";
 
         if (nodeColour != null) {
             this.nodeColour = nodeColour;


### PR DESCRIPTION
<!--

### Requirements

* Filling out the template is required. Any pull request that does not include
enough information to be reviewed in a timely manner may be closed at the
maintainers' discretion.
* All new code requires unit tests to ensure they work as expected and will
continue to work as new code is added in the future (regression testing).
* Make sure your branch name is prefixed by `feature`, `bugfix` or `release`
* Have you read Constellation's Code of Conduct? By filing an issue, you are
expected to comply with it, including treating everyone with respect:
https://github.com/constellation-app/constellation/blob/master/CODE_OF_CONDUCT.md

-->

### Prerequisites

- [x] Reviewed the [checklist](CHECKLIST.md)

- [ ] Reviewed feedback from the "Sonar Cloud" bot. Note that you have to wait
    for the "CI / Unit Tests") to complete first. Failed Unit tests can be 
    debugged by adding the label "verbose logging" to the GitHub PR.

### Description of the Change

<!--

We must be able to understand the design of your change from this description.
If we can't get a good idea of what the code will be doing from the description
here, the pull request may be closed at the maintainers' discretion. Keep in
mind that the maintainer reviewing this PR may not be familiar with or have
worked with the code here recently, so please walk us through the concepts.

-->
**_Fix for issue #1848 found during testing of release candidate v2.10.0-rc1_**

Notes that are being edit do not get reset when an autosave occurs. If a note is in edit mode and the user switches graphs, that note will remain in edit mode with any changes made when the user returns.

### Alternate Designs

<!--

Explain what other alternates were considered and why the proposed version was
selected.

-->

### Why Should This Be In Core?

<!--

Explain why this functionality should be in Constellation Core as opposed to a
different module suite. Note that this question is more applicable when adding
new functionality. If this change is a minor update to an existing file then it
is understood that this change has to be to this module suite and a response
and therefore a response to this question is not required.

-->
Makes editing notes safe as the users can the sure there changes won't randomly be lost if a background plugin finishes running.
### Benefits

<!-- What benefits will be realized by the code change? -->
Increases usability of the notes view.
### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->
Auto notes are not updated in real time.
### Verification Process

<!--

What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (e.g. buttons you clicked, text you typed,
commands you ran, etc.), and describe the results you observed.

-->
Made changes to note in edit mode switched graphs and came back to see note still in edit mode with the changes I have made.
### Applicable Issues

<!-- Link any applicable issues here -->
#1848 
