### PR TITLE
Fixed issue with missing screenshots on the welcome page.

### DIFF
--- a/CoreGraphFile/src/au/gov/asd/tac/constellation/graph/file/open/RecentFiles.java
+++ b/CoreGraphFile/src/au/gov/asd/tac/constellation/graph/file/open/RecentFiles.java
@@ -177,8 +177,9 @@ public final class RecentFiles {
                 if (!historyReady.await(300, TimeUnit.SECONDS)) {
                     LOGGER.log(Level.WARNING, ">> Recent Files did not initialise within 5 minutes <<", new Exception(NotifyDisplayer.BLOCK_POPUP_FLAG + "WARNING: Recent Files data did not initialise within a reasonable time"));
                 }
-            } catch (final InterruptedException ex) { // NOSONAR
+            } catch (final InterruptedException ex) {
                 LOGGER.log(Level.SEVERE, ex.toString(), ex);
+                Thread.currentThread().interrupt();
             }
         }
         synchronized (HISTORY_LOCK) {

--- a/CoreGraphFile/src/au/gov/asd/tac/constellation/graph/file/open/RecentFiles.java
+++ b/CoreGraphFile/src/au/gov/asd/tac/constellation/graph/file/open/RecentFiles.java
@@ -127,10 +127,18 @@ public final class RecentFiles {
             }
             TopComponent.getRegistry().
                     addPropertyChangeListener(RECENT_FILE_SAVED);
-            historyReady.countDown();
+            decrementHistoryReadyLatch();
         });
     }
 
