### PR TITLE
Added checks for null attributes and only add if "Show All" selected

### DIFF
--- a/CoreAttributeEditorView/src/au/gov/asd/tac/constellation/views/attributeeditor/AttributeEditorPanel.java
+++ b/CoreAttributeEditorView/src/au/gov/asd/tac/constellation/views/attributeeditor/AttributeEditorPanel.java
@@ -755,21 +755,18 @@ public class AttributeEditorPanel extends BorderPane {
                 final Set<String> hiddenAttrSet = new HashSet<>(hiddenAttrList);
 
                 currentAttributeNames.put(type, new ArrayList<>());
-                final List<String> attrNameList = currentAttributeNames.get(type);
-
                 for (final AttributeData data : attributeDataList) {
                     final boolean hidden = hiddenAttrSet.contains(data.getElementType().toString() + data.getAttributeName());
                     final Object[] values = state.getAttributeValues().get(type.getLabel() + data.getAttributeName());
                     final boolean noValue = ((values == null) || (values[0] == null)); // does attribute have a null value
-                    attrNameList.add(data.getAttributeName());
-                    final TitledPane attribute = createAttributeTitlePane(data, values, longestTitleWidth, hidden);
-                    attribute.setMinWidth(0);
-                    attribute.maxWidthProperty().bind(header.widthProperty());
-                    
+
                     // If we are NOT showing all attributes and this attribute
                     // is null, don't add it to the list of children, this will
                     // have the effect of hiding it
                     if (showAll || !noValue) {
+                        final TitledPane attribute = createAttributeTitlePane(data, values, longestTitleWidth, hidden);
+                        attribute.setMinWidth(0);
+                        attribute.maxWidthProperty().bind(header.widthProperty());
                         header.getChildren().add(attribute); 
                     }
                 }

--- a/CoreAttributeEditorView/src/au/gov/asd/tac/constellation/views/attributeeditor/AttributeEditorPanel.java
+++ b/CoreAttributeEditorView/src/au/gov/asd/tac/constellation/views/attributeeditor/AttributeEditorPanel.java
@@ -461,6 +461,22 @@ public class AttributeEditorPanel extends BorderPane {
     }
 
     /**
+     * Determine if the values list is null or all values in the supplied values
+     * list are empty (null).
+     * @param values List of values to check.
+     * @return True if values is null or all values in the supplied values list
+     * are empty (null) or false otherwise.
+     */
+    private boolean attributeValuesEmpty(final Object[] values)
+    {
+        if (values == null) return true;
+        for (Object value : values) {
+            if (value != null) return false;
+        }
+        return true;
+    }
+    
+    /**
      * Creates individual TitledPane within header title panes.
      *
      * @param attribute the attribute to display.
@@ -471,7 +487,7 @@ public class AttributeEditorPanel extends BorderPane {
      */
     private TitledPane createAttributeTitlePane(final AttributeData attribute, final Object[] values, final double longestTitledWidth, final boolean hidden) {
         final String attributeTitle = attribute.getAttributeName();
-        final boolean noValue = ((values == null) || (values[0] == null)); // does attribute have a null value
+        final boolean noValue = attributeValuesEmpty(values); // does attribute have a null value
         final int spacing = 5;
         final GridPane gridPane = new GridPane();
         gridPane.setHgap(spacing);
@@ -497,7 +513,7 @@ public class AttributeEditorPanel extends BorderPane {
 
         if (attribute.isKey()) {
             final String color;
-            if (hidden || noValue) {
+            if (hidden) {
                 final ConstellationColor hiddenColor = ConstellationColor.fromHtmlColor(prefs.get(AttributePreferenceKey.HIDDEN_ATTRIBUTE_COLOR, HIDDEN_ATTRIBUTE_COLOR));
                 final ConstellationColor keyColor = ConstellationColor.fromHtmlColor(prefs.get(AttributePreferenceKey.PRIMARY_KEY_ATTRIBUTE_COLOR, PRIMARY_KEY_ATTRIBUTE_COLOR));
                 color = (ConstellationColor.getColorValue(hiddenColor.getRed() * 0.5F + keyColor.getRed() * 0.5F, hiddenColor.getGreen() * 0.5F + keyColor.getGreen() * 0.5F, hiddenColor.getBlue() * 0.5F + keyColor.getBlue() * 0.5F, 1F)).getHtmlColor();
@@ -507,7 +523,7 @@ public class AttributeEditorPanel extends BorderPane {
             attributePane.setStyle(JavafxStyleManager.CSS_BASE_STYLE_PREFIX + color + SeparatorConstants.SEMICOLON);
         } else if (!attribute.isSchema()) {
             final String color;
-            if (hidden || noValue) {
+            if (hidden) {
                 final ConstellationColor hiddenColor = ConstellationColor.fromHtmlColor(prefs.get(AttributePreferenceKey.HIDDEN_ATTRIBUTE_COLOR, HIDDEN_ATTRIBUTE_COLOR));
                 final ConstellationColor customColor = ConstellationColor.fromHtmlColor(prefs.get(AttributePreferenceKey.CUSTOM_ATTRIBUTE_COLOR, CUSTOM_ATTRIBUTE_COLOR));
                 color = (ConstellationColor.getColorValue(hiddenColor.getRed() * 0.5F + customColor.getRed() * 0.5F, hiddenColor.getGreen() * 0.5F + customColor.getGreen() * 0.5F, hiddenColor.getBlue() * 0.5F + customColor.getBlue() * 0.5F, 1F)).getHtmlColor();
@@ -515,7 +531,7 @@ public class AttributeEditorPanel extends BorderPane {
                 color = prefs.get(AttributePreferenceKey.CUSTOM_ATTRIBUTE_COLOR, CUSTOM_ATTRIBUTE_COLOR);
             }
             attributePane.setStyle(JavafxStyleManager.CSS_BASE_STYLE_PREFIX + color + SeparatorConstants.SEMICOLON);
-        } else if (hidden || noValue) {
+        } else if (hidden) {
             final String hiddenColor = prefs.get(AttributePreferenceKey.HIDDEN_ATTRIBUTE_COLOR, HIDDEN_ATTRIBUTE_COLOR);
             attributePane.setStyle(JavafxStyleManager.CSS_BASE_STYLE_PREFIX + hiddenColor + SeparatorConstants.SEMICOLON);
         } else {
@@ -758,7 +774,7 @@ public class AttributeEditorPanel extends BorderPane {
                 for (final AttributeData data : attributeDataList) {
                     final boolean hidden = hiddenAttrSet.contains(data.getElementType().toString() + data.getAttributeName());
                     final Object[] values = state.getAttributeValues().get(type.getLabel() + data.getAttributeName());
-                    final boolean noValue = ((values == null) || (values[0] == null)); // does attribute have a null value
+                    final boolean noValue = attributeValuesEmpty(values); // does attribute have a null value
 
                     // If we are NOT showing all attributes and this attribute
                     // is null, don't add it to the list of children, this will

--- a/CoreAttributeEditorView/src/au/gov/asd/tac/constellation/views/attributeeditor/AttributeEditorPanel.java
+++ b/CoreAttributeEditorView/src/au/gov/asd/tac/constellation/views/attributeeditor/AttributeEditorPanel.java
@@ -238,7 +238,7 @@ public class AttributeEditorPanel extends BorderPane {
             root.getChildren().add(tooltipPane);
             this.setCenter(root);
         });
-        showEmptyToggles = new HashMap<HeadingType, ToggleButton>();
+        showEmptyToggles = new HashMap<>();
         updateEditorPanel(null);
     }
 
@@ -249,7 +249,6 @@ public class AttributeEditorPanel extends BorderPane {
     public void refreshShowEmpty() {
         for (final HeadingType headingType : HeadingType.values()) {
             final String emptyKey;
-            final GraphElementType elementType;
             switch (headingType) {
                 case GRAPH:
                     emptyKey = AttributePreferenceKey.GRAPH_SHOW_EMPTY;
@@ -527,8 +526,7 @@ public class AttributeEditorPanel extends BorderPane {
      * @return True if values is null or all values in the supplied values list
      * are empty (null) or false otherwise.
      */
-    private boolean attributeValuesEmpty(final Object[] values)
-    {
+    private boolean attributeValuesEmpty(final Object[] values) {
         if (values == null) {
             return true;
         }
@@ -551,7 +549,6 @@ public class AttributeEditorPanel extends BorderPane {
      */
     private TitledPane createAttributeTitlePane(final AttributeData attribute, final Object[] values, final double longestTitledWidth, final boolean hidden) {
         final String attributeTitle = attribute.getAttributeName();
-        final boolean noValue = attributeValuesEmpty(values); // does attribute have a null value
         final int spacing = 5;
         final GridPane gridPane = new GridPane();
         gridPane.setHgap(spacing);

--- a/CoreAttributeEditorView/src/au/gov/asd/tac/constellation/views/attributeeditor/AttributeEditorPanel.java
+++ b/CoreAttributeEditorView/src/au/gov/asd/tac/constellation/views/attributeeditor/AttributeEditorPanel.java
@@ -246,10 +246,8 @@ public class AttributeEditorPanel extends BorderPane {
      * Every time that the 'Attribute Editor' is redisplayed, reset the
      * 'Show Empty' toggles to be toggled on.
      */
-    public void refreshShowEmpty()
-    {
-        for (final HeadingType headingType : HeadingType.values())
-        {
+    public void refreshShowEmpty() {
+        for (final HeadingType headingType : HeadingType.values()) {
             final String emptyKey;
             final GraphElementType elementType;
             switch (headingType) {
@@ -269,8 +267,7 @@ public class AttributeEditorPanel extends BorderPane {
 
             // Ensure empty attributes are shown by default  
             prefs.putBoolean(emptyKey, true);
-            if (showEmptyToggles.containsKey(headingType))
-            {
+            if (showEmptyToggles.containsKey(headingType)) {
                 showEmptyToggles.get(headingType).setSelected(true); 
             }
         }
@@ -367,7 +364,7 @@ public class AttributeEditorPanel extends BorderPane {
                 elementType = null;
                 break;
         }
-        showEmptyToggle.selectedProperty().addListener((ObservableValue<? extends Boolean> observable, Boolean oldValue, Boolean newValue)
+        showEmptyToggle.selectedProperty().addListener((final ObservableValue<? extends Boolean> observable, final Boolean oldValue, final Boolean newValue)
                 -> prefs.putBoolean(emptyKey, newValue));
         showEmptyToggle.setSelected(prefs.getBoolean(emptyKey, false));
         showEmptyToggles.put(headingType, showEmptyToggle);  // Store handle to toggle
@@ -394,7 +391,7 @@ public class AttributeEditorPanel extends BorderPane {
                 hiddenKey = "";
                 break;
         }
-        showHiddenToggle.selectedProperty().addListener((ObservableValue<? extends Boolean> observable, Boolean oldValue, Boolean newValue)
+        showHiddenToggle.selectedProperty().addListener((final ObservableValue<? extends Boolean> observable, final Boolean oldValue, final Boolean newValue)
                 -> prefs.putBoolean(hiddenKey, newValue));
         showHiddenToggle.setSelected(prefs.getBoolean(hiddenKey, false));
 
@@ -532,9 +529,13 @@ public class AttributeEditorPanel extends BorderPane {
      */
     private boolean attributeValuesEmpty(final Object[] values)
     {
-        if (values == null) return true;
+        if (values == null) {
+            return true;
+        }
         for (final Object value : values) {
-            if (value != null) return false;
+            if (value != null) {
+                return false;
+            }
         }
         return true;
     }

--- a/CoreAttributeEditorView/src/au/gov/asd/tac/constellation/views/attributeeditor/AttributeEditorPanel.java
+++ b/CoreAttributeEditorView/src/au/gov/asd/tac/constellation/views/attributeeditor/AttributeEditorPanel.java
@@ -533,7 +533,7 @@ public class AttributeEditorPanel extends BorderPane {
     private boolean attributeValuesEmpty(final Object[] values)
     {
         if (values == null) return true;
-        for (Object value : values) {
+        for (final Object value : values) {
             if (value != null) return false;
         }
         return true;

--- a/CoreAttributeEditorView/src/au/gov/asd/tac/constellation/views/attributeeditor/AttributeEditorPanel.java
+++ b/CoreAttributeEditorView/src/au/gov/asd/tac/constellation/views/attributeeditor/AttributeEditorPanel.java
@@ -144,7 +144,7 @@ public class AttributeEditorPanel extends BorderPane {
     private static final double CELL_ITEM_SPACING = 5;
     private static final int VISIBLE_ROWS = 10;
     private static final String[] HEADING_TITLES = {"Graph  (%d attributes%s)", "Node  (%d attributes%s)", "Transaction  (%d attributes%s)"};
-    private static final String HIDDEN_ATTRIBUTES_INFORMATION = ", %d hidden/empty";
+    private static final String HIDDEN_EMPTY_ATTRIBUTES_INFORMATION = ", %d not shown";
     private static final GraphElementType[] ELEMENT_TYPES = {GraphElementType.GRAPH, GraphElementType.VERTEX, GraphElementType.TRANSACTION};
     private static final String NO_VALUE_TEXT = "<No Value>";
 
@@ -164,11 +164,12 @@ public class AttributeEditorPanel extends BorderPane {
     private final AttributeEditorTopComponent topComponent;
     private final StringProperty[] headingTitleProperties = new StringProperty[3];
     private final Map<GraphElementType, List<String>> currentAttributeNames = new HashMap<>();
-
+    
     private enum HeadingType {
         GRAPH, NODE, TRANSACTION;
     }
-
+    
+    private final Map<HeadingType, ToggleButton> showEmptyToggles; // Access to 'Show Toggle' buttons to allow reset
     private static final AttributeEditorFactory ATTRIBUTE_EDITOR_FACTORY = new AttributeEditorFactory();
     private static final ListSelectionEditorFactory LIST_SELECTION_EDITOR_FACTORY = new ListSelectionEditorFactory();
     private static final TimeZoneEditorFactory UPDATE_TIME_ZONE_EDITOR_FACTORY = new TimeZoneEditorFactory();
@@ -237,8 +238,42 @@ public class AttributeEditorPanel extends BorderPane {
             root.getChildren().add(tooltipPane);
             this.setCenter(root);
         });
-
+        showEmptyToggles = new HashMap<HeadingType, ToggleButton>();
         updateEditorPanel(null);
+    }
+
+    /**
+     * Every time that the 'Attribute Editor' is redisplayed, reset the
+     * 'Show Empty' toggles to be toggled on.
+     */
+    public void refreshShowEmpty()
+    {
+        for (final HeadingType headingType : HeadingType.values())
+        {
+            final String emptyKey;
+            final GraphElementType elementType;
+            switch (headingType) {
+                case GRAPH:
+                    emptyKey = AttributePreferenceKey.GRAPH_SHOW_EMPTY;
+                    break;
+                case NODE:
+                    emptyKey = AttributePreferenceKey.NODE_SHOW_EMPTY;
+                    break;
+                case TRANSACTION:
+                    emptyKey = AttributePreferenceKey.TRANSACTION_SHOW_EMPTY;
+                    break;
+                default:
+                    emptyKey = "";
+                    break;
+            }
+
+            // Ensure empty attributes are shown by default  
+            prefs.putBoolean(emptyKey, true);
+            if (showEmptyToggles.containsKey(headingType))
+            {
+                showEmptyToggles.get(headingType).setSelected(true); 
+            }
+        }
     }
 
     protected void rebuildColorMenu() {
@@ -304,36 +339,64 @@ public class AttributeEditorPanel extends BorderPane {
         heading.textProperty().bind(title);
         heading.setStyle("-fx-font-weight:bold;");
         heading.setFill(Color.web("#e0e0e0"));
-        final ToggleButton showAllToggle = new ToggleButton("Show all");
-        showAllToggle.setAlignment(Pos.CENTER);
-        showAllToggle.setTextAlignment(TextAlignment.CENTER);
-        showAllToggle.setStyle("-fx-background-insets: 0, 0; -fx-padding: 0");
-        showAllToggle.setPrefSize(60, 12);
-        showAllToggle.setPadding(new Insets(5));
-        showAllToggle.setTooltip(new Tooltip("Show hidden and empty attributes"));
-        final String key;
+        
+        final ToggleButton showEmptyToggle = new ToggleButton("Show Empty");
+        showEmptyToggle.setAlignment(Pos.CENTER);
+        showEmptyToggle.setTextAlignment(TextAlignment.CENTER);
+        showEmptyToggle.setStyle("-fx-background-insets: 0, 0; -fx-padding: 0");
+        showEmptyToggle.setPrefSize(80, 12);
+        showEmptyToggle.setPadding(new Insets(5));
+        showEmptyToggle.setTooltip(new Tooltip("Show empty attributes"));
+        final String emptyKey;
         final GraphElementType elementType;
         switch (headingType) {
             case GRAPH:
-                key = AttributePreferenceKey.GRAPH_SHOW_ALL;
+                emptyKey = AttributePreferenceKey.GRAPH_SHOW_EMPTY;
                 elementType = GraphElementType.GRAPH;
                 break;
             case NODE:
-                key = AttributePreferenceKey.NODE_SHOW_ALL;
+                emptyKey = AttributePreferenceKey.NODE_SHOW_EMPTY;
                 elementType = GraphElementType.VERTEX;
                 break;
             case TRANSACTION:
-                key = AttributePreferenceKey.TRANSACTION_SHOW_ALL;
+                emptyKey = AttributePreferenceKey.TRANSACTION_SHOW_EMPTY;
                 elementType = GraphElementType.TRANSACTION;
                 break;
             default:
-                key = "";
+                emptyKey = "";
                 elementType = null;
                 break;
         }
-        showAllToggle.selectedProperty().addListener((ObservableValue<? extends Boolean> observable, Boolean oldValue, Boolean newValue)
-                -> prefs.putBoolean(key, newValue));
-        showAllToggle.setSelected(prefs.getBoolean(key, false));
+        showEmptyToggle.selectedProperty().addListener((ObservableValue<? extends Boolean> observable, Boolean oldValue, Boolean newValue)
+                -> prefs.putBoolean(emptyKey, newValue));
+        showEmptyToggle.setSelected(prefs.getBoolean(emptyKey, false));
+        showEmptyToggles.put(headingType, showEmptyToggle);  // Store handle to toggle
+
+        final ToggleButton showHiddenToggle = new ToggleButton("Show Hidden");
+        showHiddenToggle.setAlignment(Pos.CENTER);
+        showHiddenToggle.setTextAlignment(TextAlignment.CENTER);
+        showHiddenToggle.setStyle("-fx-background-insets: 0, 0; -fx-padding: 0");
+        showHiddenToggle.setPrefSize(80, 12);
+        showHiddenToggle.setPadding(new Insets(5));
+        showHiddenToggle.setTooltip(new Tooltip("Show hidden attributes"));
+        final String hiddenKey;
+        switch (headingType) {
+            case GRAPH:
+                hiddenKey = AttributePreferenceKey.GRAPH_SHOW_HIDDEN;
+                break;
+            case NODE:
+                hiddenKey = AttributePreferenceKey.NODE_SHOW_HIDDEN;
+                break;
+            case TRANSACTION:
+                hiddenKey = AttributePreferenceKey.TRANSACTION_SHOW_HIDDEN;
+                break;
+            default:
+                hiddenKey = "";
+                break;
+        }
+        showHiddenToggle.selectedProperty().addListener((ObservableValue<? extends Boolean> observable, Boolean oldValue, Boolean newValue)
+                -> prefs.putBoolean(hiddenKey, newValue));
+        showHiddenToggle.setSelected(prefs.getBoolean(hiddenKey, false));
 
         final Button addMenu = new Button(null, new ImageView(UserInterfaceIconProvider.ADD.buildImage(16)));
         addMenu.setAlignment(Pos.CENTER);
@@ -427,7 +490,7 @@ public class AttributeEditorPanel extends BorderPane {
         }
 
         optionsButtons.maxHeightProperty().bind(addMenu.heightProperty());
-        optionsButtons.getChildren().addAll(showAllToggle, addMenu, editKeyButton);
+        optionsButtons.getChildren().addAll(showEmptyToggle, showHiddenToggle, addMenu, editKeyButton);
         headerGraphic.setLeft(heading);
         headerGraphic.setRight(optionsButtons);
         headerGraphic.prefWidthProperty().bind(scrollPane.widthProperty().subtract(45));
@@ -615,8 +678,8 @@ public class AttributeEditorPanel extends BorderPane {
                 for (int i = 0; i < titledPaneHeadingsContainer.getChildren().size(); i++) {
                     final TitledPane tp = (TitledPane) titledPaneHeadingsContainer.getChildren().get(i);
                     final int count = ((VBox) tp.getContent()).getChildren().size();
-                    final int totalAttrs = state.getAttributeCounts().get(ELEMENT_TYPES[i]);
-                    final String attrCountDisplay = totalAttrs == count ? String.format(HEADING_TITLES[i], totalAttrs, "") : String.format(HEADING_TITLES[i], totalAttrs, String.format(HIDDEN_ATTRIBUTES_INFORMATION, totalAttrs - count));
+                    final int totalAttrs = state.getAttributeCounts().get(ELEMENT_TYPES[i]);                 
+                    final String attrCountDisplay = totalAttrs == count ? String.format(HEADING_TITLES[i], totalAttrs, "") : String.format(HEADING_TITLES[i], totalAttrs, String.format(HIDDEN_EMPTY_ATTRIBUTES_INFORMATION, totalAttrs - count));
                     headingTitleProperties[i].setValue(attrCountDisplay);
                     if (!state.getActiveGraphElements().isEmpty()) {
                         tp.setExpanded(state.getActiveGraphElements().contains(ELEMENT_TYPES[i]));
@@ -740,18 +803,18 @@ public class AttributeEditorPanel extends BorderPane {
     private void populateContentContainer(final AttributeState state, final GraphElementType type, final double longestTitleWidth) {
         final int elementTypeIndex;
 
-        String showAllKey = "";  //Key used to indicate state of "Show All" key 
+        String showEmptyKey = ""; // Key used to indicate state of "Show Empty" key 
         switch (type) {
             case GRAPH:
-                showAllKey = AttributePreferenceKey.GRAPH_SHOW_ALL;
+                showEmptyKey = AttributePreferenceKey.GRAPH_SHOW_EMPTY;
                 elementTypeIndex = 0;
                 break;
             case VERTEX:
-                showAllKey = AttributePreferenceKey.NODE_SHOW_ALL;
+                showEmptyKey = AttributePreferenceKey.NODE_SHOW_EMPTY;
                 elementTypeIndex = 1;
                 break;
             case TRANSACTION:
-                showAllKey = AttributePreferenceKey.TRANSACTION_SHOW_ALL;
+                showEmptyKey = AttributePreferenceKey.TRANSACTION_SHOW_EMPTY;
                 elementTypeIndex = 2;
                 break;
             default:
@@ -760,7 +823,7 @@ public class AttributeEditorPanel extends BorderPane {
         }
 
         // Check if we are showing all attributes regardless of hidden state
-        final boolean showAll = prefs.getBoolean(showAllKey, false);
+        final boolean showEmpty = prefs.getBoolean(showEmptyKey, false);
       
         if (elementTypeIndex > -1 && state != null) {
             final List<AttributeData> attributeDataList = state.getAttributeNames().get(type);
@@ -779,7 +842,7 @@ public class AttributeEditorPanel extends BorderPane {
                     // If we are NOT showing all attributes and this attribute
                     // is null, don't add it to the list of children, this will
                     // have the effect of hiding it
-                    if (showAll || !noValue) {
+                    if (showEmpty || !noValue ) {
                         final TitledPane attribute = createAttributeTitlePane(data, values, longestTitleWidth, hidden);
                         attribute.setMinWidth(0);
                         attribute.maxWidthProperty().bind(header.widthProperty());

--- a/CoreAttributeEditorView/src/au/gov/asd/tac/constellation/views/attributeeditor/AttributeEditorTopComponent.java
+++ b/CoreAttributeEditorView/src/au/gov/asd/tac/constellation/views/attributeeditor/AttributeEditorTopComponent.java
@@ -173,6 +173,12 @@ public final class AttributeEditorTopComponent extends JavaFxTopComponent<Attrib
         newActiveGraph(GraphManager.getDefault().getActiveGraph());
 
         PreferenceUtilities.addPreferenceChangeListener(prefs.absolutePath(), this);
+        
+        // Ensure that all the 'Show Empty' buttons are toggled on when panel
+        // is re-displayed
+        if (attributePanel != null) {
+            attributePanel.refreshShowEmpty();
+        }
     }
 
     @Override

--- a/CoreAttributeEditorView/src/au/gov/asd/tac/constellation/views/attributeeditor/AttributeEditorTopComponent.java
+++ b/CoreAttributeEditorView/src/au/gov/asd/tac/constellation/views/attributeeditor/AttributeEditorTopComponent.java
@@ -26,6 +26,7 @@ import au.gov.asd.tac.constellation.views.JavaFxTopComponent;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.LinkedBlockingQueue;
+import java.util.prefs.PreferenceChangeEvent;
 import java.util.prefs.PreferenceChangeListener;
 import java.util.prefs.Preferences;
 import org.netbeans.api.settings.ConvertAsProperties;
@@ -257,5 +258,12 @@ public final class AttributeEditorTopComponent extends JavaFxTopComponent<Attrib
     @Override
     protected AttributeEditorPanel createContent() {
         return attributePanel;
+    }
+    
+    @Override
+    protected void handlePreferenceChange(final PreferenceChangeEvent event) {
+        if (reader != null) {
+            attributePanel.updateEditorPanel(reader.refreshAttributes(true));
+        }
     }
 }

--- a/CoreAttributeEditorView/src/au/gov/asd/tac/constellation/views/attributeeditor/AttributePreferenceKey.java
+++ b/CoreAttributeEditorView/src/au/gov/asd/tac/constellation/views/attributeeditor/AttributePreferenceKey.java
@@ -33,9 +33,12 @@ public class AttributePreferenceKey {
     protected static final char[] META_CHARS = {SPLIT_CHAR};
     protected static final Set<Character> SPLIT_CHAR_SET = new HashSet<>();
     public static final String HIDDEN_ATTRIBUTES = "hiddenAttribute";
-    public static final String GRAPH_SHOW_ALL = "graphShowAll";
-    public static final String NODE_SHOW_ALL = "nodeShowAll";
-    public static final String TRANSACTION_SHOW_ALL = "transactionShowAll";
+    public static final String GRAPH_SHOW_HIDDEN = "graphShowHidden";
+    public static final String NODE_SHOW_HIDDEN = "nodeShowHidden";
+    public static final String TRANSACTION_SHOW_HIDDEN = "transactionShowHidden";
+    public static final String GRAPH_SHOW_EMPTY = "graphShowEmpty";
+    public static final String NODE_SHOW_EMPTY = "nodeShowEmpty";
+    public static final String TRANSACTION_SHOW_EMPTY = "transactionShowEmpty"; 
     public static final String PRIMARY_KEY_ATTRIBUTE_COLOR = "primaryKeyAttributeColor";
     public static final String CUSTOM_ATTRIBUTE_COLOR = "customAttributeColor";
     public static final String SCHEMA_ATTRIBUTE_COLOR = "schemaAttributeColor";

--- a/CoreAttributeEditorView/src/au/gov/asd/tac/constellation/views/attributeeditor/AttributeReader.java
+++ b/CoreAttributeEditorView/src/au/gov/asd/tac/constellation/views/attributeeditor/AttributeReader.java
@@ -106,12 +106,12 @@ public class AttributeReader {
         boolean selectionModified = false;
         boolean attributeModified = false;
         boolean valueModified = false;
-
-        // show all preferences
-        final Map<GraphElementType, Boolean> showAllPrefs = new HashMap<>();
-        showAllPrefs.put(GraphElementType.GRAPH, prefs.getBoolean(AttributePreferenceKey.GRAPH_SHOW_ALL, false));
-        showAllPrefs.put(GraphElementType.VERTEX, prefs.getBoolean(AttributePreferenceKey.NODE_SHOW_ALL, false));
-        showAllPrefs.put(GraphElementType.TRANSACTION, prefs.getBoolean(AttributePreferenceKey.TRANSACTION_SHOW_ALL, false));
+        
+        // hidden attribute preferences
+        final Map<GraphElementType, Boolean> showHiddenPrefs = new HashMap<>();
+        showHiddenPrefs.put(GraphElementType.GRAPH, prefs.getBoolean(AttributePreferenceKey.GRAPH_SHOW_HIDDEN, false));
+        showHiddenPrefs.put(GraphElementType.VERTEX, prefs.getBoolean(AttributePreferenceKey.NODE_SHOW_HIDDEN, false));
+        showHiddenPrefs.put(GraphElementType.TRANSACTION, prefs.getBoolean(AttributePreferenceKey.TRANSACTION_SHOW_HIDDEN, false));
 
         final List<String> hiddenAttrs = StringUtilities.splitLabelsWithEscapeCharacters(prefs.get(AttributePreferenceKey.HIDDEN_ATTRIBUTES, ""), AttributePreferenceKey.SPLIT_CHAR_SET);
         final Set<String> hiddenAttrsSet = new HashSet<>(hiddenAttrs);
@@ -125,7 +125,7 @@ public class AttributeReader {
             attributeModified = currAttributeModificationCount != lastAttributeModificationCount;
             lastAttributeModificationCount = currAttributeModificationCount;
             if (attributeModified || preferenceChanged) {
-                updateElementAttributeNames(rg, ACCEPTED_ELEMENT_TYPES, hiddenAttrsSet, showAllPrefs);
+                updateElementAttributeNames(rg, ACCEPTED_ELEMENT_TYPES, hiddenAttrsSet, showHiddenPrefs);
             }
             final List<GraphElementType> toPopulate = new ArrayList<>(activeElementTypes);
             toPopulate.add(GraphElementType.GRAPH);
@@ -175,7 +175,6 @@ public class AttributeReader {
                             selectedNodes.add(result.getNextElement());
                         }
                     }
-
                 }
             };
             selectedNodethread.setName(UPDATE_SELECTED_NODE_THREAD_NAME);
@@ -225,20 +224,20 @@ public class AttributeReader {
         }
     }
 
-    private void updateElementAttributeNames(final ReadableGraph rg, final List<GraphElementType> elementTypes, final Set<String> hiddenAttrsSet, final Map<GraphElementType, Boolean> showAllPrefs) {
+    private void updateElementAttributeNames(final ReadableGraph rg, final List<GraphElementType> elementTypes, final Set<String> hiddenAttrsSet, final Map<GraphElementType, Boolean> showHiddenPrefs) {
 
         elementAttributeData.clear();
         for (final GraphElementType elementType : elementTypes) {
 
             final int attributeCount = rg.getAttributeCount(elementType);
             final ArrayList<AttributeData> attributeNames = new ArrayList<>();
-            final boolean showAll = showAllPrefs.get(elementType);
+            final boolean showHidden = showHiddenPrefs.get(elementType);
             for (int i = 0; i < attributeCount; i++) {
 
                 final Attribute attr = new GraphAttribute(rg, rg.getAttribute(elementType, i));
                 // do check only if not showing all
 
-                if (!showAll && hiddenAttrsSet.contains(attr.getElementType().toString() + attr.getName())) {
+                if (!showHidden && hiddenAttrsSet.contains(attr.getElementType().toString() + attr.getName())) {
                     continue;
                 }
 

--- a/CoreWhatsNewView/src/au/gov/asd/tac/constellation/views/whatsnew/whatsnew.txt
+++ b/CoreWhatsNewView/src/au/gov/asd/tac/constellation/views/whatsnew/whatsnew.txt
@@ -1,6 +1,11 @@
 == 3030-12-31 Getting Started
 <p>If you're new to Constellation, read the <a href="" helpId="au.gov.asd.tac.constellation.functionality.gettingstarted">getting started guide</a>.</p>
 
+== 2023-09-28 Hide empty attributes in the Attribute Editor View
+<p>The Attribute Editor view now allows for empty (null) attributes to be hidden to de-clutter the view.</p>
+<p>The heading of each attribute category has replaced the "Show all" toggle with a "Show Hidden" toggle and a new "Show Empty" toggle has been added. The "Show Empty" toggle is enabled each time Constellation is restarted to ensure users make a conscious decision to hide them.</p>
+<p>Attributes that are marked as hidden will only be shown if the "Show Hidden" toggle is enabled while attributes that have no value set (and are empty) will only be shown if the "Show Empty" toggle is enabled. Hidden and empty attributes require both toggles to be enabled.</p>
+
 == 2023-08-28 Markdown support in the Notes View
 <p>The notes can now optionally render markdown text. You can now italicise, bold and strikethrough text. Headings can be added to the note as well as lists and sub lists.</p>
 <p>The new note pop-up window will have a preview tab where you can see how your markdown text will be rendered before adding it as a note.</p>


### PR DESCRIPTION
### Prerequisites

- [X] Reviewed the [checklist](CHECKLIST.md)

- [X] Reviewed feedback from the "Sonar Cloud" bot. Note that you have to wait
    for the "CI / Unit Tests") to complete first. Failed Unit tests can be 
    debugged by adding the label "verbose logging" to the GitHub PR.

### Description of the Change

Added checks of attributes being displayed in populateContentContainer and if "Show All" is NOT enabled and values are null then dont call createAttributeTitlePane and add title pane for the attributes.

Updated AttributeEditorTopComponent to have a hook for preference changes to allow update as Show All is toggled.

### Alternate Designs

nil

### Why Should This Be In Core?

Fixing bug in "Show All" plus user requested ability to hide large amounts of null content

### Benefits

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process

Open a graph and Attribute Editor. Hide/Unhide some attributes and ensure they are hidden/shown on Attribute editor. Now enable "Show All" and repeat.

confirm that if no node selected all node attributes show as null and dont display if "Show All" not enabled.
Set valeus for one or more of these and confirm it is shown as having a value.

### Applicable Issues

#1893 
