### PR TITLE
Add recent values to SVGExport  ValueInputFields

### DIFF
--- a/CorePluginFramework/src/au/gov/asd/tac/constellation/plugins/gui/PluginParametersSwingDialog.java
+++ b/CorePluginFramework/src/au/gov/asd/tac/constellation/plugins/gui/PluginParametersSwingDialog.java
@@ -76,6 +76,7 @@ public class PluginParametersSwingDialog implements PluginParametersPaneListener
     
     private final HashMap<PluginParameter<?>, Boolean> parameterValidity = new HashMap();
     private final JButton acceptanceOption;
+    private final PluginParameters parameters;
 
     /**
      * Display a dialog box containing the parameters that allows the user to
@@ -155,6 +156,7 @@ public class PluginParametersSwingDialog implements PluginParametersPaneListener
     public PluginParametersSwingDialog(final String title, final PluginParameters parameters, final Set<String> excludedParameters, final String acceptanceText, final String disclaimer, final String helpID) {
         this.title = title;
         this.acceptanceOption = new JButton(getAcceptanceButton(acceptanceText));
+        this.parameters = parameters;
         final CountDownLatch latch = new CountDownLatch(1);
         xp = helpID != null ? new JFXPanelWithHelp(helpID) : new JFXPanel();
         Platform.runLater(() -> {
@@ -162,7 +164,7 @@ public class PluginParametersSwingDialog implements PluginParametersPaneListener
             // Create the panes
             final BorderPane root = new BorderPane();
             final ScrollPane scrollableContent = new ScrollPane();
-            final PluginParametersPane parametersPane = PluginParametersPane.buildPane(parameters, this, excludedParameters);
+            final PluginParametersPane parametersPane = PluginParametersPane.buildPane(this.parameters, this, excludedParameters);
             final HBox disclaimerPane = new HBox();
             
             // Style the panes
@@ -235,6 +237,7 @@ public class PluginParametersSwingDialog implements PluginParametersPaneListener
         if (r == DialogDescriptor.CANCEL_OPTION){
             result = CANCEL;
         } else if (r == DialogDescriptor.OK_OPTION){
+            this.parameters.storeRecentValues();
             result = OK;
         } else {
             result = null;
@@ -256,6 +259,7 @@ public class PluginParametersSwingDialog implements PluginParametersPaneListener
         if (r == DialogDescriptor.CANCEL_OPTION){
             result = CANCEL;
         } else if (r == DialogDescriptor.OK_OPTION){
+            this.parameters.storeRecentValues();
             result = OK;
         } else {
             result = null;

--- a/CorePluginFramework/src/au/gov/asd/tac/constellation/plugins/gui/PluginParametersSwingDialog.java
+++ b/CorePluginFramework/src/au/gov/asd/tac/constellation/plugins/gui/PluginParametersSwingDialog.java
@@ -237,7 +237,7 @@ public class PluginParametersSwingDialog implements PluginParametersPaneListener
         if (r == DialogDescriptor.CANCEL_OPTION){
             result = CANCEL;
         } else if (r == DialogDescriptor.OK_OPTION){
-            this.parameters.storeRecentValues();
+            parameters.storeRecentValues();
             result = OK;
         } else {
             result = null;
@@ -259,7 +259,7 @@ public class PluginParametersSwingDialog implements PluginParametersPaneListener
         if (r == DialogDescriptor.CANCEL_OPTION){
             result = CANCEL;
         } else if (r == DialogDescriptor.OK_OPTION){
-            this.parameters.storeRecentValues();
+            parameters.storeRecentValues();
             result = OK;
         } else {
             result = null;


### PR DESCRIPTION
<!--

### Requirements

* Filling out the template is required. Any pull request that does not include
enough information to be reviewed in a timely manner may be closed at the
maintainers' discretion.
* All new code requires unit tests to ensure they work as expected and will
continue to work as new code is added in the future (regression testing).
* Make sure your branch name is prefixed by `feature`, `bugfix` or `release`
* Have you read Constellation's Code of Conduct? By filing an issue, you are
expected to comply with it, including treating everyone with respect:
https://github.com/constellation-app/constellation/blob/master/CODE_OF_CONDUCT.md

-->

### Prerequisites

- [ ] Reviewed the [checklist](CHECKLIST.md)

- [ ] Reviewed feedback from the "Sonar Cloud" bot. Note that you have to wait
    for the "CI / Unit Tests") to complete first. Failed Unit tests can be 
    debugged by adding the label "verbose logging" to the GitHub PR.

### Description of the Change

This PR enables the Graph Title input field on the ExportToSVGPlugin PluiginParametersSwingDialog to express recent values correctly.
![image](https://github.com/constellation-app/constellation/assets/139201011/22d9614a-eb52-4a65-8768-eafab34bbdd4)


### Alternate Designs

N/A

### Why Should This Be In Core?

It is a core feature.

### Verification Process

Export a graph to SVG | File -> Export -> to SVG.
(Note the graph title value is blank as a graph title has not yet been set.)

Export a different graph to SVG | File -> Export -> to SVG.
(Note the previously exported graph title is in the recent values dropdown.)

### Applicable Issues
#1930
