### PR TITLE
Fix bug allowing user to open same graph multiple times on welcome page

### DIFF
--- a/CoreInteractiveGraph/src/au/gov/asd/tac/constellation/graph/interaction/gui/VisualGraphOpener.java
+++ b/CoreInteractiveGraph/src/au/gov/asd/tac/constellation/graph/interaction/gui/VisualGraphOpener.java
@@ -43,7 +43,9 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.ZonedDateTime;
+import java.util.ArrayList;
 import java.util.Date;
+import java.util.List;
 import java.util.Properties;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -61,10 +63,8 @@ import org.openide.windows.TopComponent;
 /**
  * A GraphOpener that opens a graph into a VisualTopComponent.
  * <p>
- * Note that if you don't have support for OpenGL then comment out the
- * ServiceProvider annotation which will mean that
- * {@link au.gov.asd.tac.constellation.graph.node.gui.SimpleGraphTopComponent}
- * is used instead.
+ * Note that if you don't have support for OpenGL then comment out the ServiceProvider annotation which will mean that
+ * {@link au.gov.asd.tac.constellation.graph.node.gui.SimpleGraphTopComponent} is used instead.
  *
  * @author algol
  */
@@ -78,14 +78,16 @@ import org.openide.windows.TopComponent;
 public final class VisualGraphOpener extends GraphOpener {
 
     private static final Logger LOGGER = Logger.getLogger(VisualGraphOpener.class.getName());
-    
+
     private static final String UNABLE_TO_REMOVE_SECONDARY_BACKUP_MESSAGE = "Unable to remove old secondary backup file: {0}";
+
+    final private static List<String> openingGraphs = new ArrayList<>();
 
     /**
      * Open a graph file into a VisualTopComponent.
      * <p>
-     * A check is done to see if the file to be opened is already open. If it
-     * is, that TopComponent is made active, rather than opening the file again.
+     * A check is done to see if the file to be opened is already open. If it is, that TopComponent is made active,
+     * rather than opening the file again.
      *
      * @param gdo The GraphDataObject to read from.
      */
@@ -103,10 +105,16 @@ public final class VisualGraphOpener extends GraphOpener {
             }
         }
 
+        final File f = FileUtil.toFile(gdo.getPrimaryFile());
+
+        // If graph is currently being opened, but isn't open yet
+        if (openingGraphs.contains(f.getPath())) {
+            return;
+        }
+
         // The file isn't already open.
         // Check to see if there is a more recent autosave for this file.
         // If there is, ask the user if they want to open it.
-        final File f = FileUtil.toFile(gdo.getPrimaryFile());
         final Properties props = AutosaveUtilities.getAutosave(f);
         if (props != null) {
             final String dtprop = props.getProperty(AutosaveUtilities.DT);
@@ -135,11 +143,11 @@ public final class VisualGraphOpener extends GraphOpener {
                                     LOGGER.log(Level.WARNING, "Unable to backup file: {0}", toBak);
                                 } else {
                                     AutosaveUtilities.copyFile(autosaved, f);
-                                } 
+                                }
                             } else {
                                 AutosaveUtilities.copyFile(autosaved, f);
                             }
-                            
+
                         } catch (final IOException ex) {
                             LOGGER.log(Level.WARNING, "Copying autosaved file", ex);
                         }
@@ -149,6 +157,9 @@ public final class VisualGraphOpener extends GraphOpener {
                 }
             }
         }
+
+        // Add to list of graphs currently being opened
+        openingGraphs.add(f.getPath());
 
         // The file isn't already open, so open it.
         new GraphFileOpener(gdo, null, null).execute();
