### PR TITLE
Fix exception being thrown when closing and saving graphs too quickly

### DIFF
--- a/CoreInteractiveGraph/src/au/gov/asd/tac/constellation/graph/interaction/gui/VisualGraphTopComponent.java
+++ b/CoreInteractiveGraph/src/au/gov/asd/tac/constellation/graph/interaction/gui/VisualGraphTopComponent.java
@@ -114,6 +114,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.lang.ref.Cleaner;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
@@ -969,6 +970,14 @@ public final class VisualGraphTopComponent extends CloneableTopComponent impleme
                 final String name = gdo.getName();
                 // Create a new file and write to it.
                 final String tmpnam = String.format("%s_tmp%08x", name, gdo.hashCode());
+
+                //Dont create temp file if one already exists (createFromTemplate will throw an exception if one of the same name exists)
+                final Path folderPath = Paths.get(gdo.getFolder().getPrimaryFile().toURI());
+                final Path filepath = Paths.get(folderPath.toString(), tmpnam + GraphDataObject.FILE_EXTENSION);
+                if (Files.exists(filepath)) {
+                    return;
+                }
+
                 final GraphDataObject freshGdo = (GraphDataObject) gdo.createFromTemplate(gdo.getFolder(), tmpnam);
 
                 final Semaphore waiter = new Semaphore(0);
@@ -1150,7 +1159,9 @@ public final class VisualGraphTopComponent extends CloneableTopComponent impleme
             cancelled = false;
             this.waiter = semaphore;
 
-            GraphNode.getGraphNode(graph).makeBusy(true);
+            if (GraphNode.getGraphNode(graph) != null) {
+                GraphNode.getGraphNode(graph).makeBusy(true);
+            }
         }
 
         @Override

--- a/CoreInteractiveGraph/test/unit/src/au/gov/asd/tac/constellation/graph/interaction/gui/VisualGraphTopComponentNGTest.java
+++ b/CoreInteractiveGraph/test/unit/src/au/gov/asd/tac/constellation/graph/interaction/gui/VisualGraphTopComponentNGTest.java
@@ -350,4 +350,60 @@ public class VisualGraphTopComponentNGTest {
 
         instance.requestActiveWithLatch(null);
     }
+    
+    /**
+     * Test of saveGraph method, of class VisualGraphTopComponent.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testHandleSaveFileExists() throws Exception {
+        System.out.println("handleSave file already exists");
+
+        // Mock variables
+        final GraphDataObject mockGDO = mock(GraphDataObject.class);
+        final FileObject mockFileObject = mock(FileObject.class);
+        final File mockFile = mock(File.class);
+        final DualGraph dgSpy = spy(new DualGraph(null));
+        final String path = "mocked path";
+        final Long lastModified = 123L;
+
+        final DataFolder mockFolder = mock(DataFolder.class);
+        final FileObject mockFolderFileObject = mock(FileObject.class);
+        final URI mockURI = mock(URI.class);
+        final Path mockFolderPath = mock(Path.class);
+        final String mockFolderPathString = "mockFolderPathString";
+
+        when(mockGDO.isInMemory()).thenReturn(false);
+        when(mockGDO.isValid()).thenReturn(true);
+        when(mockGDO.getPrimaryFile()).thenReturn(mockFileObject);
+        when(mockGDO.createFromTemplate(any(), anyString())).thenReturn(mockGDO);
+
+        when(mockFileObject.getPath()).thenReturn("");
+        when(mockFile.getPath()).thenReturn(path);
+        when(mockFile.lastModified()).thenReturn(lastModified);
+
+        when(mockFolder.getPrimaryFile()).thenReturn(mockFolderFileObject);
+        when(mockFolderFileObject.toURI()).thenReturn(mockURI);
+        when(mockGDO.getFolder()).thenReturn(mockFolder);
+        when(mockFolderPath.toString()).thenReturn(mockFolderPathString);
+
+        try (final MockedStatic<Paths> mockPaths = Mockito.mockStatic(Paths.class, Mockito.CALLS_REAL_METHODS); final MockedStatic<Files> mockFiles = Mockito.mockStatic(Files.class, Mockito.CALLS_REAL_METHODS)) {
+            // Set up paths mock
+            mockPaths.when(() -> Paths.get(mockURI)).thenReturn(mockFolderPath);
+            mockPaths.when(() -> Paths.get(anyString(), anyString())).thenReturn(mockFolderPath);
+            // Set up Files mock
+            mockFiles.when(() -> Files.exists(mockFolderPath)).thenReturn(true);
+
+            final VisualGraphTopComponent instance = new VisualGraphTopComponent(mockGDO, dgSpy);
+            instance.getGraphNode().setDataObject(mockGDO);
+            instance.saveGraph();
+
+            assertEquals(instance.getGraphNode().getDataObject(), mockGDO);
+
+            verify(mockGDO).isValid();
+            verify(mockGDO).isInMemory();
+            verify(mockGDO, times(2)).getName();
+        }
+    }
 }

--- a/CoreInteractiveGraph/test/unit/src/au/gov/asd/tac/constellation/graph/interaction/gui/VisualGraphTopComponentNGTest.java
+++ b/CoreInteractiveGraph/test/unit/src/au/gov/asd/tac/constellation/graph/interaction/gui/VisualGraphTopComponentNGTest.java
@@ -350,15 +350,15 @@ public class VisualGraphTopComponentNGTest {
 
         instance.requestActiveWithLatch(null);
     }
-    
+
     /**
-     * Test of saveGraph method, of class VisualGraphTopComponent.
+     * Test of saveGraph method when temp file already exists, of class VisualGraphTopComponent.
      *
      * @throws Exception
      */
     @Test
