### PR TITLE
Allow Saving Templates in the Data Access View when there are null Global Parameters.

### DIFF
--- a/CoreDataAccessView/src/au/gov/asd/tac/constellation/views/dataaccess/api/DataAccessUserPreferences.java
+++ b/CoreDataAccessView/src/au/gov/asd/tac/constellation/views/dataaccess/api/DataAccessUserPreferences.java
@@ -75,6 +75,7 @@ public final class DataAccessUserPreferences {
         // Extract the global parameters
         globalParameters = pane.getGlobalParametersPane().getParams().getParameters().entrySet().stream()
                 .map(param -> new AbstractMap.SimpleImmutableEntry<>(param.getKey(), param.getValue().getStringValue()))
+                .filter(param -> param.getValue() != null)
                 .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
         
         pluginParameters = new HashMap<>();

--- a/CoreDataAccessView/src/au/gov/asd/tac/constellation/views/dataaccess/io/DataAccessParametersIoProvider.java
+++ b/CoreDataAccessView/src/au/gov/asd/tac/constellation/views/dataaccess/io/DataAccessParametersIoProvider.java
@@ -65,7 +65,6 @@ public class DataAccessParametersIoProvider {
     public static void saveParameters(final TabPane tabs) {
         final List<DataAccessUserPreferences> dataAccessUserPreferenceses = new ArrayList<>();
 
-        String queryName = null;
         for (final Tab step : tabs.getTabs()) {
             // Translate the plugin pane to the JSON format
             final DataAccessUserPreferences preferences = new DataAccessUserPreferences(
@@ -76,26 +75,11 @@ public class DataAccessParametersIoProvider {
             final Label defaultCaption = (Label) tabCaption.getGraphic();
             preferences.setStepCaption(!StringUtils.isBlank(tabCaption.getText()) ? tabCaption.getText() : defaultCaption.getText());
 
-            // Remember the first non-null, non-blank query name.
-            if (queryName == null
-                    && preferences.getGlobalParameters().containsKey(
-                            CoreGlobalParameters.QUERY_NAME_PARAMETER_ID
-                    )
-                    && StringUtils.isNotBlank(preferences.getGlobalParameters().get(
-                            CoreGlobalParameters.QUERY_NAME_PARAMETER_ID
-                    ))) {
-                queryName = preferences.getGlobalParameters().get(
-                        CoreGlobalParameters.QUERY_NAME_PARAMETER_ID
-                );
-            }
-
             dataAccessUserPreferenceses.add(preferences);
         }
 
-        // Only save if the query name parameter is present
-        if (queryName != null) {
-            JsonIO.saveJsonPreferences(Optional.of(DATA_ACCESS_DIR), dataAccessUserPreferenceses);
-        }
+        // Can now save the preferences even if no query name parameter is present
+        JsonIO.saveJsonPreferences(Optional.of(DATA_ACCESS_DIR), dataAccessUserPreferenceses);
     }
 
     /**

--- a/CoreDataAccessView/test/unit/src/au/gov/asd/tac/constellation/views/dataaccess/io/DataAccessParametersIoProviderNGTest.java
+++ b/CoreDataAccessView/test/unit/src/au/gov/asd/tac/constellation/views/dataaccess/io/DataAccessParametersIoProviderNGTest.java
@@ -108,7 +108,7 @@ public class DataAccessParametersIoProviderNGTest {
                 "param2", "tab2_param2_value"
         );
 
-        saveParameters(tab1GlobalParams, tab2GlobalParams, false);
+        saveParameters(tab1GlobalParams, tab2GlobalParams, true);
     }
 
     @Test
@@ -122,7 +122,7 @@ public class DataAccessParametersIoProviderNGTest {
                 "param2", "tab2_param2_value"
         );
 
-        saveParameters(tab1GlobalParams, tab2GlobalParams, false);
+        saveParameters(tab1GlobalParams, tab2GlobalParams, true);
     }
 
     @Test


### PR DESCRIPTION

### Prerequisites

- [ ] Reviewed the [checklist](CHECKLIST.md)

- [ ] Reviewed feedback from the "Sonar Cloud" bot. Note that you have to wait
    for the "CI / Unit Tests") to complete first. Failed Unit tests can be 
    debugged by adding the label "verbose logging" to the GitHub PR.

### Description of the Change

We can now Save Templates in the Data Access View even when there are no values supplied yet in the Global Parameters.
This would previously either throw a null pointer exception, or not provide any feedback to the user that the save will not be performed.

### Alternate Designs

N/A

### Why Should This Be In Core?

Improved user experience, Improved functionality.

### Benefits

Properly handle null/empty Global Parameters when Saving Templates.
Don't throw unnecessary null pointer exceptions.

### Verification Process

Open the Data Access View.
Clear the Query Name parameter in the Global Parameters section (we are testing the case for when Query Name is empty).
Click the Workflow Options button and select Save Templates

Confirm that it prompts for a template name, rather than do nothing at all.
Now enter a name (ie. "template_test") and click OK.

Now set the current Query Name in the Data Access View to any arbitrary value ("abc").
Click the Workflow Options button and select Load Templates

Select the template that was saved earlier ("template_test") and click OK.
Confirm that the Query Name has now been cleared, matching the null/empty state it was in when the template was saved.

