### PR TITLE
User defined Types will now be checked if they extend from an existing Schema Type.

### DIFF
--- a/CoreGraphFramework/src/au/gov/asd/tac/constellation/graph/schema/type/SchemaTransactionTypeUtilities.java
+++ b/CoreGraphFramework/src/au/gov/asd/tac/constellation/graph/schema/type/SchemaTransactionTypeUtilities.java
@@ -189,9 +189,23 @@ public class SchemaTransactionTypeUtilities {
 
         SchemaTransactionType type = SchemaTransactionTypeUtilities.getType(name);
         if (type.equals(defaultType)) {
-            type = new SchemaTransactionType.Builder(defaultType, name)
-                    .setIncomplete(true)
-                    .build();
+            String hierarchicalName = name;
+            int lastHSCPos = hierarchicalName.lastIndexOf(SchemaElementType.HIERARCHY_SEPARATOR_CHARACTER);
+            boolean foundMatch = false;
+            SchemaTransactionType ancestorType = null;
+            while (lastHSCPos > -1 && !foundMatch) {
+                ancestorType = SchemaTransactionTypeUtilities.getType(hierarchicalName.substring(0, lastHSCPos));
+                if (!ancestorType.equals(defaultType)) {
+                    foundMatch = true;
+                }
+                hierarchicalName = hierarchicalName.substring(0, lastHSCPos);
+                lastHSCPos = hierarchicalName.lastIndexOf(SchemaElementType.HIERARCHY_SEPARATOR_CHARACTER);
+            }
+            if (foundMatch) {
+                type = new SchemaTransactionType.Builder(ancestorType, name).build();
+            } else {
+                type = new SchemaTransactionType.Builder(defaultType, name).setIncomplete(true).build();
+            }
         }
 
         return type;

--- a/CoreGraphFramework/src/au/gov/asd/tac/constellation/graph/schema/type/SchemaVertexTypeUtilities.java
+++ b/CoreGraphFramework/src/au/gov/asd/tac/constellation/graph/schema/type/SchemaVertexTypeUtilities.java
@@ -196,9 +196,23 @@ public class SchemaVertexTypeUtilities {
 
         SchemaVertexType type = SchemaVertexTypeUtilities.getType(name);
         if (type.equals(defaultType)) {
-            type = new SchemaVertexType.Builder(defaultType, name)
-                    .setIncomplete(true)
-                    .build();
+            String hierarchicalName = name;
+            int lastHSCPos = hierarchicalName.lastIndexOf(SchemaElementType.HIERARCHY_SEPARATOR_CHARACTER);
+            boolean foundMatch = false;
+            SchemaVertexType ancestorType = null;
+            while (lastHSCPos > -1 && !foundMatch) {
+                ancestorType = SchemaVertexTypeUtilities.getType(hierarchicalName.substring(0, lastHSCPos));
+                if (!ancestorType.equals(defaultType)) {
+                    foundMatch = true;
+                }
+                hierarchicalName = hierarchicalName.substring(0, lastHSCPos);
+                lastHSCPos = hierarchicalName.lastIndexOf(SchemaElementType.HIERARCHY_SEPARATOR_CHARACTER);
+            }
+            if (foundMatch) {
+                type = new SchemaVertexType.Builder(ancestorType, name).build();
+            } else {
+                type = new SchemaVertexType.Builder(defaultType, name).setIncomplete(true).build();
+            }
         }
 
         return type;


### PR DESCRIPTION

<!--

### Requirements

* Filling out the template is required. Any pull request that does not include
enough information to be reviewed in a timely manner may be closed at the
maintainers' discretion.
* All new code requires unit tests to ensure they work as expected and will
continue to work as new code is added in the future (regression testing).
* Make sure your branch name is prefixed by `feature`, `bugfix` or `release`
* Have you read Constellation's Code of Conduct? By filing an issue, you are
expected to comply with it, including treating everyone with respect:
https://github.com/constellation-app/constellation/blob/master/CODE_OF_CONDUCT.md

-->

### Prerequisites

- [x] Reviewed the [checklist](CHECKLIST.md)

- [x] Reviewed feedback from the "Sonar Cloud" bot. Note that you have to wait
    for the "CI / Unit Tests") to complete first. Failed Unit tests can be 
    debugged by adding the label "verbose logging" to the GitHub PR.

### Description of the Change

<!--

We must be able to understand the design of your change from this description.
If we can't get a good idea of what the code will be doing from the description
here, the pull request may be closed at the maintainers' discretion. Keep in
mind that the maintainer reviewing this PR may not be familiar with or have
worked with the code here recently, so please walk us through the concepts.

-->

If a Vertex Type or Transaction Type is manually entered, and a Schema update is performed ("Complete with Schema"), it will now be checked if it extends from and existing Type in the Schema.
ie. For Analytic Graphs there is a Type called "Document", and if you create a new Vertex and set the Type to "Document.Letter" it will be identified as an extension of the Document Type and use that as its base when performing a Schema update, instead of the default behaviour where it will be based on the "Unknown" Type.

The image icon and background colour will be set according to the new base Type identified.
The full text that was entered as the Type will be displayed in the Label, as well as the Type Editor screen.

Note that it looks for a hierarchical syntax for the Type when looking for a match in the Schema.
Periods are used as the hierarchical separators for the Type definition.


### Why Should This Be In Core?

Improved user experience.

<!--

Explain why this functionality should be in Constellation Core as opposed to a
different module suite. Note that this question is more applicable when adding
new functionality. If this change is a minor update to an existing file then it
is understood that this change has to be to this module suite and a response
and therefore a response to this question is not required.

-->


### Verification Process

Create a new Analytic Graph and add a new Vertex, then set the Type to "Document.Some.Specific.Category.Text".
The initial part of the Type definition hierarchy is what is checked for a match with the Schema Types.
In this case it should match the first component of the hierarchy "Document"

Perform a Schema update on the graph (Tools -> "Complete with Schema" , or press F5)
Confirm the Vertex has been updated with the colour and icon associated with the standard Document Type.

<!--

What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (e.g. buttons you clicked, text you typed,
commands you ran, etc.), and describe the results you observed.

-->

