### PR TITLE
undone change to undo graph edit state causing performance issues

### DIFF
--- a/CoreGraphFramework/src/au/gov/asd/tac/constellation/graph/undo/UndoGraphEditState.java
+++ b/CoreGraphFramework/src/au/gov/asd/tac/constellation/graph/undo/UndoGraphEditState.java
@@ -150,7 +150,7 @@ public class UndoGraphEditState {
     }
 
     public byte[] getByteStack() {
-        return byteStack.clone();
+        return byteStack;
     }
 
     public void setByteStack(final byte[] byteStack) {
@@ -166,7 +166,7 @@ public class UndoGraphEditState {
     }
 
     public short[] getShortStack() {
-        return shortStack.clone();
+        return shortStack;
     }
 
     public void setShortStack(final short[] shortStack) {
@@ -182,7 +182,7 @@ public class UndoGraphEditState {
     }
 
     public int[] getIntStack() {
-        return intStack.clone();
+        return intStack;
     }
 
     public void setIntStack(final int[] intStack) {
@@ -198,7 +198,7 @@ public class UndoGraphEditState {
     }
 
     public long[] getLongStack() {
-        return longStack.clone();
+        return longStack;
     }
 
     public void setLongStack(final long[] longStack) {
@@ -214,7 +214,7 @@ public class UndoGraphEditState {
     }
 
     public Object[] getObjectStack() {
-        return objectStack.clone();
+        return objectStack;
     }
 
     public void setObjectStack(final Object[] objectStack) {


### PR DESCRIPTION
<!--

### Requirements

* Filling out the template is required. Any pull request that does not include
enough information to be reviewed in a timely manner may be closed at the
maintainers' discretion.
* All new code requires unit tests to ensure they work as expected and will
continue to work as new code is added in the future (regression testing).
* Make sure your branch name is prefixed by `feature`, `bugfix` or `release`
* Have you read Constellation's Code of Conduct? By filing an issue, you are
expected to comply with it, including treating everyone with respect:
https://github.com/constellation-app/constellation/blob/master/CODE_OF_CONDUCT.md

-->

### Prerequisites

- [x] Reviewed the [checklist](CHECKLIST.md)

- [ ] Reviewed feedback from the "Sonar Cloud" bot. Note that you have to wait
    for the "CI / Unit Tests") to complete first. Failed Unit tests can be 
    debugged by adding the label "verbose logging" to the GitHub PR.

### Description of the Change

A change made to `UndoGraphEditState` here #2031 had resulted in some significant performance issues with loading graphs. This change reverts the changes made to that class and fixes the performance issue

### Alternate Designs

<!--

Explain what other alternates were considered and why the proposed version was
selected.

-->

### Why Should This Be In Core?

Improved performance

### Benefits

Performance no longer as degraded

### Possible Drawbacks

Sonar smells are restored by it seems they will need to be addressed another way (another time)

### Verification Process

1. Open new graph
2. Run Sphere Graph builder with 50k nodes, 50k transactions
3. Difference running on master vs this branch should be significant (will vary depending on system but on my system it was around 10 secs vs 5.5 mins)

### Applicable Issues
