### PR TITLE
SVG Export Plugin locking graph when interrupted

### DIFF
--- a/CoreImportExportPlugins/src/au/gov/asd/tac/constellation/plugins/importexport/svg/ExportToSVGPlugin.java
+++ b/CoreImportExportPlugins/src/au/gov/asd/tac/constellation/plugins/importexport/svg/ExportToSVGPlugin.java
@@ -164,29 +164,30 @@ public class ExportToSVGPlugin extends SimpleReadPlugin {
         }
         
         final File imageFile = new File(fnam);  
-       
-        // Build a SVG representation of the graph
-        final SVGData svg = new SVGGraphBuilder()
-                .withInteraction(interaction)
-                .withTitle(title)
-                .withReadableGraph(graph)
-                .withBackground(color)
-                .withSelectedElementsOnly(selectedElements)
-                .includeNodes(showNodes)
-                .includeConnections(showConnections)
-                .includeNodeLabels(showNodeLabels)
-                .includeConnectionLabels(showConnectionLabels)
-                .includeBlazes(showBlazes)
-                .fromPerspective(AxisConstants.getReference(exportPerspective))
-                .build();
+        
         try {
+            // Build a SVG representation of the graph
+            final SVGData svg = new SVGGraphBuilder()
+                    .withInteraction(interaction)
+                    .withTitle(title)
+                    .withReadableGraph(graph)
+                    .withBackground(color)
+                    .withSelectedElementsOnly(selectedElements)
+                    .includeNodes(showNodes)
+                    .includeConnections(showConnections)
+                    .includeNodeLabels(showNodeLabels)
+                    .includeConnectionLabels(showConnectionLabels)
+                    .includeBlazes(showBlazes)
+                    .fromPerspective(AxisConstants.getReference(exportPerspective))
+                    .build();
             interaction.setExecutionStage(0, -1, "Exporting Graph", "Writing data to file", true);
             exportToSVG(imageFile, svg, interaction);
-        } catch (final IOException ex) {
-            LOGGER.log(Level.SEVERE, ex.getLocalizedMessage(), ex);
+            interaction.setProgress(1, 0, "Finished", true);
+        
+        // Catch exceptions for mising paramter values and 
+        } catch (final IllegalArgumentException | IOException ex) {
+            throw new PluginException(PluginNotificationLevel.ERROR, ex.getLocalizedMessage());
         }
-
-        interaction.setProgress(1, 0, "Finished", true);
     }   
     
     /**

--- a/CoreImportExportPlugins/src/au/gov/asd/tac/constellation/plugins/importexport/svg/ExportToSVGPlugin.java
+++ b/CoreImportExportPlugins/src/au/gov/asd/tac/constellation/plugins/importexport/svg/ExportToSVGPlugin.java
@@ -45,7 +45,6 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -184,7 +183,7 @@ public class ExportToSVGPlugin extends SimpleReadPlugin {
             exportToSVG(imageFile, svg, interaction);
             interaction.setProgress(1, 0, "Finished", true);
         
-        // Catch exceptions for mising paramter values and 
+        // Catch exceptions for mising paramter values and issues writing to files
         } catch (final IllegalArgumentException | IOException ex) {
             throw new PluginException(PluginNotificationLevel.ERROR, ex.getLocalizedMessage());
         }

--- a/CoreImportExportPlugins/src/au/gov/asd/tac/constellation/plugins/importexport/svg/SVGGraphBuilder.java
+++ b/CoreImportExportPlugins/src/au/gov/asd/tac/constellation/plugins/importexport/svg/SVGGraphBuilder.java
@@ -217,22 +217,28 @@ public class SVGGraphBuilder {
     public SVGData build() throws InterruptedException {
         
         final SVGObject svgGraph = SVGTemplateConstants.LAYOUT.getSVGObject();
-        
         try{
-            preBuild();
-        } catch (final IllegalArgumentException ex){
-            LOGGER.log(Level.SEVERE, ex.getLocalizedMessage(), ex);
-            return null;
+            try{
+                preBuild();
+            } catch (final IllegalArgumentException ex){
+                LOGGER.log(Level.SEVERE, ex.getLocalizedMessage(), ex);
+                return null;
+            }
+
+            // Build the SVG image
+            buildHeader(svgGraph);
+            buildNodes(svgGraph);
+            buildConnections(svgGraph);            
+            buildLayout(svgGraph);
+
+            // Clean up the builder
+            postBuild();
+        } catch (InterruptedException ex) {
+            // This class utilizes GraphVisualAccess and is responsible for closing off the graph lock when the plugin is interupted
+            postBuild();
+            throw ex;
         }
-        
-        // Build the SVG image
-        buildHeader(svgGraph);
-        buildNodes(svgGraph);
-        buildConnections(svgGraph);            
-        buildLayout(svgGraph);
-        
-        // Clean up the builder
-        postBuild();
+            
         
         return svgGraph.toSVGData();
     }       

--- a/CoreImportExportPlugins/src/au/gov/asd/tac/constellation/plugins/importexport/svg/SVGGraphBuilder.java
+++ b/CoreImportExportPlugins/src/au/gov/asd/tac/constellation/plugins/importexport/svg/SVGGraphBuilder.java
@@ -214,31 +214,20 @@ public class SVGGraphBuilder {
      * Builds an SVGGraphObject representing the provided graph.
      * @return SVGData
      */
