### PR TITLE
Fix incorrect Complete With Schema processing on custom Types

### DIFF
--- a/CoreAnalyticSchema/src/au/gov/asd/tac/constellation/graph/schema/analytic/AnalyticSchemaFactory.java
+++ b/CoreAnalyticSchema/src/au/gov/asd/tac/constellation/graph/schema/analytic/AnalyticSchemaFactory.java
@@ -65,7 +65,7 @@ public class AnalyticSchemaFactory extends VisualSchemaFactory {
     private static final ConstellationIcon ICON_SYMBOL = AnalyticIconProvider.GRAPH;
     private static final ConstellationColor ICON_COLOR = ConstellationColor.CARROT;
     
-    // A custom type is essentially a modified default type (its a renamed copy).
+    // A custom type is essentially a modified default type (its just a renamed copy).
     // It should be processed (or not) in exactly the same that is done for a default type.
     boolean modifiedDefaultVtxType = false;
     boolean modifiedDefaultTxnType = false;
@@ -191,7 +191,7 @@ public class AnalyticSchemaFactory extends VisualSchemaFactory {
                     updateStoredType = true;
                 }
             } else {
-                SchemaVertexType resolvedType = SchemaVertexTypeUtilities.getType(type.toString());
+                final SchemaVertexType resolvedType = SchemaVertexTypeUtilities.getType(type.toString());
                 if (SchemaConceptUtilities.getDefaultVertexType().equals(resolvedType)) {
                     type = graph.getSchema().resolveVertexType(type.toString());
                     modifiedDefaultVtxType = true;
@@ -332,10 +332,9 @@ public class AnalyticSchemaFactory extends VisualSchemaFactory {
                 }
             } else {
                 // current directed value doesn't match expected setting for the type.
-                SchemaTransactionType resolvedType = SchemaTransactionTypeUtilities.getType(type.getName());
+                final SchemaTransactionType resolvedType = SchemaTransactionTypeUtilities.getType(type.getName());
                 if (SchemaTransactionTypeUtilities.getDefaultType().equals(resolvedType)) {
                     type = resolveTransactionType(type.getName());
-                    // retain current settings for unknown/custom types
                     modifiedDefaultTxnType = true;
                 }
             }

--- a/CoreAnalyticSchema/src/au/gov/asd/tac/constellation/graph/schema/analytic/AnalyticSchemaFactory.java
+++ b/CoreAnalyticSchema/src/au/gov/asd/tac/constellation/graph/schema/analytic/AnalyticSchemaFactory.java
@@ -233,17 +233,17 @@ public class AnalyticSchemaFactory extends VisualSchemaFactory {
                 graph.setStringValue(vertexLabelAttribute, vertexId, label);
             }
 
-            if (type != null && !modifiedDefaultVtxType && (type != SchemaVertexTypeUtilities.getDefaultType() || graph.isDefaultValue(vertexColorAttribute, vertexId))
+            if (type != null && ((!modifiedDefaultVtxType && (type != SchemaVertexTypeUtilities.getDefaultType()) || graph.isDefaultValue(vertexColorAttribute, vertexId)))
                     && !Objects.equals(type.getColor(), graph.getObjectValue(vertexColorAttribute, vertexId))) {
                 graph.setObjectValue(vertexColorAttribute, vertexId, type.getColor());
             }
 
-            if (type != null && !modifiedDefaultVtxType && (type != SchemaVertexTypeUtilities.getDefaultType() || graph.isDefaultValue(vertexBackgroundIconAttribute, vertexId))
+            if (type != null && ((!modifiedDefaultVtxType && (type != SchemaVertexTypeUtilities.getDefaultType()) || graph.isDefaultValue(vertexBackgroundIconAttribute, vertexId)))
                     && !Objects.equals(type.getBackgroundIcon(), graph.getObjectValue(vertexBackgroundIconAttribute, vertexId))) {
                 graph.setObjectValue(vertexBackgroundIconAttribute, vertexId, type.getBackgroundIcon().getExtendedName());
             }
 
-            if (type != null && !modifiedDefaultVtxType && (type != SchemaVertexTypeUtilities.getDefaultType() || graph.isDefaultValue(vertexForegroundIconAttribute, vertexId))) {
+            if (type != null && ((!modifiedDefaultVtxType && type != SchemaVertexTypeUtilities.getDefaultType()) || graph.isDefaultValue(vertexForegroundIconAttribute, vertexId))) {
                 if (!SchemaVertexTypeUtilities.getDefaultType().getForegroundIcon().equals(type.getForegroundIcon())) {
                     if (!Objects.equals(type.getForegroundIcon(), graph.getObjectValue(vertexForegroundIconAttribute, vertexId))) {
                         graph.setObjectValue(vertexForegroundIconAttribute, vertexId, type.getForegroundIcon().getExtendedName());

--- a/CoreDataAccessView/src/au/gov/asd/tac/constellation/views/dataaccess/plugins/importing/file/GraphMLImportProcessor.java
+++ b/CoreDataAccessView/src/au/gov/asd/tac/constellation/views/dataaccess/plugins/importing/file/GraphMLImportProcessor.java
@@ -84,6 +84,7 @@ public class GraphMLImportProcessor implements GraphFileImportProcessor {
     public static final String KEY_TYPE_TAG = "attr.type";
     public static final String NAME_TYPE_DELIMITER = ",";
     public static final String KEY_FOR_TAG = "for";
+    public static final String ALL_TAG = "all";
 
     @Override
     public String getName() {
@@ -134,9 +135,10 @@ public class GraphMLImportProcessor implements GraphFileImportProcessor {
                         + attributes.getNamedItem(KEY_TYPE_TAG).getNodeValue();
                 final String type = attributes.getNamedItem(KEY_FOR_TAG).getNodeValue();
 
-                if (type.equals(NODE_TAG)) {
+                if (ALL_TAG.equals(type) || NODE_TAG.equals(type)) {
                     nodeAttributes.put(id, name);
-                } else {
+                }
+                if (ALL_TAG.equals(type) || EDGE_TAG.equals(type)) {
                     transactionAttributes.put(id, name);
                 }
 

--- a/CoreDataAccessView/test/unit/src/au/gov/asd/tac/constellation/views/dataaccess/plugins/clean/MergeTransactionsPluginNGTest.java
+++ b/CoreDataAccessView/test/unit/src/au/gov/asd/tac/constellation/views/dataaccess/plugins/clean/MergeTransactionsPluginNGTest.java
@@ -26,6 +26,8 @@ import au.gov.asd.tac.constellation.plugins.PluginException;
 import au.gov.asd.tac.constellation.plugins.PluginInteraction;
 import au.gov.asd.tac.constellation.plugins.parameters.PluginParameters;
 import au.gov.asd.tac.constellation.plugins.text.TextPluginInteraction;
+import java.util.ArrayList;
+import java.util.List;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 import org.testng.annotations.BeforeMethod;
@@ -167,10 +169,16 @@ public class MergeTransactionsPluginNGTest {
         instance.edit(graph, interaction, parameters);
 
         // Check that the transactions were merged 
-        assertEquals(graph.getTransactionCount(), 3);
-        assertEquals(graph.getTransaction(txId1), 1);
-        assertEquals(graph.getTransaction(txId3), 2);
-        assertEquals(graph.getTransaction(txId4), 3);
+        final int txnCount = graph.getTransactionCount();
+        assertEquals(txnCount, 3);
+        // Confirm the correct transaction ids are being used.
+        final List<Integer> txnIds = new ArrayList<>();
+        for (int txnPos = 0; txnPos < txnCount; txnPos++) {
+            txnIds.add(graph.getTransaction(txnPos));
+        }
+        assertTrue(txnIds.contains(txId3));
+        assertTrue(txnIds.contains(txId4));
+        assertTrue(txnIds.contains(txId5));
     }
     
     /**

--- a/CoreGraphFramework/src/au/gov/asd/tac/constellation/graph/processing/GraphRecordStoreUtilities.java
+++ b/CoreGraphFramework/src/au/gov/asd/tac/constellation/graph/processing/GraphRecordStoreUtilities.java
@@ -220,7 +220,7 @@ public class GraphRecordStoreUtilities {
             directed = !"False".equalsIgnoreCase(directedValue);
         } else {
             final SchemaTransactionType transactionType = SchemaTransactionTypeUtilities.getType(type);
-            if (transactionType != null && !transactionType.getName().equalsIgnoreCase("Unknown")) {
+            if (transactionType != null && !"Unknown".equalsIgnoreCase(transactionType.getName())) {
                 directed = transactionType.isDirected();
             } else {
                 // When its an Unknown transaction type we should use the current directed setting if available.

--- a/CoreGraphFramework/src/au/gov/asd/tac/constellation/graph/processing/GraphRecordStoreUtilities.java
+++ b/CoreGraphFramework/src/au/gov/asd/tac/constellation/graph/processing/GraphRecordStoreUtilities.java
@@ -68,6 +68,7 @@ public class GraphRecordStoreUtilities {
     public static final String ID = "[id]<string>";
     public static final String GHOST = "[ghost]<string>";
     public static final String DIRECTED_KEY = "[directed]<string>";
+    public static final String DIRECTED_VALUE_KEY = "directed<string>";
     public static final String COMPLETE_WITH_SCHEMA_KEY = "[complete_with_schema]<string>";
     public static final String DELETE_KEY = "[delete]<string>";
 
@@ -219,8 +220,14 @@ public class GraphRecordStoreUtilities {
             directed = !"False".equalsIgnoreCase(directedValue);
         } else {
             final SchemaTransactionType transactionType = SchemaTransactionTypeUtilities.getType(type);
-            if (transactionType != null) {
+            if (transactionType != null && !transactionType.getName().equalsIgnoreCase("Unknown")) {
                 directed = transactionType.isDirected();
+            } else {
+                // When its an Unknown transaction type we should use the current directed setting if available.
+                final String directedCurrentValue = values.get(DIRECTED_VALUE_KEY);
+                if (directedCurrentValue != null) {
+                    directed = !"False".equalsIgnoreCase(directedCurrentValue);
+                }
             }
         }
 


### PR DESCRIPTION
<!--

### Requirements

* Filling out the template is required. Any pull request that does not include
enough information to be reviewed in a timely manner may be closed at the
maintainers' discretion.
* All new code requires unit tests to ensure they work as expected and will
continue to work as new code is added in the future (regression testing).
* Make sure your branch name is prefixed by `feature`, `bugfix` or `release`
* Have you read Constellation's Code of Conduct? By filing an issue, you are
expected to comply with it, including treating everyone with respect:
https://github.com/constellation-app/constellation/blob/master/CODE_OF_CONDUCT.md

-->

### Prerequisites

- [ ] Reviewed the [checklist](CHECKLIST.md)

- [ ] Reviewed feedback from the "Sonar Cloud" bot. Note that you have to wait
    for the "CI / Unit Tests") to complete first. Failed Unit tests can be 
    debugged by adding the label "verbose logging" to the GitHub PR.

### Description of the Change

Transactions and Vertices that have custom types were being incorrectly processed when the Complete With Schema function is run.

They should now be treated the same way as having a default type.

Issue was found in #2307 when importing GraphML files,
but the problem was not limited to that scenario.

Also addressed the issue #2308 for GraphML imports to correctly process the "all" setting.

### Alternate Designs

<!--

Explain what other alternates were considered and why the proposed version was
selected.

-->

### Why Should This Be In Core?

Have standard functionality perform in an expected way.

### Benefits

Functionality performs in the way that a user would expect.
Setting attributes on a custom type will not have them overridden when a Complete With Schema function is performed.

### Possible Drawbacks

None known

### Verification Process

1. Create a new graph. Add two nodes, and a transaction between them.
2. Select the transaction and use the attribute editor to set the __directed__ attribute to __false__.
3. Set the __Type__ of the transaction to __"typetest1"__
4. Run the Complete with Schema (F5) function.
5. _Confirm_ that the directed attribute of the transaction is still set to **false**, and the colour and line style are also unchanged.
6. Select a Vertex and change its __Type__ to __"Person"__.
7. Run Complete With Schema (it should have it's icon, colour, and label changed).
8. Now change its __Type__ to __"typetest2"__
9. Run the Complete with Schema (F5) function.
10. _Confirm_ that the Vertex has only changed its label, but left all the other attributes as they were. 


### Applicable Issues

#2318
