### PR TITLE
Feature/rest case sensitivity 1767

### DIFF
--- a/CoreGraphFramework/src/au/gov/asd/tac/constellation/graph/processing/GraphRecordStoreUtilities.java
+++ b/CoreGraphFramework/src/au/gov/asd/tac/constellation/graph/processing/GraphRecordStoreUtilities.java
@@ -88,7 +88,7 @@ public class GraphRecordStoreUtilities {
             "source.Type",
             "destination.Type"
     );
-    private static final List<String> ApprovedTypes = SchemaVertexTypeUtilities.getTypes().stream().map(i -> i.getName()).collect(Collectors.toList());;
+    private static final List<String> ApprovedTypes = SchemaVertexTypeUtilities.getTypes().stream().map(i -> i.getName()).collect(Collectors.toList());
 
 
     private static int addVertex(final GraphWriteMethods graph, final Map<String, String> values,
@@ -1212,7 +1212,7 @@ public class GraphRecordStoreUtilities {
         
         // Identify a type that is spelt the same regardless of case.
         if (ApprovedTypes.indexOf(type) == -1) {
-            Optional<String> foundType = ApprovedTypes.stream().filter(i -> i.toLowerCase().equals(type.toLowerCase())).findFirst();
+            Optional<String> foundType = ApprovedTypes.stream().filter(i -> i.equalsIgnoreCase(type)).findFirst();
             if(foundType.isPresent()){
                 return parts.length != 2 ? foundType.get() : parts[0] + "<"+ foundType.get()+">";
             }

--- a/CoreGraphFramework/src/au/gov/asd/tac/constellation/graph/processing/GraphRecordStoreUtilities.java
+++ b/CoreGraphFramework/src/au/gov/asd/tac/constellation/graph/processing/GraphRecordStoreUtilities.java
@@ -1201,15 +1201,14 @@ public class GraphRecordStoreUtilities {
     /**
      * Normalize a type to existing schema types based on case sensitivity
      * e.g. person, PERSON, Person, will all normalize to the schema Type Person.
-     * @param label The {@link String} representing the complete label of a vertex
-     * e.g. def@example2.com<email>.
+     * @param vxLabel The {@link String} representing the complete label of a vertex
+     * e.g. def@example2.com&lt;email&gt;.
      * @return The normalized type e.g. Email
      */
 
     private static String normalizeType(final String vxLabel) {
         final String[] parts = vxLabel.split("<");
         final String type = parts.length != 2 ? parts[0] : parts[1].substring(0, parts[1].length()-1);
-        
         // Identify a type that is spelt the same regardless of case.
         if (ApprovedTypes.indexOf(type) == -1) {
             Optional<String> foundType = ApprovedTypes.stream().filter(i -> i.equalsIgnoreCase(type)).findFirst();
@@ -1217,7 +1216,6 @@ public class GraphRecordStoreUtilities {
                 return parts.length != 2 ? foundType.get() : parts[0] + "<"+ foundType.get()+">";
             }
         }
-        
         return vxLabel;
     }
 

--- a/CoreGraphFramework/src/au/gov/asd/tac/constellation/graph/processing/GraphRecordStoreUtilities.java
+++ b/CoreGraphFramework/src/au/gov/asd/tac/constellation/graph/processing/GraphRecordStoreUtilities.java
@@ -1206,16 +1206,19 @@ public class GraphRecordStoreUtilities {
      * @return The normalized type e.g. Email
      */
 
-    private static String normalizeType(final String vx_label) {
-        final String[] parts = vx_label.split("<");
+    private static String normalizeType(final String vxLabel) {
+        final String[] parts = vxLabel.split("<");
         final String type = parts.length != 2 ? parts[0] : parts[1].substring(0, parts[1].length()-1);
+        
+        // Identify a type that is spelt the same regardless of case.
         if (ApprovedTypes.indexOf(type) == -1) {
             Optional<String> foundType = ApprovedTypes.stream().filter(i -> i.toLowerCase().equals(type.toLowerCase())).findFirst();
             if(foundType.isPresent()){
                 return parts.length != 2 ? foundType.get() : parts[0] + "<"+ foundType.get()+">";
             }
         }
-        return vx_label;
+        
+        return vxLabel;
     }
 
     /**

--- a/CoreGraphFramework/src/au/gov/asd/tac/constellation/graph/processing/GraphRecordStoreUtilities.java
+++ b/CoreGraphFramework/src/au/gov/asd/tac/constellation/graph/processing/GraphRecordStoreUtilities.java
@@ -23,6 +23,7 @@ import au.gov.asd.tac.constellation.graph.GraphReadMethods;
 import au.gov.asd.tac.constellation.graph.GraphWriteMethods;
 import au.gov.asd.tac.constellation.graph.schema.type.SchemaTransactionType;
 import au.gov.asd.tac.constellation.graph.schema.type.SchemaTransactionTypeUtilities;
+import au.gov.asd.tac.constellation.graph.schema.type.SchemaVertexTypeUtilities;
 import au.gov.asd.tac.constellation.graph.utilities.CompositeTransactionId;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
@@ -36,10 +37,12 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Optional;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
 
 /**
@@ -75,6 +78,18 @@ public class GraphRecordStoreUtilities {
     private static final Charset UTF8 = StandardCharsets.UTF_8;
 
     private static final Logger LOGGER = Logger.getLogger(GraphRecordStoreUtilities.class.getName());
+    
+    // Columns that contain the type, either through the Identifier or Type.
+    private static final List<String> LabelTypes = Arrays.asList(
+            "source.Identifier",
+            "source.Label",
+            "destination.Identifier",
+            "destination.Label",
+            "source.Type",
+            "destination.Type"
+    );
+    private static final List<String> ApprovedTypes = SchemaVertexTypeUtilities.getTypes().stream().map(i -> i.getName()).collect(Collectors.toList());;
+
 
     private static int addVertex(final GraphWriteMethods graph, final Map<String, String> values,
             final Map<String, Integer> vertexMap, final boolean initializeWithSchema, boolean completeWithSchema,
@@ -405,13 +420,18 @@ public class GraphRecordStoreUtilities {
             final Map<String, String> transactionValues = new TreeMap<>();
             for (String key : keys) {
                 if (recordStore.hasValue(key)) {
-                    final String value = recordStore.get(key);
+                    String value = recordStore.get(key);
                     final int dividerPosition = key.indexOf('.');
 
                     if (dividerPosition > 0) {
                         final String keyDescriptor = key.substring(0, dividerPosition).toLowerCase();
                         final String keyAttribute = key.substring(dividerPosition + 1);
-                        final String[] parts = keyDescriptor.split("\\$"); // TODO: what ??
+                        final String[] parts = keyDescriptor.split("\\.");
+                        final String label = key.split("<")[0];
+                        
+                        if(LabelTypes.indexOf(label) > -1){
+                            value = normalizeType(value);
+                        }
 
                         switch (parts[0]) {
                             case "source":
@@ -1176,6 +1196,26 @@ public class GraphRecordStoreUtilities {
         for (int key : graph.getPrimaryKey(GraphElementType.VERTEX)) {
             recordStore.set(DESTINATION + graph.getAttributeName(key), graph.getStringValue(key, vertex));
         }
+    }
+    
+    /**
+     * Normalize a type to existing schema types based on case sensitivity
+     * e.g. person, PERSON, Person, will all normalize to the schema Type Person.
+     * @param label The {@link String} representing the complete label of a vertex
+     * e.g. def@example2.com<email>.
+     * @return The normalized type e.g. Email
+     */
+
+    private static String normalizeType(final String vx_label) {
+        final String[] parts = vx_label.split("<");
+        final String type = parts.length != 2 ? parts[0] : parts[1].substring(0, parts[1].length()-1);
+        if (ApprovedTypes.indexOf(type) == -1) {
+            Optional<String> foundType = ApprovedTypes.stream().filter(i -> i.toLowerCase().equals(type.toLowerCase())).findFirst();
+            if(foundType.isPresent()){
+                return parts.length != 2 ? foundType.get() : parts[0] + "<"+ foundType.get()+">";
+            }
+        }
+        return vx_label;
     }
 
     /**

--- a/CoreWebServer/test/unit/src/au/gov/asd/tac/constellation/webserver/test_rest.py
+++ b/CoreWebServer/test/unit/src/au/gov/asd/tac/constellation/webserver/test_rest.py
@@ -35,6 +35,26 @@ def _test_post():
     cc.run_plugin('SelectAll')
     cc.run_plugin('DeleteSelection')
 
+def _test_normalize_type():
+    csv_data = '''
+    from_address,from_country,to_address,to_country,dtg
+    ghi@example3.com,Zambia,mno@example3.com,Brazil,2017-01-02 01:22:33
+    '''.strip()
+    dfn = pd.read_csv(io.StringIO(csv_data))
+    dfn.from_address = dfn.from_address + '<EMAIL>'
+    dfn.to_address = dfn.to_address + '<email>'
+    dfn.dtg = pd.to_datetime(dfn.dtg)
+    dfn = dfn.rename(columns={
+        'from_address': 'source.Label',
+        'from_country': 'source.Geo.Country',
+        'to_address': 'destination.Label',
+        'to_country': 'destination.Geo.Country',
+        'dtg': 'transaction.DateTime'})
+    cc.new_graph()
+    cc.put_dataframe(dfn)
+    data = cc.get_dataframe()
+    data['source.Label'] == "ghi@example3.com<Email>"
+
 if __name__=='__main__':
     cc = constellation_client.Constellation()
     id = cc.new_graph()


### PR DESCRIPTION
### Prerequisites

- [ X] Reviewed the [checklist](CHECKLIST.md)

- [ ] Reviewed feedback from the "Sonar Cloud" bot. Note that you have to wait
    for the "CI / Unit Tests") to complete first. Failed Unit tests can be 
    debugged by adding the label "verbose logging" to the GitHub PR.

### Description of the Change

As outlined in issue #1767 when importing from Jupyter or any other external system using the REST API the types must be the exact same case as the Schema type otherwise they won't be recognized and it'll cause duplicate nodes with slightly different type.  The example given in issue #1767 was, person has to be "Person" and not "person" or "PERSON".

The case for the type varies and can also be extended upon (below) so this implementation will attempt a case insensitive match between the type and the list of available types.  Currently the 'Label', Idenitifer', and 'Type' fields will be normalized when added to the graph.
![image](https://github.com/constellation-app/constellation/assets/63685177/359699a3-d9f0-4a5a-adc5-96b7858b1db3)

Input script - Note the type should be 'Email' but 'email' and 'EMAIL' have been provided to demonstrate the bug.
![image](https://github.com/constellation-app/constellation/assets/63685177/2ed2203c-597b-4d25-a670-82433cf9f98f)

Before the change:
![image](https://github.com/constellation-app/constellation/assets/63685177/536ae093-f7d9-4072-87c0-24f38c0572a5)


After the change:
![image](https://github.com/constellation-app/constellation/assets/63685177/79fd4c91-fba3-4722-9bbc-d52df414c5cc)
Notice the type is also recognized: 
![image](https://github.com/constellation-app/constellation/assets/63685177/68764b94-a47f-40b4-b960-dfcf99870f33)

### Alternate Designs

This could have also been implemented in the constellation client however this would fix the issue when other applications outside of jupyter access the REST API.  In addition the list of types isn't exposed through the web server so changes would have to be made server side anyway. 
### Why Should This Be In Core?

This is a fix to the current issue of not recognizing types if they are the same case and the schema type.  

### Benefits

This will help keep a standard of types and will also deduplicate nodes that have different case types.

### Possible Drawbacks

None
### Verification Process
1. Open Constellation
2. Start Rest Server - Tools > Start Rest Server
3. Start Jupyter - Tools > Start Jupyter Notebook
4. Download the following notebook and add to your current instance of Jupyter - https://github.com/constellation-app/constellation-training/blob/master/Analyst%20Training/Exercise%2010%20-%20Network%20Analysis%20With%20Python/notebooks_and_constellation.ipynb
5. Change the types to mixed case, capitals, or lowercase and push the dataframe to constellation.
6. Verify the types have been normalized in the graph.


### Applicable Issues

#1767 
