### PR TITLE
Revised some of the fixed Threadpool usage.

### DIFF
--- a/CoreDataAccessView/src/au/gov/asd/tac/constellation/views/dataaccess/DataAccessViewTopComponent.java
+++ b/CoreDataAccessView/src/au/gov/asd/tac/constellation/views/dataaccess/DataAccessViewTopComponent.java
@@ -68,7 +68,7 @@ import org.openide.windows.TopComponent;
 })
 public final class DataAccessViewTopComponent extends JavaFxTopComponent<DataAccessPane> {
 
-    private final ExecutorService executorService = ConstellationGlobalThreadPool.getThreadPool().getFixedThreadPool();
+    private final ExecutorService executorService = ConstellationGlobalThreadPool.getThreadPool().getFixedThreadPool("DAV-Thread", 1);
     private final DataAccessPane dataAccessPane;
 
     /**

--- a/CoreDataAccessView/src/au/gov/asd/tac/constellation/views/dataaccess/panes/DataSourceTitledPane.java
+++ b/CoreDataAccessView/src/au/gov/asd/tac/constellation/views/dataaccess/panes/DataSourceTitledPane.java
@@ -63,7 +63,7 @@ public class DataSourceTitledPane extends TitledPane implements PluginParameters
     /**
      * A thread pool to create parameters in.
      */
-    private static final ExecutorService PARAM_CREATOR = ConstellationGlobalThreadPool.getThreadPool().getFixedThreadPool();
+    private static final ExecutorService PARAM_CREATOR = ConstellationGlobalThreadPool.getThreadPool().getFixedThreadPool("Param-Thread", 1);
 
     private static final Label DUMMY_LABEL = new Label("Waiting...");
     private static final String DAV_CREATOR_THREAD_NAME = "DAV Pane Creator";

--- a/CoreSchemaView/src/au/gov/asd/tac/constellation/views/schemaview/SchemaViewPane.java
+++ b/CoreSchemaView/src/au/gov/asd/tac/constellation/views/schemaview/SchemaViewPane.java
@@ -49,7 +49,7 @@ public class SchemaViewPane extends BorderPane {
 
     public void populate() {
         Platform.runLater(() -> {
-            final Executor pool = ConstellationGlobalThreadPool.getThreadPool().getFixedThreadPool();
+            final Executor pool = ConstellationGlobalThreadPool.getThreadPool().getFixedThreadPool("Schema-Thread", 1);
             schemaViewProviders = Lookup.getDefault().lookupAll(SchemaViewNodeProvider.class);
             schemaViewProviders.stream().forEach(provider -> {
                 final Tab tab = new Tab(provider.getText());

--- a/CoreTableView/src/au/gov/asd/tac/constellation/views/tableview/TableViewTopComponent.java
+++ b/CoreTableView/src/au/gov/asd/tac/constellation/views/tableview/TableViewTopComponent.java
@@ -83,7 +83,7 @@ public final class TableViewTopComponent extends JavaFxTopComponent<TablePane> {
 
     public static final Object TABLE_LOCK = new Object();
 
-    private final ExecutorService executorService = ConstellationGlobalThreadPool.getThreadPool().getFixedThreadPool();
+    private final ExecutorService executorService = ConstellationGlobalThreadPool.getThreadPool().getFixedThreadPool("Table-Thread", 1);
 
     private final TablePane pane;
     private final Set<AttributeValueMonitor> columnAttributeMonitors;

--- a/CoreUtilities/src/au/gov/asd/tac/constellation/utilities/visual/VisualManager.java
+++ b/CoreUtilities/src/au/gov/asd/tac/constellation/utilities/visual/VisualManager.java
@@ -66,10 +66,11 @@ import java.util.concurrent.Semaphore;
  */
 public final class VisualManager {
 
+    private static int threadIdIndex = 0;
     private final VisualAccess access;
     private final VisualProcessor processor;
     private final PriorityBlockingQueue<VisualOperation> operationQueue = new PriorityBlockingQueue<>();
-    private final ExecutorService executorService = ConstellationGlobalThreadPool.getThreadPool().getFixedThreadPool();
+    private final ExecutorService executorService = ConstellationGlobalThreadPool.getThreadPool().getFixedThreadPool(("GraphThread-" + (threadIdIndex++)), 1);
     private CompletableFuture<Void> processingFuture;
     private boolean isProcessing = false;
     private boolean rendererIdle = true;


### PR DESCRIPTION

<!--

### Requirements

* Filling out the template is required. Any pull request that does not include
enough information to be reviewed in a timely manner may be closed at the
maintainers' discretion.
* All new code requires unit tests to ensure they work as expected and will
continue to work as new code is added in the future (regression testing).
* Make sure your branch name is prefixed by `feature`, `bugfix` or `release`
* Have you read Constellation's Code of Conduct? By filing an issue, you are
expected to comply with it, including treating everyone with respect:
https://github.com/constellation-app/constellation/blob/master/CODE_OF_CONDUCT.md

-->

### Prerequisites

- [ ] Reviewed the [checklist](CHECKLIST.md)

- [ ] Reviewed feedback from the "Sonar Cloud" bot. Note that you have to wait
    for the "CI / Unit Tests") to complete first. Failed Unit tests can be 
    debugged by adding the label "verbose logging" to the GitHub PR.

### Description of the Change

Addressing the issue found in #2157 

Changed some key areas of code that were using the global fixed threadpool to instead have their own dedicated fixed threadpool.
This avoids situations where functionality was being unnecessarily blocked when the global fixed threadpool was exhausted.

### Alternate Designs

Considered using the cached threadpool, but for long running processes, it is recommended to use a fixed threadpool.

### Why Should This Be In Core?

Prevent unnecessary locks/blocking in the system.

### Benefits

Improve system performance and usability.

### Verification Process

Create multiple new graphs and confirm you can keep creating new graphs beyond the number of logical processors in your system. And each new graph is fully functional (ie. can be edited)

### Applicable Issues

#2157