-    public SVGData build() throws InterruptedException {
+    public SVGData build() throws InterruptedException, IllegalArgumentException{
         
         final SVGObject svgGraph = SVGTemplateConstants.LAYOUT.getSVGObject();
         try {
-            try {
-                preBuild();
-            } catch (final IllegalArgumentException ex){
-                LOGGER.log(Level.SEVERE, ex.getLocalizedMessage(), ex);
-                return null;
-            }
-
+            preBuild();
             // Build the SVG image
             buildHeader(svgGraph);
             buildNodes(svgGraph);
             buildConnections(svgGraph);            
             buildLayout(svgGraph);
-
+        } finally {
             // Clean up the builder
             postBuild();     
-        } catch (final InterruptedException ex) {
-            // This class utilizes GraphVisualAccess and is responsible for releasing the graph lock when the plugin is interupted
-            postBuild();
-            throw ex;
         }
-             
         return svgGraph.toSVGData();
     }       
 
@@ -247,18 +236,18 @@ public class SVGGraphBuilder {
      */
     private void preBuild() throws IllegalArgumentException {
         
+        // Initialise the VisualGraphAccess
+        access.beginUpdate();
+        access.updateInternally();
+        
         // Thorw errors if attributes without default values have not been set
         if (readableGraph == null ) {
-            throw new IllegalArgumentException("SVGGraphBuilder requires GraphReadMethodsto build");
+            throw new IllegalArgumentException("SVGGraphBuilder requires GraphReadMethods to build");
         } else if (interaction == null) {
             throw new IllegalArgumentException("SVGGraphBuilder requires a PluginInteraction to build");
         } else if (graphTitle == null) {
             throw new IllegalArgumentException("SVGGraphBuilder requires a Graph Title to build");
         }
-        
-        // Initialise the VisualGraphAccess
-        access.beginUpdate();
-        access.updateInternally();
         
         // Set the camera position and add repositioning animation 
         this.camera = access.getCamera();

--- a/CoreImportExportPlugins/src/au/gov/asd/tac/constellation/plugins/importexport/svg/SVGGraphBuilder.java
+++ b/CoreImportExportPlugins/src/au/gov/asd/tac/constellation/plugins/importexport/svg/SVGGraphBuilder.java
@@ -217,8 +217,8 @@ public class SVGGraphBuilder {
     public SVGData build() throws InterruptedException {
         
         final SVGObject svgGraph = SVGTemplateConstants.LAYOUT.getSVGObject();
-        try{
-            try{
+        try {
+            try {
                 preBuild();
             } catch (final IllegalArgumentException ex){
                 LOGGER.log(Level.SEVERE, ex.getLocalizedMessage(), ex);
@@ -232,14 +232,13 @@ public class SVGGraphBuilder {
             buildLayout(svgGraph);
 
             // Clean up the builder
-            postBuild();
-        } catch (InterruptedException ex) {
-            // This class utilizes GraphVisualAccess and is responsible for closing off the graph lock when the plugin is interupted
+            postBuild();     
+        } catch (final InterruptedException ex) {
+            // This class utilizes GraphVisualAccess and is responsible for releasing the graph lock when the plugin is interupted
             postBuild();
             throw ex;
         }
-            
-        
+             
         return svgGraph.toSVGData();
     }       
 

--- a/CoreImportExportPlugins/test/unit/src/au/gov/asd/tac/constellation/plugins/importexport/svg/SVGGraphBuilderNGTest.java
+++ b/CoreImportExportPlugins/test/unit/src/au/gov/asd/tac/constellation/plugins/importexport/svg/SVGGraphBuilderNGTest.java
@@ -41,7 +41,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
-import static org.testng.Assert.assertNull;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeClass;
@@ -284,7 +283,7 @@ public class SVGGraphBuilderNGTest {
      * Test of build method, of class SVGGraphBuilder.
      */
     @Test
-    public void testBuild() throws Exception {
+    public void testBuild() throws IllegalArgumentException, InterruptedException {
         System.out.println("build");
         final SVGGraphBuilder instance = new SVGGraphBuilder()
                 .withInteraction(interactionMock)
@@ -306,7 +305,7 @@ public class SVGGraphBuilderNGTest {
      * Test of build method, of class SVGGraphBuilder.
      * @throws java.lang.InterruptedException
      */
-    @Test
+    @Test(expectedExceptions = IllegalArgumentException.class)
     public void testBuild_withoutReadableGraph() throws InterruptedException {
         System.out.println("build");
         final SVGGraphBuilder instance = new SVGGraphBuilder()
@@ -319,14 +318,14 @@ public class SVGGraphBuilderNGTest {
                 .includeConnections(true)
                 .includeConnectionLabels(false)
                 .includeBlazes(false); 
-        assertNull(instance.build());
+        instance.build();
     }
     
     /**
      * Test of build method, of class SVGGraphBuilder.
      * @throws java.lang.InterruptedException
      */
-    @Test
+    @Test(expectedExceptions = IllegalArgumentException.class)
     public void testBuild_withoutInteraction() throws InterruptedException {
         System.out.println("build");
         final SVGGraphBuilder instance = new SVGGraphBuilder()
@@ -339,15 +338,15 @@ public class SVGGraphBuilderNGTest {
                 .includeConnections(true)
                 .includeConnectionLabels(false)
                 .includeBlazes(false); 
-        assertNull(instance.build());
+        instance.build();
     }
     
     /**
      * Test of build method, of class SVGGraphBuilder.
      * @throws java.lang.InterruptedException
      */
-    @Test
-    public void testBuild_graphTitle() throws InterruptedException {
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testBuild_withoutGraphTitle() throws InterruptedException {
         System.out.println("build");
         final SVGGraphBuilder instance = new SVGGraphBuilder()
                 .withInteraction(interactionMock)
@@ -359,7 +358,7 @@ public class SVGGraphBuilderNGTest {
                 .includeConnections(true)
                 .includeConnectionLabels(false)
                 .includeBlazes(false); 
-        assertNull(instance.build());
+        instance.build();
     }
     
     private Graph buildTestableGraph() throws InterruptedException{


### PR DESCRIPTION
<!--

### Requirements

* Filling out the template is required. Any pull request that does not include
enough information to be reviewed in a timely manner may be closed at the
maintainers' discretion.
* All new code requires unit tests to ensure they work as expected and will
continue to work as new code is added in the future (regression testing).
* Make sure your branch name is prefixed by `feature`, `bugfix` or `release`
* Have you read Constellation's Code of Conduct? By filing an issue, you are
expected to comply with it, including treating everyone with respect:
https://github.com/constellation-app/constellation/blob/master/CODE_OF_CONDUCT.md

-->

### Prerequisites

- [ ] Reviewed the [checklist](CHECKLIST.md)

- [ ] Reviewed feedback from the "Sonar Cloud" bot. Note that you have to wait
    for the "CI / Unit Tests") to complete first. Failed Unit tests can be 
    debugged by adding the label "verbose logging" to the GitHub PR.

### Description of the Change

The SVG Export plugin utilizes `GraphVisualAccess` which holds a lock on the graph during the plugin execution. This PR adds a check for the `SVGGraphBuilder` to allow it to release the lock from the `GraphVisualAccess` when the plugin is interrupted.

### Alternate Designs
Alternate 1 - Refactor the `GraphVisualAccess` to accept a `GraphReadMethods` as in a constructor. This would relinquish responsibility from the `GraphVisualAccess` to release the graph but would extend the class beyond its intended use.

Alternate 2 - Refactor the Export to SVG plugin to use `VisualGraphUtilities` instead of `GraphVisualAccess`. These utilities accept `GraphReadMethods` as parameters however would require a significant amount of work to add required methods for the Export to SVG plugin and would duplicate internal functionality of `GraphVisualAccess`.

### Why Should This Be In Core?
Improves a core feature.

### Benefits
Makes the plugin more usable.

### Possible Drawbacks

May be indicating a larger issue in that `GraphVisualAccess` is not the correct class to use to get graph visual Information by a plugin. No better solution appears to exist.

### Verification Process

1. Open a sphere graph with 10000 nodes
2. Export to SVG
3. Cancel the plugin during execution

### Applicable Issues
#1951 