@@ -200,7 +211,7 @@ public final class VisualGraphOpener extends GraphOpener {
             final File graphFile = FileUtil.toFile(gdo.getPrimaryFile());
             final File backupFile = new File(graphFile.toString().concat(FileExtensionConstants.BACKUP));
             final File backupBackupFile = new File(backupFile.toString().concat(FileExtensionConstants.BACKUP));
-            
+
             if (graph == null) {
                 HandleIoProgress ioProgressHandler = new HandleIoProgress(String.format("Reading %s...", graphFile.getName()));
                 try {
@@ -208,7 +219,7 @@ public final class VisualGraphOpener extends GraphOpener {
                     LOGGER.log(Level.INFO, "Attempting to open {0}", graphFile);
                     graph = new GraphJsonReader().readGraphZip(graphFile, ioProgressHandler);
                     time = System.currentTimeMillis() - t0;
-                    
+
                     // Everything worked, there was no need for any bakbak file
                     if (backupBackupFile.exists()) {
                         try {
@@ -217,7 +228,7 @@ public final class VisualGraphOpener extends GraphOpener {
                             LOGGER.log(Level.WARNING, UNABLE_TO_REMOVE_SECONDARY_BACKUP_MESSAGE, backupBackupFile);
                         }
                     }
-                    
+
                 } catch (final GraphParseException | IOException | RuntimeException ex) {
                     gex = ex;
                 }
@@ -257,28 +268,27 @@ public final class VisualGraphOpener extends GraphOpener {
                         }
                     }
                 } catch (final GraphParseException | IOException | RuntimeException ex) {
-                    
-                    if (!backupBackupFile.exists())
-                    {
+
+                    if (!backupBackupFile.exists()) {
                         LOGGER.log(Level.WARNING, "Unable to open requested file ({0}) or associated backup", graphFile);
                     }
                     gex = ex;
                     // Clear previous progress message and reset to indicate we are trying to use backup.
                     ioProgressHandler.finish();
                 }
-                
+
                 // Handle the rare case where user elected to open an autosave, however this autosave is corrupt.
                 // Code then tried to open the original file, which is also found to be corrupt. The way autsave manages this
                 // is to copy the original file to .bak and the autosave to the original file. As we can also have a .bak
                 // we are copying this off to .bak.bak and only teying it if both the autosave and original file failed.
                 if (gex != null && backupBackupFile.exists()) {
-                    try { 
+                    try {
                         final long t0 = System.currentTimeMillis();
                         ioProgressHandler = new HandleIoProgress(String.format("Unable to read backup %s, reading secondary backup %s...",
-                                                                                backupFile.getName(), backupBackupFile.getName()));
+                                backupFile.getName(), backupBackupFile.getName()));
                         graph = new GraphJsonReader().readGraphZip(backupBackupFile, ioProgressHandler);
                         time = System.currentTimeMillis() - t0;
-                        gex = null;  
+                        gex = null;
 
                         LOGGER.log(Level.INFO, "Successfully opened secondary backup file: {0}, replacing star file", backupBackupFile);
                         FileUtils.copyFile(new File(backupBackupFile.toString()), new File(graphFile.toString()));
@@ -340,6 +350,9 @@ public final class VisualGraphOpener extends GraphOpener {
             } else {
                 // Do nothing
             }
+
+            // Graph has finished opening, so remove from list
+            openingGraphs.remove(FileUtil.toFile(gdo.getPrimaryFile()).getPath());
         }
     }
 


### PR DESCRIPTION
<!--

### Requirements

* Filling out the template is required. Any pull request that does not include
enough information to be reviewed in a timely manner may be closed at the
maintainers' discretion.
* All new code requires unit tests to ensure they work as expected and will
continue to work as new code is added in the future (regression testing).
* Make sure your branch name is prefixed by `feature`, `bugfix` or `release`
* Have you read Constellation's Code of Conduct? By filing an issue, you are
expected to comply with it, including treating everyone with respect:
https://github.com/constellation-app/constellation/blob/master/CODE_OF_CONDUCT.md

-->

### Prerequisites

- [x] Reviewed the [checklist](CHECKLIST.md)

- [x] Reviewed feedback from the "Sonar Cloud" bot. Note that you have to wait
    for the "CI / Unit Tests") to complete first. Failed Unit tests can be 
    debugged by adding the label "verbose logging" to the GitHub PR.

### Description of the Change

<!--

We must be able to understand the design of your change from this description.
If we can't get a good idea of what the code will be doing from the description
here, the pull request may be closed at the maintainers' discretion. Keep in
mind that the maintainer reviewing this PR may not be familiar with or have
worked with the code here recently, so please walk us through the concepts.

-->
Fixed a bug on the welcome page, where if a user clicks on a recently opened graph multiple times during the initial load of OpenGL (caused by opening the first graph), then multiple copies of that graph will be opened. 

### Alternate Designs

<!--

Explain what other alternates were considered and why the proposed version was
selected.

-->
N/A

### Why Should This Be In Core?

<!--

Explain why this functionality should be in Constellation Core as opposed to a
different module suite. Note that this question is more applicable when adding
new functionality. If this change is a minor update to an existing file then it
is understood that this change has to be to this module suite and a response
and therefore a response to this question is not required.

-->
N/A

### Benefits

<!-- What benefits will be realized by the code change? -->
Only open copy of each graph is opened, as would normally happen after the initial OpenGL load.

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->
None.

### Verification Process

<!--

What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (e.g. buttons you clicked, text you typed,
commands you ran, etc.), and describe the results you observed.

-->

1. Have a graph saved in the Recent graphs on the Welcome View
2. Click to open the graph multiple times
3. Observe only one copy of the graph has been opened
4. Attempt to open the graph from the welcome view again, Constellation should swap tabs to the already open graph
5. Attempt to open a graph with the same name which has been saved in a different location. It should still open.

### Applicable Issues

<!-- Link any applicable issues here -->
https://github.com/constellation-app/constellation/issues/2172