### PR TITLE
Handle close of listeners to QC Auto Vetter to trigger removal of graph listneer if no listeners to auto vetter

### DIFF
--- a/CoreDataAccessView/src/au/gov/asd/tac/constellation/views/dataaccess/DataAccessViewTopComponent.java
+++ b/CoreDataAccessView/src/au/gov/asd/tac/constellation/views/dataaccess/DataAccessViewTopComponent.java
@@ -175,7 +175,7 @@ public final class DataAccessViewTopComponent extends JavaFxTopComponent<DataAcc
      * @param add Should quality control auto vetter listeners be added (true)
      * or removed (false).
      */
-    private void manageQualityControlListeners(boolean add) {
+    private void manageQualityControlListeners(final boolean add) {
         // Dig down to the button toolbar and find any quality control auto
         // buttons - these subscribe as listeners to the quality control auto
         // vetter and as such these subscriptions need to be modified.

--- a/CoreDataAccessView/src/au/gov/asd/tac/constellation/views/dataaccess/DataAccessViewTopComponent.java
+++ b/CoreDataAccessView/src/au/gov/asd/tac/constellation/views/dataaccess/DataAccessViewTopComponent.java
@@ -18,13 +18,16 @@ package au.gov.asd.tac.constellation.views.dataaccess;
 import au.gov.asd.tac.constellation.graph.Graph;
 import au.gov.asd.tac.constellation.graph.manager.GraphManager;
 import au.gov.asd.tac.constellation.security.proxy.ProxyUtilities;
-import au.gov.asd.tac.constellation.utilities.threadpool.ConstellationGlobalThreadPool;
 import au.gov.asd.tac.constellation.views.JavaFxTopComponent;
+import au.gov.asd.tac.constellation.views.dataaccess.components.ButtonToolbar;
 import au.gov.asd.tac.constellation.views.dataaccess.panes.DataAccessPane;
 import au.gov.asd.tac.constellation.views.dataaccess.utilities.DataAccessUtilities;
 import au.gov.asd.tac.constellation.views.qualitycontrol.daemon.QualityControlAutoVetter;
+import au.gov.asd.tac.constellation.views.qualitycontrol.widget.DefaultQualityControlAutoButton;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import javafx.application.Platform;
+import javafx.scene.layout.HBox;
 import org.openide.awt.ActionID;
 import org.openide.awt.ActionReference;
 import org.openide.awt.ActionReferences;
@@ -64,10 +67,10 @@ import org.openide.windows.TopComponent;
 })
 public final class DataAccessViewTopComponent extends JavaFxTopComponent<DataAccessPane> {
 
-    private final ExecutorService executorService = ConstellationGlobalThreadPool.getThreadPool().getFixedThreadPool();
+    private final ExecutorService executorService = Executors.newFixedThreadPool(1);
     
     private final DataAccessPane dataAccessPane;
-    
+
     /**
      * Create a new data access view.
      */
@@ -124,15 +127,23 @@ public final class DataAccessViewTopComponent extends JavaFxTopComponent<DataAcc
         return "resources/data-access-view.css";
     }
 
+    /**
+     * Handle component opening and hook up listeners and observers.
+     */
     @Override
     public void handleComponentOpened() {
         super.handleComponentOpened();
+        ManageQualityControlListeners(true);
         QualityControlAutoVetter.getInstance().addObserver(getDataAccessPane());
     }
 
+    /**
+     * Handle component closing and pull down listeners and observers.
+     */
     @Override
     public void handleComponentClosed() {
         super.handleComponentClosed();
+        ManageQualityControlListeners(false);
         QualityControlAutoVetter.getInstance().removeObserver(getDataAccessPane());
     }
 
