### PR TITLE
Importing recent files that have been unzipped

### DIFF
--- a/CoreGraphFile/src/au/gov/asd/tac/constellation/graph/file/open/RecentFiles.java
+++ b/CoreGraphFile/src/au/gov/asd/tac/constellation/graph/file/open/RecentFiles.java
@@ -200,6 +200,7 @@ public final class RecentFiles {
         synchronized (HISTORY_LOCK) {
             return getRecentFiles().stream()
                     .filter(file -> convertPath2File(file.getPath()) != null)
+                    .filter(file -> !(new File(file.getPath()).isDirectory()))
                     .distinct()
                     .collect(ImmutableList.toImmutableList());
         }
@@ -354,9 +355,12 @@ public final class RecentFiles {
     }
 
     public static FileObject convertPath2File(final String path) {
-        File f = new File(path);
-        f = FileUtil.normalizeFile(f);
-        return f == null ? null : FileUtil.toFileObject(f);
+        final File f = new File(path);
+        if (FileUtil.normalizeFile(f) == null || f.isDirectory()) {
+            return null;
+        } else {
+            return FileUtil.toFileObject(f);
+        }
     }
 
     /**

--- a/CoreGraphFile/src/au/gov/asd/tac/constellation/graph/file/open/RecentFiles.java
+++ b/CoreGraphFile/src/au/gov/asd/tac/constellation/graph/file/open/RecentFiles.java
@@ -200,7 +200,6 @@ public final class RecentFiles {
         synchronized (HISTORY_LOCK) {
             return getRecentFiles().stream()
                     .filter(file -> convertPath2File(file.getPath()) != null)
-                    .filter(file -> !(new File(file.getPath()).isDirectory()))
                     .distinct()
                     .collect(ImmutableList.toImmutableList());
         }

--- a/CoreGraphFile/src/au/gov/asd/tac/constellation/graph/file/open/RecentFiles.java
+++ b/CoreGraphFile/src/au/gov/asd/tac/constellation/graph/file/open/RecentFiles.java
@@ -354,11 +354,12 @@ public final class RecentFiles {
     }
 
     public static FileObject convertPath2File(final String path) {
-        final File f = new File(path);
-        if (FileUtil.normalizeFile(f) == null || f.isDirectory()) {
+        final File file = new File(path);
+        final File normalizedFile = FileUtil.normalizeFile(file);
+        if (normalizedFile == null || file.isDirectory()) {
             return null;
         } else {
-            return FileUtil.toFileObject(f);
+            return FileUtil.toFileObject(normalizedFile);
         }
     }
 


### PR DESCRIPTION
<!--

### Requirements

* Filling out the template is required. Any pull request that does not include
enough information to be reviewed in a timely manner may be closed at the
maintainers' discretion.
* All new code requires unit tests to ensure they work as expected and will
continue to work as new code is added in the future (regression testing).
* Make sure your branch name is prefixed by `feature`, `bugfix` or `release`
* Have you read Constellation's Code of Conduct? By filing an issue, you are
expected to comply with it, including treating everyone with respect:
https://github.com/constellation-app/constellation/blob/master/CODE_OF_CONDUCT.md

-->

### Prerequisites

- [ ] Reviewed the [checklist](CHECKLIST.md)

- [ ] Reviewed feedback from the "Sonar Cloud" bot. Note that you have to wait
    for the "CI / Unit Tests") to complete first. Failed Unit tests can be 
    debugged by adding the label "verbose logging" to the GitHub PR.

### Description of the Change

In a very niche case, selecting a recent file of which the source file has been unzipped manually from a star file results in constellation displaying the folder and file contents of the uncompressed text that represents the graph being imported. see below screenshot:
![image](https://github.com/constellation-app/constellation/assets/139201011/1260e241-ae1c-40c9-b1a4-6fd31cdfcff8)

This PR fixes this issue by preventing recent files that are directories from being included in the recent files list. 

### Alternate Designs
The result of opening the file in this way (seeing the saved files json text) may be a useful feature but should be implemented intentionally instead of being a side effect.

### Possible Drawbacks
The welcome view does not dynamically update during runtime so if a user were to alter the file as per the below instructions with constellation still open and then try to open the graph from a welcome view shortcut then the same issue would still occur.

This could be solved by making RecentFiles listenable and having the WelcomeViewPane listen for changes to the recent values list. 

### Why Should This Be In Core?
It is a core feature

### Verification Process

1. In constellation: Open a graph with some nodes on it.
2. In constellation: Save the graph.
3. In constellation: Close the graph.
4. In constellation: Select File > Open Recent (note that the file is shown)
5. Close constellation
6. Open constellation
7. In constellation: Open the welcome view (note the file is in the welcome view)
9. In file explorer: Find the saved file on your computer.
10. In file explorer: Change the file name to have a .star.zip extension
11. In file explorer: Extract from the .zip in the same location.
12. In constellation: Select File > Open Recent (note that the file is not shown)
13. Close constellation
14. Open constellation
15. In constellation: Open the welcome view (note the file is not in the welcome view).


### Applicable Issues

N/A
