### PR TITLE
modified schema updater to account for changes since it was created

### DIFF
--- a/CoreVisualSchema/src/au/gov/asd/tac/constellation/graph/schema/visual/compatibility/VisualSchemaV6UpdateProvider.java
+++ b/CoreVisualSchema/src/au/gov/asd/tac/constellation/graph/schema/visual/compatibility/VisualSchemaV6UpdateProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2022 Australian Signals Directorate
+ * Copyright 2010-2024 Australian Signals Directorate
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +15,7 @@
  */
 package au.gov.asd.tac.constellation.graph.schema.visual.compatibility;
 
+import au.gov.asd.tac.constellation.graph.Graph;
 import au.gov.asd.tac.constellation.graph.GraphElementType;
 import au.gov.asd.tac.constellation.graph.StoreGraph;
 import au.gov.asd.tac.constellation.graph.schema.SchemaFactory;
@@ -28,8 +29,7 @@ import org.openide.util.lookup.ServiceProvider;
 /**
  *
  * This update ensures that the node_labels_top and node_labels bottom graph
- * attributes appropriately change name to node_top_labels_colours and
- * node_bottom_labels_colours
+ * attributes appropriately change to new name
  *
  * @author Atlas139mkm
  */
@@ -38,7 +38,6 @@ public class VisualSchemaV6UpdateProvider extends SchemaUpdateProvider {
 
     private static final String GRAPH_BOTTOM_LABELS = "node_labels_bottom";
     private static final String GRAPH_TOP_LABELS = "node_labels_top";
-    private static final String GRAPH_TRANSACTION_LABELS = "transaction_labels";
 
     public static final int SCHEMA_VERSION_THIS_UPDATE = 6;
 
@@ -63,31 +62,24 @@ public class VisualSchemaV6UpdateProvider extends SchemaUpdateProvider {
         // retrieve the attribute Id of both the graph_labels_top/bottom
         final int oldGraphBottomlabelsAttributeId = graph.getAttribute(GraphElementType.GRAPH, GRAPH_BOTTOM_LABELS);
         final int oldGraphToplabelsAttributeId = graph.getAttribute(GraphElementType.GRAPH, GRAPH_TOP_LABELS);
-        final int oldGraphTransactionlabelsAttributeId = graph.getAttribute(GraphElementType.GRAPH, GRAPH_TRANSACTION_LABELS);
 
-        // retrieve the new values for the graph_labels_bottom and set it to the
-        // new values
-        final int newGraphBottomLabelsAttributeId = VisualConcept.GraphAttribute.BOTTOM_LABELS.ensure(graph);
-        final String bottomLabelValue = graph.getStringValue(oldGraphBottomlabelsAttributeId, 0);
-        graph.setStringValue(newGraphBottomLabelsAttributeId, 0, bottomLabelValue);
+        // retrieve the new values for the graph_labels_bottom and set it to the new values
+        if (oldGraphBottomlabelsAttributeId != Graph.NOT_FOUND) {
+            final int newGraphBottomLabelsAttributeId = VisualConcept.GraphAttribute.BOTTOM_LABELS.ensure(graph);
+            final String bottomLabelValue = graph.getStringValue(oldGraphBottomlabelsAttributeId, 0);
+            graph.setStringValue(newGraphBottomLabelsAttributeId, 0, bottomLabelValue);
+        }
 
-        // retrieve the new values for the graph_labels_top and set it to the
-        // new values
-        final int newGraphTopLabelsAttributeId = VisualConcept.GraphAttribute.TOP_LABELS.ensure(graph);
-        final String topLabelValue = graph.getStringValue(oldGraphToplabelsAttributeId, 0);
-        graph.setStringValue(newGraphTopLabelsAttributeId, 0, topLabelValue);
-
-        // retrieve the new values for the transaction_labels and set it to the
-        // new values
-        final int newGraphTransactionlabelsAttributeId = VisualConcept.GraphAttribute.TRANSACTION_LABELS.ensure(graph);
-        final String transactionLabelValue = graph.getStringValue(oldGraphTransactionlabelsAttributeId, 0);
-        graph.setStringValue(newGraphTransactionlabelsAttributeId, 0, transactionLabelValue);
+        // retrieve the new values for the graph_labels_top and set it to the new values
+        if (oldGraphToplabelsAttributeId != Graph.NOT_FOUND) {
+            final int newGraphTopLabelsAttributeId = VisualConcept.GraphAttribute.TOP_LABELS.ensure(graph);
+            final String topLabelValue = graph.getStringValue(oldGraphToplabelsAttributeId, 0);
+            graph.setStringValue(newGraphTopLabelsAttributeId, 0, topLabelValue);
+        }
 
         // remove the old attributes
         graph.removeAttribute(oldGraphBottomlabelsAttributeId);
         graph.removeAttribute(oldGraphToplabelsAttributeId);
-        graph.removeAttribute(oldGraphTransactionlabelsAttributeId);
-
     }
 
 }

