### PR TITLE
Layers View: Box selection should not include invisible elements

### DIFF
--- a/CoreInteractiveGraph/src/au/gov/asd/tac/constellation/graph/interaction/plugins/select/BoxSelectionPlugin.java
+++ b/CoreInteractiveGraph/src/au/gov/asd/tac/constellation/graph/interaction/plugins/select/BoxSelectionPlugin.java
@@ -18,6 +18,7 @@ package au.gov.asd.tac.constellation.graph.interaction.plugins.select;
 import au.gov.asd.tac.constellation.graph.Graph;
 import au.gov.asd.tac.constellation.graph.GraphElementType;
 import au.gov.asd.tac.constellation.graph.GraphWriteMethods;
+import au.gov.asd.tac.constellation.graph.LayersConcept;
 import au.gov.asd.tac.constellation.graph.operations.SetBooleanValuesOperation;
 import au.gov.asd.tac.constellation.graph.schema.visual.concept.VisualConcept;
 import au.gov.asd.tac.constellation.graph.visual.framework.VisualGraphDefaults;
@@ -79,6 +80,8 @@ public final class BoxSelectionPlugin extends SimpleEditPlugin {
         final int txSelectedAttr = VisualConcept.TransactionAttribute.SELECTED.get(graph);
         final int vxVisibilityAttr = VisualConcept.VertexAttribute.VISIBILITY.get(graph);
         final int txVisibilityAttr = VisualConcept.TransactionAttribute.VISIBILITY.get(graph);
+        final int vxLayerVisibilityAttr = LayersConcept.VertexAttribute.LAYER_VISIBILITY.get(graph);
+        final int txLayerVisibilityAttr = LayersConcept.TransactionAttribute.LAYER_VISIBILITY.get(graph);
 
         final SetBooleanValuesOperation selectVerticesOperation = new SetBooleanValuesOperation(graph, GraphElementType.VERTEX, vxSelectedAttr);
         final SetBooleanValuesOperation selectTransactionsOperation = new SetBooleanValuesOperation(graph, GraphElementType.TRANSACTION, txSelectedAttr);
@@ -128,7 +131,8 @@ public final class BoxSelectionPlugin extends SimpleEditPlugin {
 
             if (requiresVertexVisibility) {
                 final float visibility = graph.getFloatValue(vxVisibilityAttr, vxId);
-                if (visibility <= 1.0F && (visibility > visibilityHigh || visibility < visibilityLow)) {
+                final float layerVisibility = graph.getFloatValue(vxLayerVisibilityAttr, vxId);
+                if (layerVisibility == 0.0f || visibility <= 1.0F && (visibility > visibilityHigh || visibility < visibilityLow)) {
                     continue;
                 }
             }
@@ -288,8 +292,9 @@ public final class BoxSelectionPlugin extends SimpleEditPlugin {
                         final int txId = graph.getTransaction(position);
                         if (vxIncluded.get(graph.getTransactionSourceVertex(txId)) && vxIncluded.get(graph.getTransactionDestinationVertex(txId)) && !graph.getBooleanValue(txSelectedAttr, txId)) {
                             if (requiresTransactionVisibility) {
-                                float visibility = graph.getFloatValue(txVisibilityAttr, txId);
-                                if (visibility <= 1.0F && (visibility > visibilityHigh || visibility < visibilityLow)) {
+                                final float visibility = graph.getFloatValue(txVisibilityAttr, txId);
+                                final float layerVisibility = graph.getFloatValue(txLayerVisibilityAttr, txId);
+                                if (layerVisibility == 0.0f || visibility <= 1.0F && (visibility > visibilityHigh || visibility < visibilityLow)) {
                                     continue;
                                 }
                             }
@@ -312,7 +317,8 @@ public final class BoxSelectionPlugin extends SimpleEditPlugin {
                         if (vxIncluded.get(graph.getTransactionSourceVertex(txId)) && vxIncluded.get(graph.getTransactionDestinationVertex(txId))) {
                             if (requiresTransactionVisibility) {
                                 float visibility = graph.getFloatValue(txVisibilityAttr, txId);
-                                if (visibility <= 1.0F && (visibility > visibilityHigh || visibility < visibilityLow)) {
+                                final float layerVisibility = graph.getFloatValue(txLayerVisibilityAttr, txId);
+                                if (layerVisibility == 0.0f || visibility <= 1.0F && (visibility > visibilityHigh || visibility < visibilityLow)) {
                                     continue;
                                 }
                             }
@@ -339,7 +345,8 @@ public final class BoxSelectionPlugin extends SimpleEditPlugin {
                         boolean included = vxIncluded.get(graph.getTransactionSourceVertex(txId)) && vxIncluded.get(graph.getTransactionDestinationVertex(txId));
                         if (requiresTransactionVisibility) {
                             float visibility = graph.getFloatValue(txVisibilityAttr, txId);
-                            if (visibility <= 1.0F && (visibility > visibilityHigh || visibility < visibilityLow)) {
+                            final float layerVisibility = graph.getFloatValue(txLayerVisibilityAttr, txId);
+                            if (layerVisibility == 0.0f || visibility <= 1.0F && (visibility > visibilityHigh || visibility < visibilityLow)) {
                                 included = false;
                             }
                         }

--- a/CoreInteractiveGraph/src/au/gov/asd/tac/constellation/graph/interaction/plugins/select/BoxSelectionPlugin.java
+++ b/CoreInteractiveGraph/src/au/gov/asd/tac/constellation/graph/interaction/plugins/select/BoxSelectionPlugin.java
@@ -132,7 +132,7 @@ public final class BoxSelectionPlugin extends SimpleEditPlugin {
             if (requiresVertexVisibility) {
                 final float visibility = graph.getFloatValue(vxVisibilityAttr, vxId);
                 final float layerVisibility = graph.getFloatValue(vxLayerVisibilityAttr, vxId);
-                if (layerVisibility == 0.0f || visibility <= 1.0F && (visibility > visibilityHigh || visibility < visibilityLow)) {
+                if (layerVisibility == 0.0F || visibility <= 1.0F && (visibility > visibilityHigh || visibility < visibilityLow)) {
                     continue;
                 }
             }
@@ -294,7 +294,7 @@ public final class BoxSelectionPlugin extends SimpleEditPlugin {
                             if (requiresTransactionVisibility) {
                                 final float visibility = graph.getFloatValue(txVisibilityAttr, txId);
                                 final float layerVisibility = graph.getFloatValue(txLayerVisibilityAttr, txId);
-                                if (layerVisibility == 0.0f || visibility <= 1.0F && (visibility > visibilityHigh || visibility < visibilityLow)) {
+                                if (layerVisibility == 0.0F || visibility <= 1.0F && (visibility > visibilityHigh || visibility < visibilityLow)) {
                                     continue;
                                 }
                             }
@@ -316,9 +316,9 @@ public final class BoxSelectionPlugin extends SimpleEditPlugin {
                         final int txId = graph.getTransaction(position);
                         if (vxIncluded.get(graph.getTransactionSourceVertex(txId)) && vxIncluded.get(graph.getTransactionDestinationVertex(txId))) {
                             if (requiresTransactionVisibility) {
-                                float visibility = graph.getFloatValue(txVisibilityAttr, txId);
+                                final float visibility = graph.getFloatValue(txVisibilityAttr, txId);
                                 final float layerVisibility = graph.getFloatValue(txLayerVisibilityAttr, txId);
-                                if (layerVisibility == 0.0f || visibility <= 1.0F && (visibility > visibilityHigh || visibility < visibilityLow)) {
+                                if (layerVisibility == 0.0F || visibility <= 1.0F && (visibility > visibilityHigh || visibility < visibilityLow)) {
                                     continue;
                                 }
                             }
@@ -344,9 +344,9 @@ public final class BoxSelectionPlugin extends SimpleEditPlugin {
                         final int txId = graph.getTransaction(position);
                         boolean included = vxIncluded.get(graph.getTransactionSourceVertex(txId)) && vxIncluded.get(graph.getTransactionDestinationVertex(txId));
                         if (requiresTransactionVisibility) {
-                            float visibility = graph.getFloatValue(txVisibilityAttr, txId);
+                            final float visibility = graph.getFloatValue(txVisibilityAttr, txId);
                             final float layerVisibility = graph.getFloatValue(txLayerVisibilityAttr, txId);
-                            if (layerVisibility == 0.0f || visibility <= 1.0F && (visibility > visibilityHigh || visibility < visibilityLow)) {
+                            if (layerVisibility == 0.0F || visibility <= 1.0F && (visibility > visibilityHigh || visibility < visibilityLow)) {
                                 included = false;
                             }
                         }

--- a/CoreInteractiveGraph/test/unit/src/au/gov/asd/tac/constellation/graph/interaction/plugins/select/BoxSelectionPluginNGTest.java
+++ b/CoreInteractiveGraph/test/unit/src/au/gov/asd/tac/constellation/graph/interaction/plugins/select/BoxSelectionPluginNGTest.java
@@ -15,6 +15,7 @@
  */
 package au.gov.asd.tac.constellation.graph.interaction.plugins.select;
 
+import au.gov.asd.tac.constellation.graph.LayersConcept;
 import au.gov.asd.tac.constellation.graph.StoreGraph;
 import au.gov.asd.tac.constellation.graph.schema.visual.concept.VisualConcept;
 import au.gov.asd.tac.constellation.plugins.PluginException;
@@ -46,7 +47,7 @@ public class BoxSelectionPluginNGTest {
     private int attrX, attrY;
     private int vxId1, vxId2, vxId3, vxId4;
     private int txId1, txId2;
-    private int vSelectedAttrId, tSelectedAttrId;
+    private int vSelectedAttrId, tSelectedAttrId, layerVisibilityV, layerVisibilityT;
     private StoreGraph graph;
 
     public BoxSelectionPluginNGTest() {
@@ -81,6 +82,8 @@ public class BoxSelectionPluginNGTest {
 
         vSelectedAttrId = VisualConcept.VertexAttribute.SELECTED.ensure(graph);
         tSelectedAttrId = VisualConcept.TransactionAttribute.SELECTED.ensure(graph);
+        layerVisibilityV = LayersConcept.VertexAttribute.LAYER_VISIBILITY.ensure(graph);
+        layerVisibilityT = LayersConcept.TransactionAttribute.LAYER_VISIBILITY.ensure(graph);
 
         VisualConcept.VertexAttribute.NODE_RADIUS.ensure(graph);
     }

--- a/CoreInteractiveGraph/test/unit/src/au/gov/asd/tac/constellation/graph/interaction/plugins/select/BoxSelectionPluginNGTest.java
+++ b/CoreInteractiveGraph/test/unit/src/au/gov/asd/tac/constellation/graph/interaction/plugins/select/BoxSelectionPluginNGTest.java
@@ -47,7 +47,7 @@ public class BoxSelectionPluginNGTest {
     private int attrX, attrY;
     private int vxId1, vxId2, vxId3, vxId4;
     private int txId1, txId2;
-    private int vSelectedAttrId, tSelectedAttrId, layerVisibilityV, layerVisibilityT;
+    private int vSelectedAttrId, tSelectedAttrId;
     private StoreGraph graph;
 
     public BoxSelectionPluginNGTest() {
@@ -82,8 +82,8 @@ public class BoxSelectionPluginNGTest {
 
         vSelectedAttrId = VisualConcept.VertexAttribute.SELECTED.ensure(graph);
         tSelectedAttrId = VisualConcept.TransactionAttribute.SELECTED.ensure(graph);
-        layerVisibilityV = LayersConcept.VertexAttribute.LAYER_VISIBILITY.ensure(graph);
-        layerVisibilityT = LayersConcept.TransactionAttribute.LAYER_VISIBILITY.ensure(graph);
+        LayersConcept.VertexAttribute.LAYER_VISIBILITY.ensure(graph);
+        LayersConcept.TransactionAttribute.LAYER_VISIBILITY.ensure(graph);
 
         VisualConcept.VertexAttribute.NODE_RADIUS.ensure(graph);
     }


### PR DESCRIPTION
<!--

### Requirements

* Filling out the template is required. Any pull request that does not include
enough information to be reviewed in a timely manner may be closed at the
maintainers' discretion.
* All new code requires unit tests to ensure they work as expected and will
continue to work as new code is added in the future (regression testing).
* Make sure your branch name is prefixed by `feature`, `bugfix` or `release`
* Have you read Constellation's Code of Conduct? By filing an issue, you are
expected to comply with it, including treating everyone with respect:
https://github.com/constellation-app/constellation/blob/master/CODE_OF_CONDUCT.md

-->

### Prerequisites

- [ ] Reviewed the [checklist](CHECKLIST.md)

- [ ] Reviewed feedback from the "Sonar Cloud" bot. Note that you have to wait
    for the "CI / Unit Tests") to complete first. Failed Unit tests can be 
    debugged by adding the label "verbose logging" to the GitHub PR.

### Description of the Change

Addressed a Box Selection issue (where you click and drag the mouse over the graph to create a selection area) ...

Currently, when Layers are active, and the graph window is displaying a subset of graph elements appropriate to the active layers ... all elements with x,y coordinates within the selection box are being selected, regardless of their visibility.

The Box Selection functionality should filter out graph elements that are not visible for the active layers.

The code will now check if a graph element has appropriate visibility before being included in the set of elements being selected during a BoxSelection action.

Note: this fix only addresses one of the many issues with integrating layer functionality across the product. See #2182 for more details

### Alternate Designs

N/A

### Why Should This Be In Core?

Improved/more intuitive UI

### Benefits

Improved functionality when Layers are being used. 

### Verification Process

Create a new empty graph.
Open the Layers View.
Add a Layer.
Active Layer 1.
Create a node on the graph (it will be auto-allocated to Layer 1).
De-active layer 1, then active Layer 2.
Create a node on the graph (it will be auto-allocated to Layer 2).
Note: Only node 2 should be visible.
Do a Box Selection over the entire graph window.
Only node 2 should be selected as it is the only visible node.
De-activate Layer 2.
You should now see the complete graph with both nodes displaying.
Confirm that only the second node is selected.

### Applicable Issues

#2182