+    /**
+     * Will decrement the historyReady CountDownLatch
+     * Placed this code into it's own method so it can be called separately in unit testing.
+     */
+    public static void decrementHistoryReadyLatch(){
+        historyReady.countDown();
+    }
+    
     /**
      * Add the specified path to the recent file list.
      *

--- a/CoreGraphFile/src/au/gov/asd/tac/constellation/graph/file/open/RecentFiles.java
+++ b/CoreGraphFile/src/au/gov/asd/tac/constellation/graph/file/open/RecentFiles.java
@@ -173,8 +173,9 @@ public final class RecentFiles {
     public static List<HistoryItem> getUniqueRecentFiles() {
         if (historyReady.getCount() != 0) {
             try {
+                LOGGER.log(Level.WARNING, ">> Timing issue encountered: Recent Files data is being accessed before it has been initialised <<");
                 if (!historyReady.await(300, TimeUnit.SECONDS)) {
-                    LOGGER.log(Level.WARNING, ">> Recent Files did not initialise within 5 minutes <<", new Exception(NotifyDisplayer.BLOCK_POPUP_FLAG + "WARNING: Recent Files data did not initialise within 5 minutes"));
+                    LOGGER.log(Level.WARNING, ">> Recent Files did not initialise within 5 minutes <<", new Exception(NotifyDisplayer.BLOCK_POPUP_FLAG + "WARNING: Recent Files data did not initialise within a reasonable time"));
                 }
             } catch (final InterruptedException ex) { // NOSONAR
                 LOGGER.log(Level.SEVERE, ex.toString(), ex);

--- a/CoreGraphFile/src/au/gov/asd/tac/constellation/graph/file/open/RecentFiles.java
+++ b/CoreGraphFile/src/au/gov/asd/tac/constellation/graph/file/open/RecentFiles.java
@@ -171,13 +171,14 @@ public final class RecentFiles {
      * @return list of recent files
      */
     public static List<HistoryItem> getUniqueRecentFiles() {
-        try {
-            if (historyReady.getCount() > 0) {
-                LOGGER.log(Level.WARNING, ">> Timing issue caught: Recent Files not yet initialised <<", new Exception(NotifyDisplayer.BLOCK_POPUP_FLAG + "Warning: Timing issue caught. Recent Files data had not been initialised."));
-                historyReady.await(300, TimeUnit.SECONDS);
+        if (!(historyReady.getCount() == 0)) {
+            try {
+                if (!historyReady.await(300, TimeUnit.SECONDS)) {
+                    LOGGER.log(Level.SEVERE, ">> Recent Files did not initialise within 5 minutes <<", new Exception(NotifyDisplayer.BLOCK_POPUP_FLAG + "ERROR: Recent Files did not initialise within 5 minutes"));
+                }
+            } catch (final InterruptedException ex) { // NOSONAR
+                LOGGER.log(Level.SEVERE, ex.toString(), ex);
             }
-        } catch (final InterruptedException ex) { // NOSONAR
-            LOGGER.log(Level.SEVERE, ex.toString(), ex);
         }
         synchronized (HISTORY_LOCK) {
             return getRecentFiles().stream()

--- a/CoreGraphFile/src/au/gov/asd/tac/constellation/graph/file/open/RecentFiles.java
+++ b/CoreGraphFile/src/au/gov/asd/tac/constellation/graph/file/open/RecentFiles.java
@@ -171,10 +171,10 @@ public final class RecentFiles {
      * @return list of recent files
      */
     public static List<HistoryItem> getUniqueRecentFiles() {
-        if (!(historyReady.getCount() == 0)) {
+        if (historyReady.getCount() != 0) {
             try {
                 if (!historyReady.await(300, TimeUnit.SECONDS)) {
-                    LOGGER.log(Level.SEVERE, ">> Recent Files did not initialise within 5 minutes <<", new Exception(NotifyDisplayer.BLOCK_POPUP_FLAG + "ERROR: Recent Files did not initialise within 5 minutes"));
+                    LOGGER.log(Level.WARNING, ">> Recent Files did not initialise within 5 minutes <<", new Exception(NotifyDisplayer.BLOCK_POPUP_FLAG + "WARNING: Recent Files data did not initialise within 5 minutes"));
                 }
             } catch (final InterruptedException ex) { // NOSONAR
                 LOGGER.log(Level.SEVERE, ex.toString(), ex);

--- a/CoreGraphFile/src/au/gov/asd/tac/constellation/graph/file/open/RecentFiles.java
+++ b/CoreGraphFile/src/au/gov/asd/tac/constellation/graph/file/open/RecentFiles.java
@@ -54,6 +54,7 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.prefs.BackingStoreException;
@@ -173,9 +174,9 @@ public final class RecentFiles {
         try {
             if (historyReady.getCount() > 0) {
                 LOGGER.log(Level.WARNING, ">> Timing issue caught: Recent Files not yet initialised <<", new Exception(NotifyDisplayer.BLOCK_POPUP_FLAG + "Warning: Timing issue caught. Recent Files data had not been initialised."));
-                historyReady.await();
+                historyReady.await(300, TimeUnit.SECONDS);
             }
-        } catch (final InterruptedException ex) {
+        } catch (final InterruptedException ex) { // NOSONAR
             LOGGER.log(Level.SEVERE, ex.toString(), ex);
         }
         synchronized (HISTORY_LOCK) {

--- a/CoreGraphFile/test/unit/src/au/gov/asd/tac/constellation/graph/file/open/RecentFilesNGTest.java
+++ b/CoreGraphFile/test/unit/src/au/gov/asd/tac/constellation/graph/file/open/RecentFilesNGTest.java
@@ -123,6 +123,8 @@ public class RecentFilesNGTest {
                     .thenReturn(fo2);
             
             recentFilesMockedStatic.when(RecentFiles::getUniqueRecentFiles).thenCallRealMethod();
+            recentFilesMockedStatic.when(RecentFiles::decrementHistoryReadyLatch).thenCallRealMethod();
+            RecentFiles.decrementHistoryReadyLatch();
 
             final List<HistoryItem> result = RecentFiles.getUniqueRecentFiles();
             assertTrue(result.contains(h1));


### PR DESCRIPTION
### Prerequisites

- [x] Reviewed the [checklist](CHECKLIST.md)

- [x] Reviewed feedback from the "Sonar Cloud" bot. Note that you have to wait
    for the "CI / Unit Tests") to complete first. Failed Unit tests can be 
    debugged by adding the label "verbose logging" to the GitHub PR.

### Description of the Change

Screenshots for recent graphs (if available) should now be consistently displayed on the welcome page.

### Alternate Designs

N/A

### Why Should This Be In Core?

Improved user experience.

### Benefits

Reliable quick access to recently used graphs.

### Possible Drawbacks

N/A

### Verification Process

Confirm that recently used graphs are consistently showing up in the welcome page on startup.
In the event that a timing issue does occur, a warning message is logged, and the affected process will wait up to 5 minutes for the data to be initialised, afterwhich the processing resumes as normal.
If the data is still not initialised after 5 minutes, another warning is logged with an exception, which will be captured by the Error Report view, and the process will proceed with an empty list (with no recent files displayed on the welcome page).

### Applicable Issues

#1838 