--- a/CoreVisualSchema/src/au/gov/asd/tac/constellation/graph/schema/visual/compatibility/VisualSchemaV6UpdateProvider.java
+++ b/CoreVisualSchema/src/au/gov/asd/tac/constellation/graph/schema/visual/compatibility/VisualSchemaV6UpdateProvider.java
@@ -68,6 +68,7 @@ public class VisualSchemaV6UpdateProvider extends SchemaUpdateProvider {
             final int newGraphBottomLabelsAttributeId = VisualConcept.GraphAttribute.BOTTOM_LABELS.ensure(graph);
             final String bottomLabelValue = graph.getStringValue(oldGraphBottomlabelsAttributeId, 0);
             graph.setStringValue(newGraphBottomLabelsAttributeId, 0, bottomLabelValue);
+            graph.removeAttribute(oldGraphBottomlabelsAttributeId);
         }
 
         // retrieve the new values for the graph_labels_top and set it to the new values
@@ -75,11 +76,8 @@ public class VisualSchemaV6UpdateProvider extends SchemaUpdateProvider {
             final int newGraphTopLabelsAttributeId = VisualConcept.GraphAttribute.TOP_LABELS.ensure(graph);
             final String topLabelValue = graph.getStringValue(oldGraphToplabelsAttributeId, 0);
             graph.setStringValue(newGraphTopLabelsAttributeId, 0, topLabelValue);
+            graph.removeAttribute(oldGraphToplabelsAttributeId);
         }
-
-        // remove the old attributes
-        graph.removeAttribute(oldGraphBottomlabelsAttributeId);
-        graph.removeAttribute(oldGraphToplabelsAttributeId);
     }
 
 }

--- a/CoreVisualSchema/test/unit/src/au/gov/asd/tac/constellation/graph/schema/visual/compatibility/VisualSchemaV1UpdateProviderNGTest.java
+++ b/CoreVisualSchema/test/unit/src/au/gov/asd/tac/constellation/graph/schema/visual/compatibility/VisualSchemaV1UpdateProviderNGTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2022 Australian Signals Directorate
+ * Copyright 2010-2024 Australian Signals Directorate
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/CoreVisualSchema/test/unit/src/au/gov/asd/tac/constellation/graph/schema/visual/compatibility/VisualSchemaV2UpdateProviderNGTest.java
+++ b/CoreVisualSchema/test/unit/src/au/gov/asd/tac/constellation/graph/schema/visual/compatibility/VisualSchemaV2UpdateProviderNGTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2022 Australian Signals Directorate
+ * Copyright 2010-2024 Australian Signals Directorate
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/CoreVisualSchema/test/unit/src/au/gov/asd/tac/constellation/graph/schema/visual/compatibility/VisualSchemaV3UpdateProviderNGTest.java
+++ b/CoreVisualSchema/test/unit/src/au/gov/asd/tac/constellation/graph/schema/visual/compatibility/VisualSchemaV3UpdateProviderNGTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2022 Australian Signals Directorate
+ * Copyright 2010-2024 Australian Signals Directorate
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/CoreVisualSchema/test/unit/src/au/gov/asd/tac/constellation/graph/schema/visual/compatibility/VisualSchemaV4UpdateProviderNGTest.java
+++ b/CoreVisualSchema/test/unit/src/au/gov/asd/tac/constellation/graph/schema/visual/compatibility/VisualSchemaV4UpdateProviderNGTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2022 Australian Signals Directorate
+ * Copyright 2010-2024 Australian Signals Directorate
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/CoreVisualSchema/test/unit/src/au/gov/asd/tac/constellation/graph/schema/visual/compatibility/VisualSchemaV5UpdateProviderNGTest.java
+++ b/CoreVisualSchema/test/unit/src/au/gov/asd/tac/constellation/graph/schema/visual/compatibility/VisualSchemaV5UpdateProviderNGTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2022 Australian Signals Directorate
+ * Copyright 2010-2024 Australian Signals Directorate
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,6 @@
  */
 package au.gov.asd.tac.constellation.graph.schema.visual.compatibility;
 
