### PR TITLE
Handle null values in selected Editors

### DIFF
--- a/CoreAttributeEditorView/src/au/gov/asd/tac/constellation/views/attributeeditor/editors/BooleanEditorFactory.java
+++ b/CoreAttributeEditorView/src/au/gov/asd/tac/constellation/views/attributeeditor/editors/BooleanEditorFactory.java
@@ -58,7 +58,8 @@ public class BooleanEditorFactory extends AttributeValueEditorFactory<Boolean> {
 
         @Override
         public void updateControlsWithValue(final Boolean value) {
-            checkBox.setSelected(value);
+            // A null boolean is treated as false
+            checkBox.setSelected((value != null) && value);
         }
 
         @Override

--- a/CoreAttributeEditorView/src/au/gov/asd/tac/constellation/views/attributeeditor/editors/DecoratorsEditorFactory.java
+++ b/CoreAttributeEditorView/src/au/gov/asd/tac/constellation/views/attributeeditor/editors/DecoratorsEditorFactory.java
@@ -71,7 +71,12 @@ public class DecoratorsEditorFactory extends AttributeValueEditorFactory<VertexD
         }
 
         @Override
-        public void updateControlsWithValue(final VertexDecorators value) {
+        public void updateControlsWithValue(VertexDecorators value) {
+            // Ensure a null value is translated to an empty/default VertexDecorators object
+            if (value == null ) {
+                value = new VertexDecorators(null, null, null, null);
+            }
+            
             setDecoratorChoice(nwCombo, value.getNorthWestDecoratorAttribute());
             setDecoratorChoice(neCombo, value.getNorthEastDecoratorAttribute());
             setDecoratorChoice(seCombo, value.getSouthEastDecoratorAttribute());

--- a/CoreAttributeEditorView/src/au/gov/asd/tac/constellation/views/attributeeditor/editors/DrawFlagsEditorFactory.java
+++ b/CoreAttributeEditorView/src/au/gov/asd/tac/constellation/views/attributeeditor/editors/DrawFlagsEditorFactory.java
@@ -61,7 +61,12 @@ public class DrawFlagsEditorFactory extends AttributeValueEditorFactory<DrawFlag
         }
 
         @Override
-        public void updateControlsWithValue(final DrawFlags value) {
+        public void updateControlsWithValue(DrawFlags value) {
+            // Ensure a null value is translated to an empty/default DrawFlags object
+            if (value == null ) {
+                value = new DrawFlags(false, false, false, false, false);
+            }
+            
             drawNodesCheckBox.setSelected(value.drawNodes());
             drawConnectionsCheckBox.setSelected(value.drawConnections());
             drawNodeLabelsCheckBox.setSelected(value.drawNodeLabels());


### PR DESCRIPTION
Handle null values in selected Editors

### Prerequisites

- [x] Reviewed the [checklist](CHECKLIST.md)

- [x] Reviewed feedback from the "Sonar Cloud" bot. Note that you have to wait
    for the "CI / Unit Tests") to complete first. Failed Unit tests can be 
    debugged by adding the label "verbose logging" to the GitHub PR.

### Description of the Change

Look at atribute types in the attribute editor and for each one, test the ability to edit "multiple entries", which passes null to the Editor.
For those that cannot handle null, explictly catch the case and deal with it.

### Alternate Designs

Nil - bug fix

### Why Should This Be In Core?

bug fix

### Benefits

avoid errors which prevent editing multiple entires of the given types

### Possible Drawbacks

none known

### Verification Process

1. Create a new graph.
2. Add multiple custom attributes covering each data type.
3. Add two nodes.
4. Select one of the nodes and for each custom attribute, modifiy the value in the Attribute Editor.
5. now select both nodes and confirm that the atrtribute editor shows "Multiple Values" for each of the custom attribute.
6. For each custom attribute attempt to edit the multiple attributes and set to a known value.
7. Confirm changes are made.

### Applicable Issues

https://github.com/constellation-app/constellation/issues/1879