### PR TITLE
Levenshtein allow identical matches

### DIFF
--- a/CoreAlgorithmPlugins/src/au/gov/asd/tac/constellation/plugins/algorithms/sna/similarity/LevenshteinDistancePlugin.java
+++ b/CoreAlgorithmPlugins/src/au/gov/asd/tac/constellation/plugins/algorithms/sna/similarity/LevenshteinDistancePlugin.java
@@ -38,10 +38,8 @@ import au.gov.asd.tac.constellation.plugins.parameters.types.SingleChoiceParamet
 import au.gov.asd.tac.constellation.plugins.parameters.types.SingleChoiceParameterType.SingleChoiceParameterValue;
 import au.gov.asd.tac.constellation.plugins.templates.PluginTags;
 import au.gov.asd.tac.constellation.plugins.templates.SimpleEditPlugin;
-import au.gov.asd.tac.constellation.utilities.datastructure.Tuple;
 import au.gov.asd.tac.constellation.utilities.gui.NotifyDisplayer;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.apache.commons.lang3.StringUtils;
@@ -138,8 +136,6 @@ public class LevenshteinDistancePlugin extends SimpleEditPlugin {
             return;
         }
 
-        final Map<Tuple<Integer, Integer>, Integer> distances = new HashMap<>();
-
         // compare each pair of vertices
         final int vertexCount = graph.getVertexCount();
         for (int one = 0; one < vertexCount; one++) {
@@ -165,11 +161,6 @@ public class LevenshteinDistancePlugin extends SimpleEditPlugin {
                 if (caseInsensitive) {
                     stringOne = stringOne.toLowerCase();
                     stringTwo = stringTwo.toLowerCase();
-                }
-
-                if (stringOne.equals(stringTwo)) {
-                    distances.put(Tuple.create(vxOneId, vxTwoId), 0);
-                    continue;
                 }
 
                 final LevenshteinDistanceFunction ldf = new LevenshteinDistanceFunction(maxDistance);

--- a/CoreAlgorithmPlugins/test/unit/src/au/gov/asd/tac/constellation/plugins/algorithms/sna/similarity/LevenshteinDistancePluginNGTest.java
+++ b/CoreAlgorithmPlugins/test/unit/src/au/gov/asd/tac/constellation/plugins/algorithms/sna/similarity/LevenshteinDistancePluginNGTest.java
@@ -126,6 +126,35 @@ public class LevenshteinDistancePluginNGTest {
      * @throws java.lang.Exception
      */
     @Test
+    public void testLevenshteinDistanceMaxDistanceZero() throws Exception {
+
+        final int vertexLabelAttributeId = VisualConcept.VertexAttribute.LABEL.ensure(graph);
+
+        graph.getSchema().newGraph(graph);
+        final int srcId = graph.addVertex();
+        graph.setStringValue(vertexLabelAttributeId, srcId, "Test");
+
+        final int dstId = graph.addVertex();
+        graph.setStringValue(vertexLabelAttributeId, dstId, "Test");
+
+        final LevenshteinDistancePlugin instance = new LevenshteinDistancePlugin();
+        PluginExecution.withPlugin(instance)
+                .withParameter(LevenshteinDistancePlugin.ATTRIBUTE_PARAMETER_ID, graph.getAttributeName(vertexLabelAttributeId))
+                .withParameter(LevenshteinDistancePlugin.MAXIMUM_DISTANCE_PARAMETER_ID, 0)
+                .withParameter(LevenshteinDistancePlugin.CASE_INSENSITIVE_PARAMETER_ID, false)
+                .withParameter(LevenshteinDistancePlugin.SELECTED_ONLY_PARAMETER_ID, false)
+                .executeNow(graph);
+
+        // Assert there is a similarity link between the nodes with distance = 1
+        assertEquals(graph.getTransactionCount(), 1);
+    }
+
+    /**
+     * Test of class LevenshteinDistancePlugin.
+     *
+     * @throws java.lang.Exception
+     */
+    @Test
     public void testLevenshteinDistanceCaseInsensitive() throws Exception {
 
         final int vertexIdentifierAttributeId = VisualConcept.VertexAttribute.IDENTIFIER.ensure(graph);


### PR DESCRIPTION
### Prerequisites

- [X] Reviewed the [checklist](CHECKLIST.md)

- [ ] Reviewed feedback from the "Sonar Cloud" bot. Note that you have to wait
    for the "CI / Unit Tests") to complete first. Failed Unit tests can be 
    debugged by adding the label "verbose logging" to the GitHub PR.

### Description of the Change

As outlined in #1894, when doing a levenshtein match on attributes in the analytic view identical matches are removed, this was originally a design decision to find similar attributes, not identical attributes.  This use case has since changed and the maxDistance can be zero.  The proposed change simply removes the checks to remove exact matches from the results.


### Alternate Designs

None considered.

### Why Should This Be In Core?

This is a modification to current core code and gives a consistent experience for the user.

### Benefits

Consistence experience when using the levenshtein analytic, when using the maximum distance results are returned as expected.

### Possible Drawbacks

None considered.

### Verification Process

1. Open a new graph in Constellation
2. Add three nodes 
3. Create a new string attribute 
4. With the new attribute change two nodes to have the exact same attribute and the 3rd to have a different attribute.
5. Open the Analytic View, select Similarity from Categories and select 'Levenshtein Distance Analytic'.
6. Change the Compare attribute to the newly created attribute.
7. Click Run
8. Verify the Nodes that have the same attribute value have a distance of zero and the 3rd node has a non-zero distance to the identical attributes.

![image](https://github.com/constellation-app/constellation/assets/63685177/685371ea-838a-4b15-89f8-6d06f6ef5f98)

### Applicable Issues

#1894 