-import au.gov.asd.tac.constellation.graph.GraphElementType;
 import au.gov.asd.tac.constellation.graph.StoreGraph;
 import au.gov.asd.tac.constellation.graph.schema.SchemaFactory;
 import au.gov.asd.tac.constellation.graph.schema.SchemaFactoryUtilities;

--- a/CoreVisualSchema/test/unit/src/au/gov/asd/tac/constellation/graph/schema/visual/compatibility/VisualSchemaV6UpdateProviderNGTest.java
+++ b/CoreVisualSchema/test/unit/src/au/gov/asd/tac/constellation/graph/schema/visual/compatibility/VisualSchemaV6UpdateProviderNGTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2022 Australian Signals Directorate
+ * Copyright 2010-2024 Australian Signals Directorate
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,7 +24,7 @@ import org.mockito.Mockito;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.when;
-import static org.testng.Assert.*;
+import static org.testng.Assert.assertEquals;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeClass;
@@ -99,16 +99,12 @@ public class VisualSchemaV6UpdateProviderNGTest {
         System.out.println("VisualSchemaV6UpdateProviderNGTest.testSchemaUpdate");
         when(mockStoreGraph.getAttribute(GraphElementType.GRAPH, "node_labels_bottom")).thenReturn(23);
         when(mockStoreGraph.getAttribute(GraphElementType.GRAPH, "node_labels_top")).thenReturn(24);
-        when(mockStoreGraph.getAttribute(GraphElementType.GRAPH, "transaction_labels")).thenReturn(25);
         when(mockStoreGraph.getStringValue(23, 0)).thenReturn("strBottom");
         when(mockStoreGraph.getStringValue(24, 0)).thenReturn("strTop");
-        when(mockStoreGraph.getStringValue(25, 0)).thenReturn("strTrans");
         instance.schemaUpdate(mockStoreGraph);
         Mockito.verify(mockStoreGraph, times(1)).setStringValue(0, 0, "strBottom");
         Mockito.verify(mockStoreGraph, times(1)).setStringValue(0, 0, "strTop");
-        Mockito.verify(mockStoreGraph, times(1)).setStringValue(0, 0, "strTrans");
         Mockito.verify(mockStoreGraph, times(1)).removeAttribute(23);
         Mockito.verify(mockStoreGraph, times(1)).removeAttribute(24);
-        Mockito.verify(mockStoreGraph, times(1)).removeAttribute(25);
     }
 }


### PR DESCRIPTION
<!--

### Requirements

* Filling out the template is required. Any pull request that does not include
enough information to be reviewed in a timely manner may be closed at the
maintainers' discretion.
* All new code requires unit tests to ensure they work as expected and will
continue to work as new code is added in the future (regression testing).
* Make sure your branch name is prefixed by `feature`, `bugfix` or `release`
* Have you read Constellation's Code of Conduct? By filing an issue, you are
expected to comply with it, including treating everyone with respect:
https://github.com/constellation-app/constellation/blob/master/CODE_OF_CONDUCT.md

-->

### Prerequisites

- [x] Reviewed the [checklist](CHECKLIST.md)

- [ ] Reviewed feedback from the "Sonar Cloud" bot. Note that you have to wait
    for the "CI / Unit Tests") to complete first. Failed Unit tests can be 
    debugged by adding the label "verbose logging" to the GitHub PR.

### Description of the Change

At the time the Visual Schema v6 updater was created, there were no issues with how it was constructed. Since then though, the v7 changes have been introduced which was related to modifying the same attributes. for transaction_labels though, this represented reverting its name back to what it was prior to v6. What this meant now was that graphs now opened with visual schema v5 or earlier were now having that attribute removed from their graph (as the new and old version of that attribute were the same). These changes account for that by removing the updates made to transaction_labels in the v6 updater.

Doing this won't cause any issues as any graphs that already updated to visual schema v6 before the existence of v7 aren't affected.

### Alternate Designs

I considered keeping the transaction_labels code and simply adding some conditions around the code if the old and new are the same but given this only affects older graphs (visual schema < 6), the case the conditions wouldn't protect doesn't really exist and so the other solution achieves the same thing with less technical debt.

### Why Should This Be In Core?

Fixes an issue in Core with a schema updater

### Benefits

Older graph will no longer have transaction_labels attribute removed by updater

### Possible Drawbacks

Nil

### Verification Process

Open a graph with visual schema < 6 (will be one created before Sep 21 2014 which when the v6 change was merged into master) and verify the transaction_labels graph attribute is still there in the attribute editor

### Applicable Issues