-    public void testHandleSaveFileExists() throws Exception {
-        System.out.println("handleSave file already exists");
+    public void testSaveGraphFileExists() throws Exception {
+        System.out.println("SaveGraph file already exists");
 
         // Mock variables
         final GraphDataObject mockGDO = mock(GraphDataObject.class);

--- a/CoreInteractiveGraph/test/unit/src/au/gov/asd/tac/constellation/graph/interaction/gui/VisualGraphTopComponentNGTest.java
+++ b/CoreInteractiveGraph/test/unit/src/au/gov/asd/tac/constellation/graph/interaction/gui/VisualGraphTopComponentNGTest.java
@@ -24,12 +24,15 @@ import au.gov.asd.tac.constellation.graph.schema.visual.attribute.objects.Connec
 import static au.gov.asd.tac.constellation.graph.schema.visual.attribute.objects.ConnectionMode.LINK;
 import au.gov.asd.tac.constellation.graph.visual.framework.VisualGraphDefaults;
 import java.io.File;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.concurrent.TimeoutException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import org.mockito.MockedConstruction;
+import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
@@ -37,6 +40,9 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import org.openide.filesystems.FileObject;
+import org.openide.loaders.DataFolder;
+import java.net.URI;
+import java.nio.file.Files;
 import org.testfx.api.FxToolkit;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
@@ -172,6 +178,12 @@ public class VisualGraphTopComponentNGTest {
         final String path = "mocked path";
         final Long lastModified = 123L;
 
+        final DataFolder mockFolder = mock(DataFolder.class);
+        final FileObject mockFolderFileObject = mock(FileObject.class);
+        final URI mockURI = mock(URI.class);
+        final Path mockFolderPath = mock(Path.class);
+        final String mockFolderPathString = "mockFolderPathString";
+
         when(mockGDO.isInMemory()).thenReturn(false);
         when(mockGDO.isValid()).thenReturn(true);
         when(mockGDO.getPrimaryFile()).thenReturn(mockFileObject);
@@ -181,17 +193,29 @@ public class VisualGraphTopComponentNGTest {
         when(mockFile.getPath()).thenReturn(path);
         when(mockFile.lastModified()).thenReturn(lastModified);
 
-        // Mock contruct save as action, GraphNode
-        VisualGraphTopComponent instance = new VisualGraphTopComponent(mockGDO, dgSpy);
-        instance.getGraphNode().setDataObject(mockGDO);
-        instance.saveGraph();
+        when(mockFolder.getPrimaryFile()).thenReturn(mockFolderFileObject);
+        when(mockFolderFileObject.toURI()).thenReturn(mockURI);
+        when(mockGDO.getFolder()).thenReturn(mockFolder);
+        when(mockFolderPath.toString()).thenReturn(mockFolderPathString);
 
-        assertEquals(instance.getGraphNode().getDataObject(), mockGDO);
+        try (final MockedStatic<Paths> mockPaths = Mockito.mockStatic(Paths.class, Mockito.CALLS_REAL_METHODS); final MockedStatic<Files> mockFiles = Mockito.mockStatic(Files.class, Mockito.CALLS_REAL_METHODS)) {
+            // Set up paths mock
+            mockPaths.when(() -> Paths.get(mockURI)).thenReturn(mockFolderPath);
+            mockPaths.when(() -> Paths.get(anyString(), anyString())).thenReturn(mockFolderPath);
+            // Set up Files mock
+            mockFiles.when(() -> Files.exists(mockFolderPath)).thenReturn(false);
 
-        verify(mockGDO).isValid();
-        verify(mockGDO).isInMemory();
-        verify(mockGDO, times(2)).getName();
-        verify(mockGDO, times(4)).getPrimaryFile();
+            final VisualGraphTopComponent instance = new VisualGraphTopComponent(mockGDO, dgSpy);
+            instance.getGraphNode().setDataObject(mockGDO);
+            instance.saveGraph();
+
+            assertEquals(instance.getGraphNode().getDataObject(), mockGDO);
+
+            verify(mockGDO).isValid();
+            verify(mockGDO).isInMemory();
+            verify(mockGDO, times(2)).getName();
+            verify(mockGDO, times(4)).getPrimaryFile();
+        }
     }
 
     /**
@@ -284,9 +308,9 @@ public class VisualGraphTopComponentNGTest {
         when(mockReadableGraph.getAttribute(GraphElementType.GRAPH, "draw_flags")).thenReturn(graphNotFound);
 
         // Mock contruct save as action, GraphNode
-        try (MockedConstruction<SaveAsAction> mockSaveAsAction = Mockito.mockConstruction(SaveAsAction.class)) {
+        try (final MockedConstruction<SaveAsAction> mockSaveAsAction = Mockito.mockConstruction(SaveAsAction.class)) {
 
-            VisualGraphTopComponent instance = new VisualGraphTopComponent(mockGDO, dgSpy);
+            final VisualGraphTopComponent instance = new VisualGraphTopComponent(mockGDO, dgSpy);
 
             instance.getGraphNode().setDataObject(mockGDO);
             instance.saveGraph();
@@ -322,7 +346,6 @@ public class VisualGraphTopComponentNGTest {
         when(mockFile.getPath()).thenReturn(path);
         when(mockFile.lastModified()).thenReturn(lastModified);
 
-        // Mock contruct save as action, GraphNode
         final VisualGraphTopComponent instance = new VisualGraphTopComponent(mockGDO, dgSpy);
 
         instance.requestActiveWithLatch(null);


### PR DESCRIPTION
<!--

### Requirements

* Filling out the template is required. Any pull request that does not include
enough information to be reviewed in a timely manner may be closed at the
maintainers' discretion.
* All new code requires unit tests to ensure they work as expected and will
continue to work as new code is added in the future (regression testing).
* Make sure your branch name is prefixed by `feature`, `bugfix` or `release`
* Have you read Constellation's Code of Conduct? By filing an issue, you are
expected to comply with it, including treating everyone with respect:
https://github.com/constellation-app/constellation/blob/master/CODE_OF_CONDUCT.md

-->

### Prerequisites

- [x] Reviewed the [checklist](CHECKLIST.md)

- [x] Reviewed feedback from the "Sonar Cloud" bot. Note that you have to wait
    for the "CI / Unit Tests") to complete first. Failed Unit tests can be 
    debugged by adding the label "verbose logging" to the GitHub PR.

### Description of the Change

<!--

We must be able to understand the design of your change from this description.
If we can't get a good idea of what the code will be doing from the description
here, the pull request may be closed at the maintainers' discretion. Keep in
mind that the maintainer reviewing this PR may not be familiar with or have
worked with the code here recently, so please walk us through the concepts.

-->
Fix exception being thrown when closing and saving graphs too quickly. This was because a second temp file would be made before the first was cleaned up, causing an error.

### Alternate Designs

<!--

Explain what other alternates were considered and why the proposed version was
selected.

-->
Could possibly use a slightly more complex solution that keeps track of files being saved in a queue system. That way there would never be duplicates. However, the simpler approach of checking if the temp file already exists is better, I think, as edge cases would be unlikely.

### Why Should This Be In Core?

<!--

Explain why this functionality should be in Constellation Core as opposed to a
different module suite. Note that this question is more applicable when adding
new functionality. If this change is a minor update to an existing file then it
is understood that this change has to be to this module suite and a response
and therefore a response to this question is not required.

-->
N/A

### Benefits

<!-- What benefits will be realized by the code change? -->
Exception no longer thrown, and graphs can be saved even when rapidly closing tabs and saving.

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->
I can see an edge case where an old temp file wasn't removed previously, and it just so happens to have the same hash code as a graph that is trying to be saved. This would be very unlikely, I think.

### Verification Process

<!--

What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (e.g. buttons you clicked, text you typed,
commands you ran, etc.), and describe the results you observed.

-->

1. Open consty
2. Open multiple previously saved graphs (e.g. 4 graphs)
3. Edit each graph in some way (e.g. add a node to each graph)
4. Quickly close all graphs EXCEPT the currently active graph, quickly saving when prompted. This can be done by rapidly clicking the 'x' on each graph tab (to close) and mashing the enter key (to save the graph).
5. Observe graphs are saved and not exception is thrown.

### Applicable Issues

<!-- Link any applicable issues here -->
https://github.com/constellation-app/constellation/issues/2195