### PR TITLE
Analytic View Reset Bug

### DIFF
--- a/CoreAnalyticView/src/au/gov/asd/tac/constellation/views/analyticview/AnalyticViewPane.java
+++ b/CoreAnalyticView/src/au/gov/asd/tac/constellation/views/analyticview/AnalyticViewPane.java
@@ -221,7 +221,7 @@ public class AnalyticViewPane extends BorderPane {
     public void deactiveResultChanges() {
         final Map<GraphVisualisation, Boolean> graphVisualisations = AnalyticViewController.getDefault().getGraphVisualisations();
         if (graphVisualisations != null && !graphVisualisations.isEmpty()) {
-            graphVisualisations.entrySet().forEach(node -> node.getKey().deactivate(node.getValue()));
+            graphVisualisations.entrySet().forEach(node -> node.getKey().deactivate(true));
         }
     }
 

--- a/CoreAnalyticView/src/au/gov/asd/tac/constellation/views/analyticview/state/AnalyticDeactivateStateChangesPlugin.java
+++ b/CoreAnalyticView/src/au/gov/asd/tac/constellation/views/analyticview/state/AnalyticDeactivateStateChangesPlugin.java
@@ -55,7 +55,7 @@ public class AnalyticDeactivateStateChangesPlugin extends SimpleEditPlugin {
         final Map<GraphVisualisation, Boolean> graphVisualisations = currentState.getGraphVisualisations();
         if (!graphVisualisations.isEmpty()) {
             graphVisualisations.entrySet().forEach(node -> {
-                node.getKey().deactivate(node.getValue());
+                node.getKey().deactivate(true);
                 node.setValue(false);
             });
             currentState.setGraphVisualisations(graphVisualisations);


### PR DESCRIPTION
<!--

### Requirements

* Filling out the template is required. Any pull request that does not include
enough information to be reviewed in a timely manner may be closed at the
maintainers' discretion.
* All new code requires unit tests to ensure they work as expected and will
continue to work as new code is added in the future (regression testing).
* Make sure your branch name is prefixed by `feature`, `bugfix` or `release`
* Have you read Constellation's Code of Conduct? By filing an issue, you are
expected to comply with it, including treating everyone with respect:
https://github.com/constellation-app/constellation/blob/master/CODE_OF_CONDUCT.md

-->

### Prerequisites

- [x] Reviewed the [checklist](CHECKLIST.md)

- [ ] Reviewed feedback from the "Sonar Cloud" bot. Note that you have to wait
    for the "CI / Unit Tests") to complete first. Failed Unit tests can be 
    debugged by adding the label "verbose logging" to the GitHub PR.

### Description of the Change
Ensures that any changes made by the analytic view are always reset when the view is closed or a new analytic is run.
<!--

We must be able to understand the design of your change from this description.
If we can't get a good idea of what the code will be doing from the description
here, the pull request may be closed at the maintainers' discretion. Keep in
mind that the maintainer reviewing this PR may not be familiar with or have
worked with the code here recently, so please walk us through the concepts.

-->


### Why Should This Be In Core?
Bugfix
<!--

Explain why this functionality should be in Constellation Core as opposed to a
different module suite. Note that this question is more applicable when adding
new functionality. If this change is a minor update to an existing file then it
is understood that this change has to be to this module suite and a response
and therefore a response to this question is not required.

-->


### Verification Process
Open multiple graphs
Run an analytic on each and select some of the graph visualisations (color, hide and size)
Close the analytic view
Check that the changes made by those graph visualisations have been reverted on all graphs.

