### PR TITLE
Fixed pandas data type error #1816

### DIFF
--- a/CoreWebServer/src/au/gov/asd/tac/constellation/webserver/resources/constellation_client.py
+++ b/CoreWebServer/src/au/gov/asd/tac/constellation/webserver/resources/constellation_client.py
@@ -460,6 +460,8 @@ class Constellation:
         # We can't create a DataFrame if there is no data.
         #
         if data:
+            if isinstance(data, bytes):
+                data = data.decode('utf8')
             df = pd.read_json(data, orient='split', dtype=False, convert_dates=False)
             df, self.types = self._fix_types(df)
             return df

--- a/CoreWebServer/test/unit/src/au/gov/asd/tac/constellation/webserver/test_rest.py
+++ b/CoreWebServer/test/unit/src/au/gov/asd/tac/constellation/webserver/test_rest.py
@@ -28,7 +28,7 @@ def _test_post():
         ['4.3.2.1<IP Address>', '9.8.7.5<IP Address>', 'Online Location', datetime.datetime(2016, 1, 1, 3, 4, 5, 0)]
     ]
     df = pd.DataFrame(columns=columns, data=data)
-    cc.put_dataframe(df, arrange=False)
+    cc.put_dataframe(df, arrange='')
     cc.run_plugin('ArrangeInTrees')
     cc.run_plugin('ResetView')
 


### PR DESCRIPTION
### Prerequisites

- [X ] Reviewed the [checklist](CHECKLIST.md)

- [] Reviewed feedback from the "Sonar Cloud" bot. Note that you have to wait
    for the "CI / Unit Tests") to complete first. Failed Unit tests can be 
    debugged by adding the label "verbose logging" to the GitHub PR.

### Description of the Change

The constellation_client wasn't decoding the output from the server from bytes to a string to then be used by Panda's read_json as outlined in #1816.  In the past this was allowed by Pandas even though it wasn't documented.  This was changed without depreciation notice sometime last year.  
Since Constellation opens the default Jupyter instance there can be many different versions of python and pandas accessing the web server using the constellation client.
The change simply checks the data returned from the Constellation web server, if it is a byte type it'll decode it to utf8, as suggested in #1816 .  This will not effect the other accepted types such as path object of file buffers.
This has been tested on 3.7.6 (using the older version of Pandas) & 3.11 that uses the new version of Pandas that was erroring.
![image](https://github.com/constellation-app/constellation/assets/63685177/18dc3346-e4c1-45d4-b937-9fc68ea887f2)

There was also a small change to the python test package that referenced arrange as a boolean instead of a plugin or empty string.
### Alternate Designs

None

### Why Should This Be In Core?

This is a bug fix for running Jupyter with newer versions of Pandas therefore should be in Constellation core,

### Benefits

The Constellation Core now works with newer versions of python.

### Possible Drawbacks

None

### Verification Process

The changes were tested against both the older versions and newer versions of python / Pandas.
Testing the fix:
1. Install a new python virtual environment
2. Install all relevant libraries used by constellation_client
3. Add the new kernel to a Jupyter instance.
4. Add constellation_client.py as either a relative file or in the system paths (Constellation will do this to the default once it's pushed)
5. Add and run the example notebook to read the current graph - https://github.com/constellation-app/constellation-training/blob/master/Analyst%20Training/Exercise%2010%20-%20Network%20Analysis%20With%20Python/notebooks_and_constellation.ipynb
6. get_dataframe should return the graph as a dataframe instead of the error 'error:Expected file path name or file-like object, got <class 'bytes'> type'
7. 

### Applicable Issues

<!-- Link any applicable issues here -->
