### PR TITLE
removed timeout from rest functions

### DIFF
--- a/CoreWebServer/src/au/gov/asd/tac/constellation/webserver/services/NewGraph.java
+++ b/CoreWebServer/src/au/gov/asd/tac/constellation/webserver/services/NewGraph.java
@@ -138,7 +138,7 @@ public class NewGraph extends RestService {
         String newId = "";
 
         try {
-            newId = RestServiceUtilities.waitForGraphChange(existingId).get(10, TimeUnit.SECONDS);
+            newId = RestServiceUtilities.waitForGraphChange(existingId).get();
             if (!newId.isBlank()) {
                 final ObjectMapper mapper = new ObjectMapper();
                 final ObjectNode root = mapper.createObjectNode();
@@ -150,7 +150,7 @@ public class NewGraph extends RestService {
         } catch (final InterruptedException ex) {
             Thread.currentThread().interrupt();
             LOGGER.log(Level.SEVERE, "Thread interrupted", ex);
-        } catch (final ExecutionException | TimeoutException ex) {
+        } catch (final ExecutionException ex) {
             throw new RestServiceException(ex);
         }
 

--- a/CoreWebServer/src/au/gov/asd/tac/constellation/webserver/services/OpenGraph.java
+++ b/CoreWebServer/src/au/gov/asd/tac/constellation/webserver/services/OpenGraph.java
@@ -107,7 +107,7 @@ public class OpenGraph extends RestService {
             final Graph g = new GraphJsonReader().readGraphZip(fnam, new HandleIoProgress(String.format("Loading graph %s...", fnam)));
             GraphOpener.getDefault().openGraph(g, name, false);
 
-            final String newId = RestServiceUtilities.waitForGraphChange(existingId).get(10, TimeUnit.SECONDS);
+            final String newId = RestServiceUtilities.waitForGraphChange(existingId).get();
             final Graph graph = GraphNode.getGraphNode(newId).getGraph();
 
             final ObjectMapper mapper = new ObjectMapper();
@@ -121,7 +121,7 @@ public class OpenGraph extends RestService {
         } catch (final InterruptedException ex) {
             Thread.currentThread().interrupt();
             LOGGER.log(Level.SEVERE, "This thread has been interrupted", ex);
-        } catch (final ExecutionException | TimeoutException ex) {
+        } catch (final ExecutionException ex) {
             throw new RestServiceException(ex);
         }
     }


### PR DESCRIPTION
<!--

### Requirements

* Filling out the template is required. Any pull request that does not include
enough information to be reviewed in a timely manner may be closed at the
maintainers' discretion.
* All new code requires unit tests to ensure they work as expected and will
continue to work as new code is added in the future (regression testing).
* Make sure your branch name is prefixed by `feature`, `bugfix` or `release`
* Have you read Constellation's Code of Conduct? By filing an issue, you are
expected to comply with it, including treating everyone with respect:
https://github.com/constellation-app/constellation/blob/master/CODE_OF_CONDUCT.md

-->

### Prerequisites

- [x] Reviewed the [checklist](CHECKLIST.md)

- [ ] Reviewed feedback from the "Sonar Cloud" bot. Note that you have to wait
    for the "CI / Unit Tests") to complete first. Failed Unit tests can be 
    debugged by adding the label "verbose logging" to the GitHub PR.

### Description of the Change

The New Graph and Open Graph rest functions have a 10 second timeout applied to them and so if that timeout is reached, you get a http 500 error thrown. For a new graph, this can happen the first time a graph is opened in a Constellation session as sorting out things with the GPU the first time around can sometimes result in this time being exceeded.

This change removes the timeouts which allows the functions to run along as needed.

### Alternate Designs

I also considered extending the timeout limit (e.g. to 30 secs) but in the end decided that the timeout period wasn't necessary. While nice in theory as it avoid having notebooks run for a considerably long time, there are 2 points to consider:
1) If either of these functions are included in the notebook, its more than likely that the code after these functions is dependent on these functions running successfully, and so better to give it a chance to complete
2) If needing to stop a notebook that is "taking too long to run", there are other ways for a user to easily do so without needing the notebook to do it by itself (e.g. if running via anaconda, there is a stop button that can be pressed).

### Why Should This Be In Core?

Removes issues in the rest api whereby the execution of a notebook may terminate as a result of hitting an arbitrary timeout limit.

### Benefits

Notebooks (and other uses of the REST API) now have a better chance of completion without throwing errors as a result of timeouts

### Possible Drawbacks

Notebooks can consequently take a fair time to execute. As noted in the alternate designs though, there are alternate means of terminating early if desired. 

### Verification Process

1. Open Constellation and Open Jupyter Notebooks
2. Open the notebooks_and_constellation notebook
3. Run the Part 1 of the notebook (only need to run up until what should be the 9th code block)

### Applicable Issues

#2067
