### PR TITLE
Removed hard coded default date value and use current date

### DIFF
--- a/CoreDataAccessView/src/au/gov/asd/tac/constellation/views/dataaccess/plugins/experimental/TestParametersPlugin.java
+++ b/CoreDataAccessView/src/au/gov/asd/tac/constellation/views/dataaccess/plugins/experimental/TestParametersPlugin.java
@@ -70,7 +70,6 @@ import java.nio.charset.StandardCharsets;
 import java.security.SecureRandom;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.time.Month;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoField;
@@ -210,7 +209,6 @@ public class TestParametersPlugin extends RecordStoreQueryPlugin implements Data
         final PluginParameter<LocalDateParameterValue> date = LocalDateParameterType.build(LOCAL_DATE_PARAMETER_ID);
         date.setName("Date");
         date.setDescription("Pick a day");
-        date.setLocalDateValue(LocalDate.of(2001, Month.JANUARY, 1));
         params.addParameter(date);
 
         final List<GraphElementTypeParameterValue> elementTypeOptions = new ArrayList<>();


### PR DESCRIPTION
### Prerequisites

- [x] Reviewed the [checklist](CHECKLIST.md)

- [x] Reviewed feedback from the "Sonar Cloud" bot. Note that you have to wait
    for the "CI / Unit Tests") to complete first. Failed Unit tests can be 
    debugged by adding the label "verbose logging" to the GitHub PR.

### Description of the Change

Remve hard coded default date in test parameters panel in DAV so that the current date is used instead

### Alternate Designs

nil

### Why Should This Be In Core?

make dates more accurate

### Benefits

make dates more accurate
consistent with developer settings in experimental

### Possible Drawbacks

nil
### Verification Process

1. Open a new graph
2. Select Experimental->Developer->Test Parameter Building and confirm date shown is current, close dialog
3. Open the Data Access View
4. Expand Developer->Test Parameters (Batched) and Developer->Test Parameters
5. Confirm that date shown in both expanded sections is current

### Applicable Issues

nil
