### PR TITLE
foreground icon resolve fix

### DIFF
--- a/CoreAnalyticSchema/src/au/gov/asd/tac/constellation/graph/schema/analytic/AnalyticSchemaFactory.java
+++ b/CoreAnalyticSchema/src/au/gov/asd/tac/constellation/graph/schema/analytic/AnalyticSchemaFactory.java
@@ -228,10 +228,9 @@ public class AnalyticSchemaFactory extends VisualSchemaFactory {
             if (type != null && (type != SchemaVertexTypeUtilities.getDefaultType() || graph.isDefaultValue(vertexForegroundIconAttribute, vertexId))) {
                 if (!Objects.equals(type.getForegroundIcon(), graph.getObjectValue(vertexForegroundIconAttribute, vertexId))) {
                     graph.setObjectValue(vertexForegroundIconAttribute, vertexId, type.getForegroundIcon().getExtendedName());
-                } else if (IconManager.iconExists(type.toString())) {
-                    if (!Objects.equals(type.toString(), graph.getObjectValue(vertexForegroundIconAttribute, vertexId))) {
-                        graph.setObjectValue(vertexForegroundIconAttribute, vertexId, type.toString());
-                    }
+                } else if (IconManager.iconExists(type.toString())
+                        && !Objects.equals(type.toString(), graph.getObjectValue(vertexForegroundIconAttribute, vertexId))) {
+                    graph.setObjectValue(vertexForegroundIconAttribute, vertexId, type.toString());
                 } 
             }
 

--- a/CoreAnalyticSchema/src/au/gov/asd/tac/constellation/graph/schema/analytic/AnalyticSchemaFactory.java
+++ b/CoreAnalyticSchema/src/au/gov/asd/tac/constellation/graph/schema/analytic/AnalyticSchemaFactory.java
@@ -226,9 +226,11 @@ public class AnalyticSchemaFactory extends VisualSchemaFactory {
             }
 
             if (type != null && (type != SchemaVertexTypeUtilities.getDefaultType() || graph.isDefaultValue(vertexForegroundIconAttribute, vertexId))) {
-                if (!Objects.equals(type.getForegroundIcon(), graph.getObjectValue(vertexForegroundIconAttribute, vertexId))) {
-                    graph.setObjectValue(vertexForegroundIconAttribute, vertexId, type.getForegroundIcon().getExtendedName());
-                } else if (IconManager.iconExists(type.toString())
+                if (type.getForegroundIcon() != null) {
+                    if (!Objects.equals(type.getForegroundIcon(), graph.getObjectValue(vertexForegroundIconAttribute, vertexId))) {
+                        graph.setObjectValue(vertexForegroundIconAttribute, vertexId, type.getForegroundIcon().getExtendedName());
+                    } 
+                } else if (IconManager.iconExists(type.toString()) 
                         && !Objects.equals(type.toString(), graph.getObjectValue(vertexForegroundIconAttribute, vertexId))) {
                     graph.setObjectValue(vertexForegroundIconAttribute, vertexId, type.toString());
                 } 

--- a/CoreAnalyticSchema/src/au/gov/asd/tac/constellation/graph/schema/analytic/AnalyticSchemaFactory.java
+++ b/CoreAnalyticSchema/src/au/gov/asd/tac/constellation/graph/schema/analytic/AnalyticSchemaFactory.java
@@ -226,13 +226,13 @@ public class AnalyticSchemaFactory extends VisualSchemaFactory {
             }
 
             if (type != null && (type != SchemaVertexTypeUtilities.getDefaultType() || graph.isDefaultValue(vertexForegroundIconAttribute, vertexId))) {
-                if (IconManager.iconExists(type.toString())) {
+                if (!Objects.equals(type.getForegroundIcon(), graph.getObjectValue(vertexForegroundIconAttribute, vertexId))) {
+                    graph.setObjectValue(vertexForegroundIconAttribute, vertexId, type.getForegroundIcon().getExtendedName());
+                } else if (IconManager.iconExists(type.toString())) {
                     if (!Objects.equals(type.toString(), graph.getObjectValue(vertexForegroundIconAttribute, vertexId))) {
                         graph.setObjectValue(vertexForegroundIconAttribute, vertexId, type.toString());
                     }
-                } else if (!Objects.equals(type.getForegroundIcon(), graph.getObjectValue(vertexForegroundIconAttribute, vertexId))) {
-                    graph.setObjectValue(vertexForegroundIconAttribute, vertexId, type.getForegroundIcon().getExtendedName());
-                }
+                } 
             }
 
             // analytic attribute cleanup


### PR DESCRIPTION
<!--

### Requirements

* Filling out the template is required. Any pull request that does not include
enough information to be reviewed in a timely manner may be closed at the
maintainers' discretion.
* All new code requires unit tests to ensure they work as expected and will
continue to work as new code is added in the future (regression testing).
* Make sure your branch name is prefixed by `feature`, `bugfix` or `release`
* Have you read Constellation's Code of Conduct? By filing an issue, you are
expected to comply with it, including treating everyone with respect:
https://github.com/constellation-app/constellation/blob/master/CODE_OF_CONDUCT.md

-->

### Prerequisites

- [x] Reviewed the [checklist](CHECKLIST.md)

- [ ] Reviewed feedback from the "Sonar Cloud" bot. Note that you have to wait
    for the "CI / Unit Tests") to complete first. Failed Unit tests can be 
    debugged by adding the label "verbose logging" to the GitHub PR.

### Description of the Change

It appears there was a logic issue in the way the analytic schema resolved the foreground icon for a vertex type. The current logic first checked if there was an icon that matched the type name and if so, set the icon to that type if it wasn't already set. After that, it then checked the foreground icon defined by the schema type and set it if it wasn't already set.

This logic appears backwards as it means the foreground icon defined for a type in schema is simply ignored if there happens to exist an icon with the same name as the type and this shouldn't be the case. This PR flips those cases around so that the foreground icon defined by schema is checked first, and then only checks for an icon matching the name is an foreground icon isn't defined in schema.

### Alternate Designs

<!--

Explain what other alternates were considered and why the proposed version was
selected.

-->

### Why Should This Be In Core?

Fixes a logic bug in the schema

### Benefits

Schema represents source of truth and types added will be reflected on the graph as defined in schema

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process

1) Complete to the end of Chapter 3 of the Dev Guide
2) Run the Import Infected Cities Plugin
3) The nodes now have the globe icon as defined in schema for the City type (previously they were displaying the city icon)

### Applicable Issues

Nil
