### PR TITLE
Update FileChooser.java to popup confirmation dialog on same screen

### DIFF
--- a/CoreUtilities/src/au/gov/asd/tac/constellation/utilities/gui/filechooser/FileChooser.java
+++ b/CoreUtilities/src/au/gov/asd/tac/constellation/utilities/gui/filechooser/FileChooser.java
@@ -30,6 +30,7 @@ import javax.swing.filechooser.FileFilter;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.openide.filesystems.FileChooserBuilder;
+import org.openide.windows.WindowManager;
 
 /**
  * Wrapper for opening file choosers built with the {@link FileChooserBuilder}. There are a couple of issues on macOS
@@ -183,7 +184,7 @@ public class FileChooser {
      *
      * @param selection the files selected by the user when trying to save
      * @param fileExtension the file extension associated with this FileChooserBuilder
-     * @return user response, indicating if user wants to overwrite exisitng file
+     * @return user response, indicating if user wants to overwrite existing file
      */
     private static boolean approver(final File[] selection, final String fileExtension) {
         // Show dialog box if file already exists when saving
@@ -192,7 +193,7 @@ public class FileChooser {
         final File file = new File(filepath);
 
         if (file.exists()) {
-            final int response = JOptionPane.showConfirmDialog(null,
+            final int response = JOptionPane.showConfirmDialog(WindowManager.getDefault().getMainWindow(),
                     "The file " + file.getName() + " already exists. Do you want to replace the existing file?",
                     "Overwrite file", JOptionPane.YES_NO_OPTION, JOptionPane.WARNING_MESSAGE);
             // Overwrite if user chose yes


### PR DESCRIPTION
<!--

### Requirements

* Filling out the template is required. Any pull request that does not include
enough information to be reviewed in a timely manner may be closed at the
maintainers' discretion.
* All new code requires unit tests to ensure they work as expected and will
continue to work as new code is added in the future (regression testing).
* Make sure your branch name is prefixed by `feature`, `bugfix` or `release`
* Have you read Constellation's Code of Conduct? By filing an issue, you are
expected to comply with it, including treating everyone with respect:
https://github.com/constellation-app/constellation/blob/master/CODE_OF_CONDUCT.md

-->

### Prerequisites

- [ ] Reviewed the [checklist](CHECKLIST.md)

- [ ] Reviewed feedback from the "Sonar Cloud" bot. Note that you have to wait
    for the "CI / Unit Tests") to complete first. Failed Unit tests can be 
    debugged by adding the label "verbose logging" to the GitHub PR.

### Description of the Change
Set the main window to be the parent of the FileChooser approver so that the confirmation dialog will pop up on the same screen/monitor.

<!--

We must be able to understand the design of your change from this description.
If we can't get a good idea of what the code will be doing from the description
here, the pull request may be closed at the maintainers' discretion. Keep in
mind that the maintainer reviewing this PR may not be familiar with or have
worked with the code here recently, so please walk us through the concepts.

-->

### Alternate Designs

<!--

Explain what other alternates were considered and why the proposed version was
selected.

-->

### Why Should This Be In Core?
This will enable the FileChooser confirmation dialog to appear on the same screen as the app.
<!--

Explain why this functionality should be in Constellation Core as opposed to a
different module suite. Note that this question is more applicable when adding
new functionality. If this change is a minor update to an existing file then it
is understood that this change has to be to this module suite and a response
and therefore a response to this question is not required.

-->

### Benefits
This will enable the FileChooser confirmation dialog to appear on the same screen as the app.
<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process

The first 2 set of steps (File Save and File Open) are to verify that the first 2 issues raised in ticket #2082 have already been fixed.

1 - File Save
a) Open a graph
b) Export the graph to an SVG
c) export the graph to a KML
d) Save the KML in the same location as the exported SVG
e) Note no warning dialog

2 - File Open
a) Open the Data Access View
b) Navigate to the Test Parameters Plugin
c) Select Open File parameter
d) Select a text file.
e) Note no warning dialog.

This next set of steps are to verify that the confirmation dialog appears on the same screen as the app (the third issue raised in the ticket).

3 - File confirmation dialog
a) Move the Consty app to a different screen that is not the primary monitor.
b) Open a graph.
c) Export the graph to an SVG. Note the name.
d) Once the file is saved, export the graph to the same SVG file name.
e) The confirmation dialog is on the same screen as the app.
<!--

What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (e.g. buttons you clicked, text you typed,
commands you ran, etc.), and describe the results you observed.

-->

### Applicable Issues
#2082 
<!-- Link any applicable issues here -->
