### PR TITLE
Fix Conversation bubble issue with detached tail

### DIFF
--- a/CoreConversationView/src/au/gov/asd/tac/constellation/views/conversationview/ConversationBubble.java
+++ b/CoreConversationView/src/au/gov/asd/tac/constellation/views/conversationview/ConversationBubble.java
@@ -170,11 +170,11 @@ public class ConversationBubble extends VBox {
         };
         LinearGradient gradient = new LinearGradient(0, 0, 0, 1, true, CycleMethod.NO_CYCLE, stops);
 
-        bubbleGraphic.setStroke(color);
+        bubbleGraphic.setStroke(bottomColor);
         bubbleGraphic.setFill(gradient);
 
         tail.setFill(bottomColor);
-        tail.setStroke(color);
-        tailTop.setStroke(bottomColor); // Erase the border of the buble where the tail joins.
+        tail.setStroke(bottomColor);
+        tailTop.setStroke(bottomColor); // Erase the border of the bubble where the tail joins.
     }
 }

--- a/CoreConversationView/src/au/gov/asd/tac/constellation/views/conversationview/DefaultConversationDatetimeProvider.java
+++ b/CoreConversationView/src/au/gov/asd/tac/constellation/views/conversationview/DefaultConversationDatetimeProvider.java
@@ -79,7 +79,7 @@ public class DefaultConversationDatetimeProvider implements ConversationDatetime
             return new SelectableLabel(
                     timestampString, 
                     false, 
-                    JavafxStyleManager.isDarkTheme() ? "-fx-text-fill: white;" : null,
+                    JavafxStyleManager.isDarkTheme() ? "-fx-text-fill: white; -fx-font-size: 0.85em; " : " -fx-font-size: 0.85em; ",
                     null, 
                     null
             );


### PR DESCRIPTION
<!--

### Requirements

* Filling out the template is required. Any pull request that does not include
enough information to be reviewed in a timely manner may be closed at the
maintainers' discretion.
* All new code requires unit tests to ensure they work as expected and will
continue to work as new code is added in the future (regression testing).
* Make sure your branch name is prefixed by `feature`, `bugfix` or `release`
* Have you read Constellation's Code of Conduct? By filing an issue, you are
expected to comply with it, including treating everyone with respect:
https://github.com/constellation-app/constellation/blob/master/CODE_OF_CONDUCT.md

-->

### Prerequisites

- [ ] Reviewed the [checklist](CHECKLIST.md)

- [ ] Reviewed feedback from the "Sonar Cloud" bot. Note that you have to wait
    for the "CI / Unit Tests") to complete first. Failed Unit tests can be 
    debugged by adding the label "verbose logging" to the GitHub PR.

### Description of the Change

Testing on Linux, it was found that the tail of the Conversation Bubble was not connected to the main body of the bubble due to the length of the date/time string shown beneath the bubble. 

The size of the date/time text has been reduced to keep it within the bounds of the bubble body.
This allows the tail to be positioned correctly.

Also corrected an issue where the colours were not matching at the bottom of the conversation body and the top of the tail.

### Alternate Designs

Could reorganise the layout of the bubble and the timestamp info if preferred.

### Why Should This Be In Core?

To address a visual issue with the Conversation Bubbles seen on a Linux machine.

### Verification Process

Confirm that the Conversation Bubbles are correctly displayed across systems.

### Applicable Issues

#2166 