@@ -144,19 +155,49 @@ public final class DataAccessViewTopComponent extends JavaFxTopComponent<DataAcc
 
     @Override
     protected void handleNewGraph(final Graph graph) {
-        System.setProperty("dav.graph.ready", Boolean.FALSE.toString());
         if (needsUpdate() && getDataAccessPane() != null) {
             getDataAccessPane().update(graph);
-            Platform.runLater(() ->
+            Platform.runLater(() -> 
                 DataAccessUtilities.loadDataAccessState(getDataAccessPane(), graph)
             );
         }
-        Platform.runLater(() ->
-                // nested runLater so it runs after all the other triggered processes for opening a graph have been run
-                Platform.runLater(() -> System.setProperty("dav.graph.ready", Boolean.TRUE.toString()))
-        );
     }
-    
+
+    /**
+     * Add or remove all quality control auto vetter listeners. These listeners
+     * are tied to DefaultQualityControlAutoButton buttons found nested within
+     * the button toolbar.
+     *
+     * @param add Should quality control auto vetter listeners be added (true)
+     * or removed (false).
+     */
+    private void ManageQualityControlListeners(boolean add) {
+        // Dig down to the button toolbar and find any quality control auto
+        // buttons - these subscribe as listeners to the quality control auto
+        // vetter and as such these subscriptions need to be modified.
+        final ButtonToolbar buttonToolbar = dataAccessPane.getButtonToolbar();
+        final HBox hboxTop = buttonToolbar.getRabRegionExectueHBoxTop();
+        final HBox hboxBottom = buttonToolbar.getRabRegionExectueHBoxBottom();
+        for (final Object button : hboxTop.getChildren()) {
+            if (button instanceof DefaultQualityControlAutoButton) {
+                if (add) {
+                    ((DefaultQualityControlAutoButton) button).AddQCListener();
+                } else {
+                    ((DefaultQualityControlAutoButton) button).RemoveQCListener();
+                }
+            }
+        }
+        for (final Object button : hboxBottom.getChildren()) {
+            if (button instanceof DefaultQualityControlAutoButton) {
+                if (add) {
+                    ((DefaultQualityControlAutoButton) button).AddQCListener();
+                } else {
+                    ((DefaultQualityControlAutoButton) button).RemoveQCListener();
+                }
+            }
+        }
+    }
+
     /**
      * This method is called from within the constructor to initialize the form.
      * WARNING: Do NOT modify this code. The content of this method is always

--- a/CoreQualityControlView/src/au/gov/asd/tac/constellation/views/qualitycontrol/daemon/QualityControlAutoVetter.java
+++ b/CoreQualityControlView/src/au/gov/asd/tac/constellation/views/qualitycontrol/daemon/QualityControlAutoVetter.java
@@ -263,6 +263,12 @@ public final class QualityControlAutoVetter implements GraphManagerListener, Gra
      */
     public void addListener(final QualityControlListener listener) {
         listeners.add(listener);
+
+        // If we have a list size of 1 then this is the first entry added so
+        // its time to re-add a change listener to currentGraph.
+        if (listeners.size() == 1 && currentGraph != null) {
+            currentGraph.addGraphChangeListener(this);
+        }
     }
 
     /**
@@ -283,6 +289,14 @@ public final class QualityControlAutoVetter implements GraphManagerListener, Gra
      */
     public void removeListener(final QualityControlListener listener) {
         listeners.remove(listener);
+
+        // After removing a listener, check if there are any further listeners
+        // still using the auto vetter - if there are not, stop listening for
+        // currentGraph change. This can be reactivated if listeners are again
+        // added.
+        if (listeners.isEmpty() && currentGraph != null) {
+            currentGraph.removeGraphChangeListener(this);
+        }
     }
 
     public void addObserver(final QualityControlAutoVetterListener buttonListener) {

--- a/CoreQualityControlView/src/au/gov/asd/tac/constellation/views/qualitycontrol/widget/DefaultQualityControlAutoButton.java
+++ b/CoreQualityControlView/src/au/gov/asd/tac/constellation/views/qualitycontrol/widget/DefaultQualityControlAutoButton.java
@@ -105,7 +105,7 @@ public final class DefaultQualityControlAutoButton extends QualityControlAutoBut
      * allows the containing top component to effectively subscribe/unsubscribe
      * listeners as the components are opened or closed.
      */
-    public void AddQCListener() {
+    public void addQCListener() {
         QualityControlAutoVetter.getInstance().addListener(this);
         QualityControlAutoVetter.getInstance().invokeListener(this);
     }
@@ -115,7 +115,7 @@ public final class DefaultQualityControlAutoButton extends QualityControlAutoBut
      * This allows the containing top component to effectively
      * subscribe/unsubscribe listeners as the components are opened or closed.
      */
-    public void RemoveQCListener() {
+    public void removeQCListener() {
         QualityControlAutoVetter.getInstance().removeListener(this);
     }
 }

--- a/CoreQualityControlView/src/au/gov/asd/tac/constellation/views/qualitycontrol/widget/DefaultQualityControlAutoButton.java
+++ b/CoreQualityControlView/src/au/gov/asd/tac/constellation/views/qualitycontrol/widget/DefaultQualityControlAutoButton.java
@@ -50,6 +50,9 @@ public final class DefaultQualityControlAutoButton extends QualityControlAutoBut
         getStylesheets().add(JavafxStyleManager.getMainStyleSheet());
         setStyle(QUERY_RISK_DEFAULT_STYLE + BUTTON_STYLE + String.format("-fx-font-size:%d;", FontUtilities.getApplicationFontSize()));
 
+        QualityControlViewPane.readSerializedRulePriorities();
+        QualityControlViewPane.readSerializedRuleEnabledStatuses();
+
         setOnAction(value -> SwingUtilities.invokeLater(() -> {
             final TopComponent qualityControlView = WindowManager.getDefault().findTopComponent(QualityControlViewTopComponent.class.getSimpleName());
             if (qualityControlView != null) {

--- a/CoreQualityControlView/src/au/gov/asd/tac/constellation/views/qualitycontrol/widget/DefaultQualityControlAutoButton.java
+++ b/CoreQualityControlView/src/au/gov/asd/tac/constellation/views/qualitycontrol/widget/DefaultQualityControlAutoButton.java
@@ -49,9 +49,6 @@ public final class DefaultQualityControlAutoButton extends QualityControlAutoBut
     public DefaultQualityControlAutoButton() {
         getStylesheets().add(JavafxStyleManager.getMainStyleSheet());
         setStyle(QUERY_RISK_DEFAULT_STYLE + BUTTON_STYLE + String.format("-fx-font-size:%d;", FontUtilities.getApplicationFontSize()));
-        
-        QualityControlViewPane.readSerializedRulePriorities();
-        QualityControlViewPane.readSerializedRuleEnabledStatuses();
 
         setOnAction(value -> SwingUtilities.invokeLater(() -> {
             final TopComponent qualityControlView = WindowManager.getDefault().findTopComponent(QualityControlViewTopComponent.class.getSimpleName());
@@ -63,8 +60,6 @@ public final class DefaultQualityControlAutoButton extends QualityControlAutoBut
             }
         }));
 
-        QualityControlAutoVetter.getInstance().addListener(this);
-        QualityControlAutoVetter.getInstance().invokeListener(this);
         QualityControlAutoVetter.getInstance().init();
     }
 
@@ -105,4 +100,22 @@ public final class DefaultQualityControlAutoButton extends QualityControlAutoBut
         return new DefaultQualityControlAutoButton();
     }
 
+    /**
+     * Add this button as a listener to the quality control auto vetter. This
+     * allows the containing top component to effectively subscribe/unsubscribe
+     * listeners as the components are opened or closed.
+     */
+    public void AddQCListener() {
+        QualityControlAutoVetter.getInstance().addListener(this);
+        QualityControlAutoVetter.getInstance().invokeListener(this);
+    }
+
+    /**
+     * Remove this button as a listener from the quality control auto vetter.
+     * This allows the containing top component to effectively
+     * subscribe/unsubscribe listeners as the components are opened or closed.
+     */
+    public void RemoveQCListener() {
+        QualityControlAutoVetter.getInstance().removeListener(this);
+    }
 }


### PR DESCRIPTION
### Prerequisites

- [X] Reviewed the [checklist](CHECKLIST.md)

- [ ] Reviewed feedback from the "Sonar Cloud" bot. Note that you have to wait
    for the "CI / Unit Tests") to complete first. Failed Unit tests can be 
    debugged by adding the label "verbose logging" to the GitHub PR.

### Description of the Change

Added code to QualityControlAutoVetter.java to remove graph change listner if no listeners remain to QualityControlAutoVetter.
Updated DataAccessViewTopComponent.java and DefaultQualityControlAutoButton.java to modify when listeners to QualityControlAutoVetter are added/removed to ensure closing the view removes all listeners.
QualityControlView already correctly removes listeners when closed.

### Alternate Designs

nil

### Why Should This Be In Core?

Improve performance by removing redundant calls to QualityControlView.graphChanged.

### Benefits

As above

### Possible Drawbacks

Nil known

### Verification Process

To test:
* in debugger, add following breakpoints to QualityControlAutoVetter.java:
	1) line 147 in first line of graphChanged
    2) line 270 in addListener where addGraphChangeListener is called
	3) line 298 in removeListener where removeGraphChangeListener is called	
* start application
* open QCV and confirm no breakpoints are hit
* open a new graph and confirm breakpoint 1) is hit
* close QCV and confirm breakpoint 3) is hit
* put graph in draw mode - confirm no breakpoints are hit
* open QCV and confirm breakpoints 1) and 2) are hit
* draw a new node and confirm breakpoint 1) is hit
* open DAV and confirm no breakpoints are hit
* close QCV and confirm breakpoint 1) is hit
* draw a new node and confirm breakpoint 1) is hit
* close DAV and confirm breakpoint 3) is hit
* draw a new node and confirm breakpoint 1) is not hit
* open DAV and confirm breakpoint 2 is hit
* draw a new node and confirm breakpoint 1) is hit
* open QCV and confirm breakpoint 1) is hit
* close DAV and confirm breakpoint 1) is hit
* close QCV and confirm breakpoint 3) is hit

### Applicable Issues

#916 
