### PR TITLE
fixed client get_graph_attributes data issue

### DIFF
--- a/CoreWebServer/src/au/gov/asd/tac/constellation/webserver/resources/constellation_client.py
+++ b/CoreWebServer/src/au/gov/asd/tac/constellation/webserver/resources/constellation_client.py
@@ -536,7 +536,7 @@ class Constellation:
         r = self.call_service('get_graph_values', args=params)
         content = r.content
         if isinstance(content, bytes):
-        content = content.decode('utf8')
+            content = content.decode('utf8')
         df = pd.read_json(content, orient='split', dtype=False, convert_dates=False)
         df, self.types = self._fix_types(df)
 

--- a/CoreWebServer/src/au/gov/asd/tac/constellation/webserver/resources/constellation_client.py
+++ b/CoreWebServer/src/au/gov/asd/tac/constellation/webserver/resources/constellation_client.py
@@ -534,8 +534,10 @@ class Constellation:
             params = {'graph_id':graph_id}
 
         r = self.call_service('get_graph_values', args=params)
-
-        df = pd.read_json(r.content, orient='split', dtype=False, convert_dates=False)
+        content = r.content
+        if isinstance(content, bytes):
+        content = content.decode('utf8')
+        df = pd.read_json(content, orient='split', dtype=False, convert_dates=False)
         df, self.types = self._fix_types(df)
 
         return df


### PR DESCRIPTION
### Prerequisites

- [ ] Reviewed the [checklist](CHECKLIST.md)

- [ ] Reviewed feedback from the "Sonar Cloud" bot. Note that you have to wait
    for the "CI / Unit Tests") to complete first. Failed Unit tests can be 
    debugged by adding the label "verbose logging" to the GitHub PR.

### Description of the Change
Similar to #1933 the constellation_client wasn't decoding the output from the server from bytes to a string to then be used by Panda's read_json as outlined in https://github.com/constellation-app/constellation/issues/1816.  This error occured when calling get_graph_attributes from the client.
Since Constellation opens the default Jupyter instance there can be many different versions of python and pandas accessing the web server using the constellation client.
The change simply checks the data returned from the Constellation web server, if it is a byte type it'll decode it to utf8, as suggested in https://github.com/constellation-app/constellation/issues/1816 . This will not effect the other accepted types such as path object of file buffers.
This has been tested on 3.7.6 (using the older version of Pandas) & 3.11 that uses the new version of Pandas that was erroring.
### Alternate Designs

<!--

Explain what other alternates were considered and why the proposed version was
selected.

-->

### Why Should This Be In Core?

This is a bug fix for running Jupyter with newer versions of Pandas therefore should be in Constellation core,



### Benefits

The Constellation Core now works with newer versions of python.


### Possible Drawbacks

None

### Verification Process

The changes were tested against both the older versions and newer versions of python / Pandas.
Testing the fix:

1. Install a new python virtual environment
2. Install all relevant libraries used by constellation_client
3. Add the new kernel to a Jupyter instance.
4. Add constellation_client.py as either a relative file or in the system paths (Constellation will do this to the default once it's pushed)
5. Add and run the example notebook to read the current graph - https://github.com/constellation-app/constellation-training/blob/master/Analyst%20Training/Exercise%2010%20-%20Network%20Analysis%20With%20Python/notebooks_and_constellation.ipynb
6. get_graph_attributes should return the graph attributes as a dataframe instead of the error 'error:Expected file path name or file-like object, got <class 'bytes'> type'

### Applicable Issues

#2004 
