### PR TITLE
Minor fixes for v3.1-rc1

### DIFF
--- a/CoreNotesView/src/au/gov/asd/tac/constellation/views/notes/resources/time-filter-dark.css
+++ b/CoreNotesView/src/au/gov/asd/tac/constellation/views/notes/resources/time-filter-dark.css
@@ -29,7 +29,7 @@
 }
 
 .contentField {
-    -fx-control-inner-background:#000000;
+    -fx-control-inner-background: #000000;
     -fx-text-fill: white;
 }
 
@@ -75,7 +75,7 @@
 }
 
 .menu-button {
-    -fx-background-color: 111111;
+    -fx-background-color: #111111;
     -fx-border-radius: 2px; 
     -fx-border-color: #444444;
     -fx-arrow-color: white;

--- a/CoreWhatsNewView/src/au/gov/asd/tac/constellation/views/whatsnew/whatsnew.txt
+++ b/CoreWhatsNewView/src/au/gov/asd/tac/constellation/views/whatsnew/whatsnew.txt
@@ -10,8 +10,8 @@
 <p>This search uses the names of each help page and the category they are in for the table of contents to narrow down results.</p>
 
 == 2024-12-18 Animation updates
-<p>Direction Indicators animation moved to Animations -> Experimental.</p>
-<p>New Color Warp animation added to Animations -> Experimental.</p>
+<p>Direction Indicators animation moved to Experimental -> Animations.</p>
+<p>New Color Warp animation added to Experimental -> Animations.</p>
 <p>Pause/Resume/Stop animation options added.</p>
 
 == 2024-11-18 Word Cloud View no longer in Experimental

--- a/nbproject/project.properties
+++ b/nbproject/project.properties
@@ -123,7 +123,7 @@ run.args.extra=-J-Dconstellation.environment\=IDE(CORE) \
                -J--add-exports=java.base/java.net\=ALL-UNNAMED \
                -J--add-exports=java.base/java.security\=ALL-UNNAMED \
                -J--add-exports=java.base/java.lang\=ALL-UNNAMED \
-               -J--add-exports=java.desktop/sun.awt\=ALL-UNNAMED \ 
+               -J--add-exports=java.desktop/sun.awt\=ALL-UNNAMED \
                -J--add-exports=java.desktop/sun.java2d\=ALL-UNNAMED \
                -J--add-exports=javafx.base/com.sun.javafx.event\=ALL-UNNAMED
                


### PR DESCRIPTION
<!--

### Requirements

* Filling out the template is required. Any pull request that does not include
enough information to be reviewed in a timely manner may be closed at the
maintainers' discretion.
* All new code requires unit tests to ensure they work as expected and will
continue to work as new code is added in the future (regression testing).
* Make sure your branch name is prefixed by `feature`, `bugfix` or `release`
* Have you read Constellation's Code of Conduct? By filing an issue, you are
expected to comply with it, including treating everyone with respect:
https://github.com/constellation-app/constellation/blob/master/CODE_OF_CONDUCT.md

-->

### Prerequisites

- [x] Reviewed the [checklist](CHECKLIST.md)

- [ ] Reviewed feedback from the "Sonar Cloud" bot. Note that you have to wait
    for the "CI / Unit Tests") to complete first. Failed Unit tests can be 
    debugged by adding the label "verbose logging" to the GitHub PR.

### Description of the Change
Some minor fixes for some issues found in v3.1-rc1

- Warning found in the logs for an incorrectly formatted css styling
- Fixed typo in what's new text 
- Potential fix for inconsistent null pointer thrown in top components when a graph is null when `graphChanged` is called

<!--

We must be able to understand the design of your change from this description.
If we can't get a good idea of what the code will be doing from the description
here, the pull request may be closed at the maintainers' discretion. Keep in
mind that the maintainer reviewing this PR may not be familiar with or have
worked with the code here recently, so please walk us through the concepts.

-->



### Why Should This Be In Core?
Fixes for issues in Core
<!--

Explain why this functionality should be in Constellation Core as opposed to a
different module suite. Note that this question is more applicable when adding
new functionality. If this change is a minor update to an existing file then it
is understood that this change has to be to this module suite and a response
and therefore a response to this question is not required.

-->

