### PR TITLE
Split nodes exception on certain edited graphs

### DIFF
--- a/CoreDataAccessView/src/au/gov/asd/tac/constellation/views/dataaccess/plugins/clean/SplitNodesPlugin.java
+++ b/CoreDataAccessView/src/au/gov/asd/tac/constellation/views/dataaccess/plugins/clean/SplitNodesPlugin.java
@@ -197,20 +197,20 @@ public class SplitNodesPlugin extends SimpleEditPlugin implements DataAccessPlug
         );
         
         //Determine the positions of the selected nodes
-        final List<Integer> selectedVerticies = new ArrayList<>();    
+        final List<Integer> selectedVertexPositions = new ArrayList<>();
         final int graphVertexCount = graph.getVertexCount();
         for (int vertexPosition = 0; vertexPosition < graphVertexCount; vertexPosition++) {
             final int currentVertexId = graph.getVertex(vertexPosition);
             if (graph.getBooleanValue(vertexSelectedAttributeId, currentVertexId)) {
-                selectedVerticies.add(vertexPosition);
+                selectedVertexPositions.add(vertexPosition);
             }
         }
         
-        totalProcessSteps = selectedVerticies.size();
+        totalProcessSteps = selectedVertexPositions.size();
         
         // Loop through the selected vertices and determine how many new verticies need to be added to the graph
         final List<Integer> newVertices = new ArrayList<>();
-        for (final int position : selectedVerticies) {
+        for (final int position : selectedVertexPositions) {
             interaction.setProgress(
                     ++currentProcessStep, 
                     totalProcessSteps, 
@@ -239,7 +239,7 @@ public class SplitNodesPlugin extends SimpleEditPlugin implements DataAccessPlug
                     leftNodeIdentifier = substrings[0];
 
                     for (int i = 1; i < substrings.length; i++) {
-                        newVertices.add(createNewNode(graph, position, substrings[i], linkType, splitIntoSameLevel));
+                        newVertices.add(createNewNode(graph, currentVertexId, substrings[i], linkType, splitIntoSameLevel));
                         createdNodesCount++;
                     }
 
@@ -250,7 +250,8 @@ public class SplitNodesPlugin extends SimpleEditPlugin implements DataAccessPlug
 
                     // There was text found on the left side of the split so ignore it and set the node for the right side
                     if (StringUtils.isNotBlank(leftNodeIdentifier)) {
-                        leftNodeIdentifier = identifier.substring(0, i);newVertices.add(createNewNode(graph, position, identifier.substring(i + 1), linkType, splitIntoSameLevel));
+                        leftNodeIdentifier = identifier.substring(0, i);
+                        newVertices.add(createNewNode(graph, currentVertexId, identifier.substring(i + 1), linkType, splitIntoSameLevel));
                         createdNodesCount++;
 
                     // There was no text on the left side of the split so set the leftNodeIdentifier to the right side. 

--- a/CoreGraphFramework/src/au/gov/asd/tac/constellation/graph/undo/UndoGraphEditOperation.java
+++ b/CoreGraphFramework/src/au/gov/asd/tac/constellation/graph/undo/UndoGraphEditOperation.java
@@ -320,7 +320,7 @@ public enum UndoGraphEditOperation {
         @Override
         public void undo(final UndoGraphEditState state, final GraphWriteMethods graph) {
             // If the high bit of the current id has been set then the transaction source and destination vertices will have been swapped during the execute phase
-            // to keep the source vertex <= the destination vertex. This means that the undo step must operate on the source vertex instead of the source vertex.
+            // to keep the source vertex <= the destination vertex. This means that the undo step must operate on the source vertex instead of the destination vertex.
             if (state.getCurrentId() >= 0) {
                 graph.setTransactionDestinationVertex(state.getCurrentId(), state.getCurrentInt() ^ graph.getTransactionDestinationVertex(state.getCurrentId()));
             } else {


### PR DESCRIPTION
<!--

### Requirements

* Filling out the template is required. Any pull request that does not include
enough information to be reviewed in a timely manner may be closed at the
maintainers' discretion.
* All new code requires unit tests to ensure they work as expected and will
continue to work as new code is added in the future (regression testing).
* Make sure your branch name is prefixed by `feature`, `bugfix` or `release`
* Have you read Constellation's Code of Conduct? By filing an issue, you are
expected to comply with it, including treating everyone with respect:
https://github.com/constellation-app/constellation/blob/master/CODE_OF_CONDUCT.md

-->

### Prerequisites

- [ ] Reviewed the [checklist](CHECKLIST.md)

- [ ] Reviewed feedback from the "Sonar Cloud" bot. Note that you have to wait
    for the "CI / Unit Tests") to complete first. Failed Unit tests can be 
    debugged by adding the label "verbose logging" to the GitHub PR.

### Description of the Change
An Illegal Argument Exception was thrown when `Split nodes Based on Identifier` was run on certain nodes of graphs created using File importer or using RecordStoreQueryPlugin. The same issue can be recreated on a graph manually created, as explained below. 

The issue was caused by the confusion between the 2 arrays in ElementStore.java (node position ID and Element ID). The code had used the node position ID instead of the Vertex Id when creating the new node. A usual graph before editing would have identical arrays, so the splitting was still working. 
<!--

We must be able to understand the design of your change from this description.
If we can't get a good idea of what the code will be doing from the description
here, the pull request may be closed at the maintainers' discretion. Keep in
mind that the maintainer reviewing this PR may not be familiar with or have
worked with the code here recently, so please walk us through the concepts.

-->

### Alternate Designs
n/a
<!--

Explain what other alternates were considered and why the proposed version was
selected.

-->

### Why Should This Be In Core?
Bug Fix
<!--

Explain why this functionality should be in Constellation Core as opposed to a
different module suite. Note that this question is more applicable when adding
new functionality. If this change is a minor update to an existing file then it
is understood that this change has to be to this module suite and a response
and therefore a response to this question is not required.

-->

### Benefits
bug fix
<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks
n/a
<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process

- Create a new graph and add 4 nodes. 
- Remove the Vertex#1 and Vertex#2
- Open DAV. Run the Spit notes plugin on each remaining node, with `#` as the split  character.
- 3 nodes `3`,`4`,`Vertex` should be created without any exception.
- Also verify no exceptions are thrown on graphs created by the File importer or using RecordStoreQueryPlugin, when splitting nodes.

<!--

What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (e.g. buttons you clicked, text you typed,
commands you ran, etc.), and describe the results you observed.

-->

### Applicable Issues
https://github.com/constellation-app/constellation/issues/853
<!-- Link any applicable issues here -->
