### PR TITLE
Fix the DuplicateKeyException in Analytic graphs when creating a new element with existing key attributes

### DIFF
--- a/CoreAnalyticSchema/src/au/gov/asd/tac/constellation/graph/schema/analytic/AnalyticSchemaFactory.java
+++ b/CoreAnalyticSchema/src/au/gov/asd/tac/constellation/graph/schema/analytic/AnalyticSchemaFactory.java
@@ -138,15 +138,15 @@ public class AnalyticSchemaFactory extends VisualSchemaFactory {
 
         @Override
         public void newVertex(final GraphWriteMethods graph, final int vertexId) {
-            super.newVertex(graph, vertexId);
-
+            // Other key attributes (TYPE here) have to be set before creating the new vertex in super.newVertex()
             final int vertexTypeAttribute = AnalyticConcept.VertexAttribute.TYPE.ensure(graph);
             final int vertexSourceAttribute = AnalyticConcept.VertexAttribute.SOURCE.ensure(graph);
 
             graph.setObjectValue(vertexTypeAttribute, vertexId, SchemaConceptUtilities.getDefaultVertexType());
             graph.setStringValue(vertexSourceAttribute, vertexId, "Manually Created");
 
-            graph.validateKey(GraphElementType.VERTEX, vertexId, false);
+            super.newVertex(graph, vertexId);
+
             completeVertex(graph, vertexId);
         }
 
@@ -280,8 +280,7 @@ public class AnalyticSchemaFactory extends VisualSchemaFactory {
 
         @Override
         public void newTransaction(final GraphWriteMethods graph, final int transactionId) {
-            super.newTransaction(graph, transactionId);
-
+            // Other key attributes (TYPE and DATETIME here) have to be set before creating the new transaction in super.newTransaction()
             final int transactionTypeAttribute = AnalyticConcept.TransactionAttribute.TYPE.ensure(graph);
             final int transactionDatetimeAttribuute = TemporalConcept.TransactionAttribute.DATETIME.ensure(graph);
             final int transactionSourceAttribute = AnalyticConcept.TransactionAttribute.SOURCE.ensure(graph);
@@ -294,7 +293,7 @@ public class AnalyticSchemaFactory extends VisualSchemaFactory {
             graph.setStringValue(transactionSourceAttribute, transactionId, "Manually Created");
             graph.setBooleanValue(transactionDirectedAttribute, transactionId, transactionDirected);
 
-            graph.validateKey(GraphElementType.TRANSACTION, transactionId, false);
+            super.newTransaction(graph, transactionId);
             completeTransaction(graph, transactionId);
         }
 


### PR DESCRIPTION


<!--

### Requirements

* Filling out the template is required. Any pull request that does not include
enough information to be reviewed in a timely manner may be closed at the
maintainers' discretion.
* All new code requires unit tests to ensure they work as expected and will
continue to work as new code is added in the future (regression testing).
* Make sure your branch name is prefixed by `feature`, `bugfix` or `release`
* Have you read Constellation's Code of Conduct? By filing an issue, you are
expected to comply with it, including treating everyone with respect:
https://github.com/constellation-app/constellation/blob/master/CODE_OF_CONDUCT.md

-->

### Prerequisites

- [ ] Reviewed the [checklist](CHECKLIST.md)

- [ ] Reviewed feedback from the "Sonar Cloud" bot. Note that you have to wait
    for the "CI / Unit Tests") to complete first. Failed Unit tests can be 
    debugged by adding the label "verbose logging" to the GitHub PR.

### Description of the Change
Analytic graphs now set the key attributes other than the Identifier, before creating the new element, to avoid duplicate key exceptions thrown. For Vertices it's Type and for transactions Type and Datetime. 

When creating a new element, the code uses the key attributes to determine whether it already exists, before incrementing the unique id in the identifier. Prior to these changes, any new element added was always identified as non existing, hence didn't impact new graphs unless edited in between.
<!--

We must be able to understand the design of your change from this description.
If we can't get a good idea of what the code will be doing from the description
here, the pull request may be closed at the maintainers' discretion. Keep in
mind that the maintainer reviewing this PR may not be familiar with or have
worked with the code here recently, so please walk us through the concepts.

-->

### Alternate Designs
N/A, but perhaps we should change the code in the VisualSchemaFactory which uses the DuplicateKeyException thrown by StoreGraph.validateKey, to identify whether a given ID is in use.  An "exists" function would be a better option rather than throw/catch of the exception.
<!--

Explain what other alternates were considered and why the proposed version was
selected.

-->

### Why Should This Be In Core?
Bug fix
<!--

Explain why this functionality should be in Constellation Core as opposed to a
different module suite. Note that this question is more applicable when adding
new functionality. If this change is a minor update to an existing file then it
is understood that this change has to be to this module suite and a response
and therefore a response to this question is not required.

-->

### Benefits
Bug fix
<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks
N/A
<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process

1. Open a new graph
2. Create 2 Nodes
3. Open Attribute Editor
4. Change one of the Node's Identifier to "Vertex 2 "
5. Add another node. No exceptions should throw and the new node should be added as "Vertex 3"
6. Test the transactions using same steps. 

<!--

What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (e.g. buttons you clicked, text you typed,
commands you ran, etc.), and describe the results you observed.

-->

### Applicable Issues
https://github.com/constellation-app/constellation/issues/2326