### PR TITLE
Word cloud view fix for no graph

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Constellation Changes
 
+## Changes in July 2024
+-   Moved `NoGraphPane` from Layers View to the View Framework so that other views can use it.
+-   Updated `NoGraphPane` to take two parameters needed for the abstraction.
+
 ## Changes in May 2024
 -   Removed `FloatArray.clone()` and replaced with a constructor that takes a `FloatArray` object. 
 -   Removed `IntArray.clone()` in favour of constructor that takes a `IntArray` object. 

--- a/CoreLayersView/src/au/gov/asd/tac/constellation/views/layers/LayersViewTopComponent.java
+++ b/CoreLayersView/src/au/gov/asd/tac/constellation/views/layers/LayersViewTopComponent.java
@@ -139,14 +139,12 @@ public final class LayersViewTopComponent extends JavaFxTopComponent<LayersViewP
     @Override
     protected void componentShowing() {
         super.componentShowing();
-        createContent().setEnabled(true);
         layersViewController.readState();
         layersViewController.addAttributes();
         setPaneStatus();
     }
 
     protected void preparePane() {
-        createContent().setEnabled(true);
         createContent().setDefaultLayers();
         layersViewController.readState();
         layersViewController.addAttributes();

--- a/CoreLayersView/src/au/gov/asd/tac/constellation/views/layers/components/LayersViewPane.java
+++ b/CoreLayersView/src/au/gov/asd/tac/constellation/views/layers/components/LayersViewPane.java
@@ -16,9 +16,11 @@
 package au.gov.asd.tac.constellation.views.layers.components;
 
 import au.gov.asd.tac.constellation.graph.GraphElementType;
+import au.gov.asd.tac.constellation.views.NoGraphPane;
 import au.gov.asd.tac.constellation.views.layers.LayersViewController;
 import au.gov.asd.tac.constellation.views.layers.query.BitMaskQuery;
 import au.gov.asd.tac.constellation.views.layers.query.Query;
+import au.gov.asd.tac.constellation.views.layers.utilities.LayersUtilities;
 import java.util.concurrent.CountDownLatch;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -54,7 +56,6 @@ public class LayersViewPane extends BorderPane {
     private static final int SCROLLPANE_VIEW_HEIGHT = 900;
 
     public LayersViewPane(final LayersViewController controller) {
-
         // create controller
         this.controller = controller;
 
@@ -118,7 +119,7 @@ public class LayersViewPane extends BorderPane {
         this.setCenter(layersViewVBox);
 
         // add layers grid and options to pane
-        this.noGraphPane = new NoGraphPane();
+        this.noGraphPane = new NoGraphPane("Layers View", LayersUtilities.createHelpButton());
 
         // create layout bindings
         noGraphPane.prefWidthProperty().bind(this.widthProperty());

--- a/CoreViewFramework/src/au/gov/asd/tac/constellation/views/NoGraphPane.java
+++ b/CoreViewFramework/src/au/gov/asd/tac/constellation/views/NoGraphPane.java
@@ -13,17 +13,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package au.gov.asd.tac.constellation.views.layers.components;
+package au.gov.asd.tac.constellation.views;
 
-import au.gov.asd.tac.constellation.views.layers.utilities.LayersUtilities;
 import javafx.geometry.Insets;
 import javafx.scene.control.Button;
 import javafx.scene.control.Label;
 import javafx.scene.layout.VBox;
 
 /**
- * Create a blank view when the layers view is open without a graph being open at the same time. 
- * Stops the user from being able to interact with layers view without a graph being open
+ * Create a blank view when a view is open without a graph being open at the same time. 
+ * Stops the user from being able to interact with a view without a graph being open
  *
  * @author aldebaran30701
  */
@@ -34,20 +33,18 @@ public class NoGraphPane extends VBox {
 
     private static final Insets PADDING = new Insets(0, 0, 0, 0);
     private static final int SPACING = 5;
-    private static final String NO_GRAPH_LABEL = "Open or create a graph to enable the Layers View.";
+    private static final String NO_GRAPH_LABEL = "Open or create a graph to enable the %s.";
 
-    public NoGraphPane() {
+    public NoGraphPane(final String viewName, final Button helpButton) {
         setSpacing(SPACING);
         setPadding(PADDING);
 
-        noGraphLabel = createNoGraphLabel();
-        helpButton = LayersUtilities.createHelpButton();
+        this.noGraphLabel = new Label(String.format(NO_GRAPH_LABEL, viewName));
+        this.helpButton = helpButton;
 
-        this.getChildren().add(noGraphLabel);
-        this.getChildren().add(helpButton);
-    }
-
-    protected Label createNoGraphLabel() {
-        return new Label(NO_GRAPH_LABEL);
+        this.getChildren().add(this.noGraphLabel);
+        if (this.helpButton != null) {
+            this.getChildren().add(this.helpButton);
+        }
     }
 }

--- a/CoreWordCloudView/src/au/gov/asd/tac/constellation/views/wordcloud/ui/WordCloudController.java
+++ b/CoreWordCloudView/src/au/gov/asd/tac/constellation/views/wordcloud/ui/WordCloudController.java
@@ -135,11 +135,8 @@ public class WordCloudController {
      */
     public void runPlugin(final PluginParameters params) {
         final Graph currentGraph = GraphManager.getDefault().getActiveGraph();
-        final ReadableGraph rg = currentGraph.getReadableGraph();
-        try {
+        try (final ReadableGraph rg = currentGraph.getReadableGraph()) {
             attrModCount = rg.getAttributeModificationCounter();
-        } finally {
-            rg.release();
         }
         pane.setInProgress();
         final Future<?> f = PluginExecution.withPlugin(new PhrasiphyContentPlugin()).withParameters(params).executeLater(currentGraph);
@@ -241,8 +238,7 @@ public class WordCloudController {
     public void updateActiveGraph(final Graph graph) {
         vertTextAttributes = new ArrayList<>(EMPTY_STRING_LIST);
         transTextAttributes = new ArrayList<>(EMPTY_STRING_LIST);
-        final ReadableGraph rg = graph.getReadableGraph();
-        try {
+        try (final ReadableGraph rg = graph.getReadableGraph()) {
             // Retrieve the cloud attribute from the new graph if present
             final int cloudAttr = WordCloudConcept.MetaAttribute.WORD_CLOUD_ATTRIBUTE.get(rg);
             cloud = cloudAttr != Graph.NOT_FOUND ? (WordCloud) rg.getObjectValue(cloudAttr, 0) : null;
@@ -261,8 +257,6 @@ public class WordCloudController {
                 }
             }
             setAttributeSelectionEnabled(true);
-        } finally {
-            rg.release();
         }
     }
 
@@ -278,8 +272,7 @@ public class WordCloudController {
         boolean doParamUpdate = false;
         graph = GraphManager.getDefault().getActiveGraph();
         if (graph != null) {
-            final ReadableGraph rg = graph.getReadableGraph();
-            try {
+            try (final ReadableGraph rg = graph.getReadableGraph()) {
                 // Check for updates to the word cloud 
                 final int cloudAttr = WordCloudConcept.MetaAttribute.WORD_CLOUD_ATTRIBUTE.get(rg);
                 amc = rg.getAttributeModificationCounter();
@@ -316,8 +309,6 @@ public class WordCloudController {
                     doParamUpdate = true;
                     attrModCount = amc;
                 }
-            } finally {
-                rg.release();
             }
 
             if (cloud != null) {

--- a/CoreWordCloudView/src/au/gov/asd/tac/constellation/views/wordcloud/ui/WordCloudPane.java
+++ b/CoreWordCloudView/src/au/gov/asd/tac/constellation/views/wordcloud/ui/WordCloudPane.java
@@ -18,12 +18,15 @@ package au.gov.asd.tac.constellation.views.wordcloud.ui;
 import au.gov.asd.tac.constellation.graph.interaction.plugins.clipboard.ClipboardUtilities;
 import au.gov.asd.tac.constellation.plugins.parameters.PluginParameters;
 import au.gov.asd.tac.constellation.utilities.tooltip.TooltipPane;
+import au.gov.asd.tac.constellation.views.NoGraphPane;
+import au.gov.asd.tac.constellation.views.wordcloud.utilities.WordCloudUtilities;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.SortedMap;
 import java.util.SortedSet;
+import javafx.application.Platform;
 import javafx.beans.value.ObservableValue;
 import javafx.event.ActionEvent;
 import javafx.geometry.Insets;
@@ -61,7 +64,9 @@ import javafx.scene.text.FontWeight;
 public class WordCloudPane extends BorderPane {
 
     private final WordCloudController controller;
-
+    
+    private final VBox noGraphPane;
+    
     private final SplitPane everything;
     private final VBox theCloud;
     private final Label queryInfoLabel;
@@ -108,7 +113,6 @@ public class WordCloudPane extends BorderPane {
         everything.setDividerPositions(0.5F);
         this.controller = controller;
         setPadding(WORDCLOUD_PADDING);
-        setTop(everything);
 
         // Scroll pane for entire top of word cloud view
         topPart = new ScrollPane();
@@ -241,6 +245,9 @@ public class WordCloudPane extends BorderPane {
         wordButtons = new HashMap<>();
         noWord = new Hyperlink();
         noWord.setMaxSize(0, 0);
+        
+        this.noGraphPane = new NoGraphPane("Word Cloud View", WordCloudUtilities.createHelpButton());
+        noGraphPane.prefWidthProperty().bind(this.widthProperty());
     }
 
     /**
@@ -280,6 +287,16 @@ public class WordCloudPane extends BorderPane {
 
     protected FlowPane getWords() {
         return words;
+    }
+    
+    /**
+     * Set the pane enabled will switch between the real word cloud pane and a
+     * message pane notifying the user that a graph is required.
+     *
+     * @param enable true if there is a graph
+     */
+    public void setEnabled(final boolean enable) {
+        Platform.runLater(() -> this.setTop(enable ? everything : noGraphPane));
     }
 
     public void setInProgress() {

--- a/CoreWordCloudView/src/au/gov/asd/tac/constellation/views/wordcloud/ui/WordCloudParametersPane.java
+++ b/CoreWordCloudView/src/au/gov/asd/tac/constellation/views/wordcloud/ui/WordCloudParametersPane.java
@@ -26,23 +26,18 @@ import au.gov.asd.tac.constellation.plugins.parameters.types.IntegerParameterTyp
 import au.gov.asd.tac.constellation.plugins.parameters.types.IntegerParameterType.IntegerParameterValue;
 import au.gov.asd.tac.constellation.plugins.parameters.types.SingleChoiceParameterType;
 import au.gov.asd.tac.constellation.plugins.parameters.types.SingleChoiceParameterType.SingleChoiceParameterValue;
-import au.gov.asd.tac.constellation.utilities.color.ConstellationColor;
 import au.gov.asd.tac.constellation.utilities.file.FileExtensionConstants;
-import au.gov.asd.tac.constellation.utilities.icon.UserInterfaceIconProvider;
 import au.gov.asd.tac.constellation.views.wordcloud.phraseanalysis.PhrasiphyContentParameters;
+import au.gov.asd.tac.constellation.views.wordcloud.utilities.WordCloudUtilities;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
-import javafx.geometry.Insets;
 import javafx.scene.control.Button;
 import javafx.scene.control.TitledPane;
-import javafx.scene.control.Tooltip;
-import javafx.scene.image.ImageView;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.VBox;
 import javafx.stage.FileChooser;
-import org.openide.util.HelpCtx;
 
 /**
  *
@@ -56,7 +51,6 @@ public class WordCloudParametersPane extends TitledPane implements PluginParamet
     private static final List<String> EMPTY_STRING_LIST = Arrays.asList(EMPTY_STRING);
     private List<String> nodeAttributes = new ArrayList<>();
     private List<String> transAttributes = new ArrayList<>();
-    private static final Insets HELP_PADDING = new Insets(2, 0, 0, 0);
 
     public WordCloudParametersPane(final WordCloudPane master) {
         setText("Generate Word Cloud");
@@ -158,7 +152,7 @@ public class WordCloudParametersPane extends TitledPane implements PluginParamet
         final HBox buttonBox = new HBox();
         run = new Button("Generate");
         run.setOnMouseClicked(event -> master.runPlugin(params));
-        final Button helpButton = createHelpButton();
+        final Button helpButton = WordCloudUtilities.createHelpButton();
         buttonBox.getChildren().add(run);
         buttonBox.getChildren().add(helpButton);
 
@@ -221,18 +215,6 @@ public class WordCloudParametersPane extends TitledPane implements PluginParamet
 
     public PluginParameters getParams() {
         return params;
-    }
-     
-    public static Button createHelpButton() {
-        final Button helpDocumentationButton = new Button("", new ImageView(UserInterfaceIconProvider.HELP.buildImage(16, ConstellationColor.SKY.getJavaColor())));
-        helpDocumentationButton.paddingProperty().set(HELP_PADDING);
-        helpDocumentationButton.setTooltip(new Tooltip("Display help for Word Cloud View"));
-        helpDocumentationButton.setOnAction(event -> new HelpCtx(WordCloudTopComponent.class.getName()).display());
-
-        // Get rid of the ugly button look so the icon stands alone.
-        helpDocumentationButton.setStyle("-fx-border-color: transparent;-fx-background-color: transparent; -fx-effect: null; ");
-
-        return helpDocumentationButton;
     }
     
     @Override

--- a/CoreWordCloudView/src/au/gov/asd/tac/constellation/views/wordcloud/ui/WordCloudTopComponent.java
+++ b/CoreWordCloudView/src/au/gov/asd/tac/constellation/views/wordcloud/ui/WordCloudTopComponent.java
@@ -16,6 +16,7 @@
 package au.gov.asd.tac.constellation.views.wordcloud.ui;
 
 import au.gov.asd.tac.constellation.graph.Graph;
+import au.gov.asd.tac.constellation.graph.manager.GraphManager;
 import au.gov.asd.tac.constellation.utilities.javafx.JavafxStyleManager;
 import au.gov.asd.tac.constellation.views.JavaFxTopComponent;
 import java.awt.BorderLayout;
@@ -84,36 +85,30 @@ public final class WordCloudTopComponent extends JavaFxTopComponent<WordCloudPan
 
         // Populate the jfx container
         Platform.setImplicitExit(false);
-        Platform.runLater(() -> {
-            wordCloudPane = createContent();
-            controller.setWordCloudPane(wordCloudPane);
-            final Scene scene = new Scene(wordCloudPane);
-            scene.getStylesheets().addAll(JavafxStyleManager.getMainStyleSheet());
-            panel.setScene(scene);
+        wordCloudPane = new WordCloudPane(controller);
+        controller.setWordCloudPane(wordCloudPane);
+        final Scene scene = new Scene(wordCloudPane);
+        scene.getStylesheets().addAll(JavafxStyleManager.getMainStyleSheet());
+        panel.setScene(scene);
 
-            // Update word cloud pane's size when window size changes
-            scene.heightProperty().addListener((obv, oldVal, newVal) -> 
-                wordCloudPane.setContentHeight(newVal.intValue()));
-        });
+        // Update word cloud pane's size when window size changes
+        scene.heightProperty().addListener((obv, oldVal, newVal) -> 
+            wordCloudPane.setContentHeight(newVal.intValue()));
     }
 
     @Override
     protected String createStyle() {
-        return JavafxStyleManager.isDarkTheme()
-                ? "resources/word-cloud-dark.css"
-                : "resources/word-cloud-light.css";
+        return JavafxStyleManager.isDarkTheme() ? "resources/word-cloud-dark.css" : "resources/word-cloud-light.css";
     }
 
     @Override
     protected WordCloudPane createContent() {
-        wordCloudPane = new WordCloudPane(controller);
         return wordCloudPane;
     }
 
     @Override
     public void handleNewGraph(final Graph graph) {
         if (this.graph != graph || controller.isControllerIntialising()) {
-
             // Remove change listener from previous graph
             if (this.graph != null) {
                 this.graph.removeGraphChangeListener(this);
@@ -139,11 +134,45 @@ public final class WordCloudTopComponent extends JavaFxTopComponent<WordCloudPan
             controller.updateButtonsOnPane();
             controller.updateParametersOnPane(vertTextAttributes, transTextAttributes);
         }
+        setPaneStatus();
     }
 
     @Override
     public void handleGraphOpened(final Graph graph) {
+        if (graph != null) {
+            controller.updateGraph();
+        }
+        setPaneStatus();
+    }
+
+    @Override
+    protected void handleGraphClosed(final Graph graph) {
+        if (graph != null) {
+            controller.updateGraph();
+        }
+        setPaneStatus();
+    }
+    
+    @Override
+    protected void handleComponentOpened() {
+        super.handleComponentOpened();
         controller.updateGraph();
+        setPaneStatus();
+    }
+
+    @Override
+    protected void componentShowing() {
+        super.componentShowing();
+        controller.updateGraph();
+        setPaneStatus();
+    }
+        
+    /**
+     * Sets the status of the pane dependent on if a graph is currently active.
+     * The status is used to enable or disable the view when a graph exists.
+     */
+    protected void setPaneStatus(){
+        createContent().setEnabled(GraphManager.getDefault().getActiveGraph() != null);
     }
 
     /**

--- a/CoreWordCloudView/src/au/gov/asd/tac/constellation/views/wordcloud/utilities/WordCloudUtilities.java
+++ b/CoreWordCloudView/src/au/gov/asd/tac/constellation/views/wordcloud/utilities/WordCloudUtilities.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2010-2024 Australian Signals Directorate
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package au.gov.asd.tac.constellation.views.wordcloud.utilities;
+
+import au.gov.asd.tac.constellation.utilities.color.ConstellationColor;
+import au.gov.asd.tac.constellation.utilities.icon.UserInterfaceIconProvider;
+import au.gov.asd.tac.constellation.views.wordcloud.ui.WordCloudTopComponent;
+import javafx.geometry.Insets;
+import javafx.scene.control.Button;
+import javafx.scene.control.Tooltip;
+import javafx.scene.image.ImageView;
+import org.openide.util.HelpCtx;
+
+/**
+ * Word Cloud Utilities
+ *
+ * @author antares
+ */
+public class WordCloudUtilities {
+    
+    private static final Insets HELP_PADDING = new Insets(2, 0, 0, 0);
+    
+    public static Button createHelpButton() {
+        final Button helpDocumentationButton = new Button("", new ImageView(UserInterfaceIconProvider.HELP.buildImage(16, ConstellationColor.SKY.getJavaColor())));
+        helpDocumentationButton.paddingProperty().set(HELP_PADDING);
+        helpDocumentationButton.setTooltip(new Tooltip("Display help for Word Cloud View"));
+        helpDocumentationButton.setOnAction(event -> new HelpCtx(WordCloudTopComponent.class.getName()).display());
+
+        // Get rid of the ugly button look so the icon stands alone.
+        helpDocumentationButton.setStyle("-fx-border-color: transparent;-fx-background-color: transparent; -fx-effect: null; ");
+
+        return helpDocumentationButton;
+    }
+}


### PR DESCRIPTION
<!--

### Requirements

* Filling out the template is required. Any pull request that does not include
enough information to be reviewed in a timely manner may be closed at the
maintainers' discretion.
* All new code requires unit tests to ensure they work as expected and will
continue to work as new code is added in the future (regression testing).
* Make sure your branch name is prefixed by `feature`, `bugfix` or `release`
* Have you read Constellation's Code of Conduct? By filing an issue, you are
expected to comply with it, including treating everyone with respect:
https://github.com/constellation-app/constellation/blob/master/CODE_OF_CONDUCT.md

-->

### Prerequisites

- [ ] Reviewed the [checklist](CHECKLIST.md)

- [ ] Reviewed feedback from the "Sonar Cloud" bot. Note that you have to wait
    for the "CI / Unit Tests") to complete first. Failed Unit tests can be 
    debugged by adding the label "verbose logging" to the GitHub PR.

### Description of the Change

Word Cloud threw an exception if the Generate button was clicked when there was no graph open. Rather than simply alerting the user that a graph needs to be open when the button is clicked, I've instead opted for something similar to Layers View in which with no graph open, the view instead simply displays a message saying that a graph needs to be open in order to use the view.

To do this, I've abstracted the `NoGraphPane` from the Layers View into the View Framework which enables us to add the same thing for the Word Cloud View. It also enables other views to take advantage, should we decide to include it for other views down the line.

### Alternate Designs

I could've simply added a null check where the exception occurred (since it was the graph that was null), but given the view has no use without a graph, I felt it made more sense to prevent use of the view altogether in that case.

I could've added the check, even with the changes I've made, but in theory the trouble code shouldn't ever be able to be executed without a graph now and so adding that check feels redundant.

### Why Should This Be In Core?

Fixes a bug in Core

### Benefits

View can only be used properly when a graph is open, prevents use when no graph is open. Abstraction enables potential use of NoGraphPane for other views

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process

1. Open Word Cloud View without a graph open
2. Open a graph and verify the word cloud view can now be used
3. Close the graph and verify it goes back to displaying the message.
4. Can also run checks with Word Cloud View in focus/not in focus, close and open view, multiple graphs, etc.
5. Do a similar thing with Layers View to verify it still runs as expected

### Applicable Issues

#2130 
