### PR TITLE
Blaze colour replacement dialog.

### DIFF
--- a/CoreVisualSchema/src/au/gov/asd/tac/constellation/graph/schema/visual/utilities/BlazeUtilities.java
+++ b/CoreVisualSchema/src/au/gov/asd/tac/constellation/graph/schema/visual/utilities/BlazeUtilities.java
@@ -188,13 +188,14 @@ public class BlazeUtilities {
                 final VBox saveColourVPane = new VBox(3, titleText, colourListView);
 
                 pane.getChildren().add(saveColourVPane);
+                pane.setMinWidth(colourListView.getWidth());
+                pane.setPrefWidth(colourListView.getWidth());
+                pane.setMaxWidth(colourListView.getWidth());
                 dialog.setGraphic(pane);
                 final Optional<ButtonType> result = dialog.showAndWait();
 
                 if (result.isPresent() && result.get() == ButtonType.OK) {
                     savePreset(newColor, colourListView.getSelectionModel().getSelectedIndex());
-                } else if (!result.isPresent() || result.get() == ButtonType.CLOSE) {
-                    colorDialog(ConstellationColor.fromJavaColor(newColor));
                 }
 
             });

--- a/CoreVisualSchema/src/au/gov/asd/tac/constellation/graph/schema/visual/utilities/BlazeUtilities.java
+++ b/CoreVisualSchema/src/au/gov/asd/tac/constellation/graph/schema/visual/utilities/BlazeUtilities.java
@@ -175,7 +175,7 @@ public class BlazeUtilities {
                 colourListView.setCellFactory((ListView<String> list) -> {
                     final ListCell<String> cell = new ListCell<>() {
                         @Override
-                        public void updateItem(String item, boolean empty) {
+                        public void updateItem(final String item, final boolean empty) {
                             super.updateItem(item, empty);
                             if (empty || item == null) {
                                 setText("");

--- a/CoreVisualSchema/src/au/gov/asd/tac/constellation/graph/schema/visual/utilities/BlazeUtilities.java
+++ b/CoreVisualSchema/src/au/gov/asd/tac/constellation/graph/schema/visual/utilities/BlazeUtilities.java
@@ -35,8 +35,25 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.BitSet;
 import java.util.List;
+import java.util.Optional;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import java.util.prefs.Preferences;
+import javafx.application.Platform;
+import javafx.collections.FXCollections;
+import javafx.scene.control.Button;
+import javafx.scene.control.ButtonBar;
+import javafx.scene.control.ButtonBar.ButtonData;
+import javafx.scene.control.ButtonType;
+import javafx.scene.control.Dialog;
+import javafx.scene.control.Label;
+import javafx.scene.control.ListView;
+import javafx.scene.control.SelectionMode;
+import javafx.scene.layout.HBox;
+import javafx.scene.layout.Pane;
+import javafx.scene.layout.VBox;
 import javafx.util.Pair;
+import javax.swing.SwingUtilities;
 import org.openide.util.NbPreferences;
 
 /**
@@ -45,6 +62,8 @@ import org.openide.util.NbPreferences;
  * @author sirius
  */
 public class BlazeUtilities {
+
+    private static final Logger LOGGER = Logger.getLogger(BlazeUtilities.class.getName());
 
     public static final Blaze DEFAULT_BLAZE = new Blaze(45, ConstellationColor.LIGHT_BLUE);
 
@@ -142,17 +161,45 @@ public class BlazeUtilities {
      * @param newColor the new selected color to add as a preset
      */
     public static void savePreset(final Color newColor) {
+        LOGGER.log(Level.SEVERE, "Saved the colour as a preset");
         final String colorString = getGraphPreferences().get(GraphPreferenceKeys.BLAZE_PRESET_COLORS, GraphPreferenceKeys.BLAZE_PRESET_COLORS_DEFAULT);
         final List<String> colorsList = Arrays.asList(colorString.split(SeparatorConstants.SEMICOLON));
         final int freePosition;
         if (colorsList.indexOf("null") != -1) {
             freePosition = colorsList.indexOf("null");
+            savePreset(newColor, freePosition);
         } else if (colorsList.size() < MAXIMUM_CUSTOM_BLAZE_COLORS) {
             freePosition = colorsList.size();
+            savePreset(newColor, freePosition);
         } else {
-            freePosition = MAXIMUM_CUSTOM_BLAZE_COLORS - 1;
+            Platform.runLater(() -> {
+                final Dialog<ButtonType> dialog = new Dialog<>();
+                dialog.setTitle("Too many presets!");
+
+                final Pane pane = new Pane();
+
+                final Label titleText = new Label("Please select a preset colour to replace");
+                final ListView<String> colourListView = new ListView<>(FXCollections.observableList(colorsList));
+                colourListView.getSelectionModel().setSelectionMode(SelectionMode.SINGLE);
+
+                dialog.getDialogPane().getButtonTypes().add(ButtonType.OK);
+                dialog.getDialogPane().getButtonTypes().add(ButtonType.CANCEL);
+
+                final VBox saveColourVPane = new VBox(3, titleText, colourListView);
+
+                pane.getChildren().add(saveColourVPane);
+                dialog.setGraphic(pane);
+                final Optional<ButtonType> result = dialog.showAndWait();
+
+                if (result.isPresent() && result.get() == ButtonType.OK) {
+                    savePreset(newColor, colourListView.getSelectionModel().getSelectedIndex());
+                } else if (!result.isPresent() || result.get() == ButtonType.CLOSE) {
+                    colorDialog(ConstellationColor.fromJavaColor(newColor));
+                }
+
+            });
         }
-        savePreset(newColor, freePosition);
+
     }
 
     /**

--- a/CoreVisualSchema/test/unit/src/au/gov/asd/tac/constellation/graph/schema/visual/utilities/BlazeUtilitiesNGTest.java
+++ b/CoreVisualSchema/test/unit/src/au/gov/asd/tac/constellation/graph/schema/visual/utilities/BlazeUtilitiesNGTest.java
@@ -217,9 +217,10 @@ public class BlazeUtilitiesNGTest {
             assertEquals(presetsAfter3, "#FF0000;#0000FF;#FFFF00;#00ffff;#00ff00;#ff00ff;#ff00ff;#ff00ff;#ff00ff;#ff00ff;");
             
             // add a color to after the preset list has been filled
+            // The same list should remain since the behaviour has been changed to not replace the last preset automatically when there are 10
             BlazeUtilities.savePreset(Color.WHITE);
             final String presetsAfter4 = p.get(GraphPreferenceKeys.BLAZE_PRESET_COLORS, GraphPreferenceKeys.BLAZE_PRESET_COLORS_DEFAULT);
-            assertEquals(presetsAfter4, "#FF0000;#0000FF;#FFFF00;#00ffff;#00ff00;#ff00ff;#ff00ff;#ff00ff;#ff00ff;#ffffff;");
+            assertEquals(presetsAfter4, "#FF0000;#0000FF;#FFFF00;#00ffff;#00ff00;#ff00ff;#ff00ff;#ff00ff;#ff00ff;#ff00ff;");
         } finally {
             // clean up, first remove Preferences nodes this test plays with
             p.removeNode();


### PR DESCRIPTION
<!--

### Requirements

* Filling out the template is required. Any pull request that does not include
enough information to be reviewed in a timely manner may be closed at the
maintainers' discretion.
* All new code requires unit tests to ensure they work as expected and will
continue to work as new code is added in the future (regression testing).
* Make sure your branch name is prefixed by `feature`, `bugfix` or `release`
* Have you read Constellation's Code of Conduct? By filing an issue, you are
expected to comply with it, including treating everyone with respect:
https://github.com/constellation-app/constellation/blob/master/CODE_OF_CONDUCT.md

-->

### Prerequisites

- [x] Reviewed the [checklist](CHECKLIST.md)

- [ ] Reviewed feedback from the "Sonar Cloud" bot. Note that you have to wait
    for the "CI / Unit Tests") to complete first. Failed Unit tests can be 
    debugged by adding the label "verbose logging" to the GitHub PR.

### Description of the Change

<!--

We must be able to understand the design of your change from this description.
If we can't get a good idea of what the code will be doing from the description
here, the pull request may be closed at the maintainers' discretion. Keep in
mind that the maintainer reviewing this PR may not be familiar with or have
worked with the code here recently, so please walk us through the concepts.

-->
When there is already 10 preset blaze colours and the user wants to add in a new preset, a dialog window will popup asking the user which preset they would like to replace with their new one.
### Alternate Designs

<!--

Explain what other alternates were considered and why the proposed version was
selected.

-->

### Why Should This Be In Core?

<!--

Explain why this functionality should be in Constellation Core as opposed to a
different module suite. Note that this question is more applicable when adding
new functionality. If this change is a minor update to an existing file then it
is understood that this change has to be to this module suite and a response
and therefore a response to this question is not required.

-->
Currently the last blaze colour preset would be replaced with the new one with no warning which isn't ideal since if that last preset colour is important it'll be lost without giving the user a choice.
### Benefits

<!-- What benefits will be realized by the code change? -->
Gives user more control over which preset they would like to replace.
### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->
Dialog windows are annoying to work with in JavaFX and making changes in the code can have unexpected effects.
### Verification Process

<!--

What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (e.g. buttons you clicked, text you typed,
commands you ran, etc.), and describe the results you observed.

-->
Saved 10 blaze colours as presets. Then set 10 new presets by replacing the existing ones via this new poop-up window.
### Applicable Issues

<!-- Link any applicable issues here -->
#1067 