### PR TITLE
updated listener of multichoice pane

### DIFF
--- a/CoreDataAccessView/src/au/gov/asd/tac/constellation/views/dataaccess/plugins/utility/SelectTopNPlugin.java
+++ b/CoreDataAccessView/src/au/gov/asd/tac/constellation/views/dataaccess/plugins/utility/SelectTopNPlugin.java
@@ -197,7 +197,6 @@ public class SelectTopNPlugin extends SimpleQueryPlugin implements DataAccessPlu
                     types.sort(String::compareTo);
                     MultiChoiceParameterType.setOptions(typeParamter, types);
                     MultiChoiceParameterType.setChoices(typeParamter, types);
-                    typeParamter.fireChangeEvent(ParameterChange.PROPERTY);
                 }
             }
         });

--- a/CorePluginFramework/src/au/gov/asd/tac/constellation/plugins/gui/MultiChoiceInputPane.java
+++ b/CorePluginFramework/src/au/gov/asd/tac/constellation/plugins/gui/MultiChoiceInputPane.java
@@ -66,15 +66,27 @@ public final class MultiChoiceInputPane extends ParameterInputPane<MultiChoicePa
 
     @Override
     public PluginParameterListener getPluginParameterListener() {
-        return (final PluginParameter<?> parameter, final ParameterChange change) -> Platform.runLater(() -> {
+        return (final PluginParameter<?> param, final ParameterChange change) -> Platform.runLater(() -> {
             @SuppressWarnings("unchecked") //mcPluginParameter is a MultiChoiceParameter
-            final PluginParameter<MultiChoiceParameterValue> mcPluginParameter = (PluginParameter<MultiChoiceParameterValue>) parameter;
+            final PluginParameter<MultiChoiceParameterValue> mcPluginParameter = (PluginParameter<MultiChoiceParameterValue>) param;
             switch (change) {
                 case VALUE -> {
-                    // Don't change the value if it isn't necessary.
-                    final List<ParameterValue> selection = getFieldValue();
-                    if (!selection.equals(MultiChoiceParameterType.getChoicesData(mcPluginParameter))){
-                        setFieldValue(selection);
+                    final List<ParameterValue> paramOptions = MultiChoiceParameterType.getOptionsData(mcPluginParameter);
+                    if (!((MultiChoiceInput) input).getOptions().equals(paramOptions)) {
+                        ((MultiChoiceInput) input).setOptions(paramOptions);
+                        final List<ParameterValue> choicesData = (List<ParameterValue>) MultiChoiceParameterType.getChoicesData(mcPluginParameter);
+                        // Only keep the value if it's in the new choices.
+                        if (paramOptions.stream().anyMatch(choicesData::contains)) {
+                            setFieldValue((List<ParameterValue>) MultiChoiceParameterType.getChoicesData(mcPluginParameter));
+                        } else {
+                            setFieldValue(null);
+                        }
+                    } else {
+                        // Don't change the value if it isn't necessary.
+                        final List<ParameterValue> selection = getFieldValue();
+                        if (!selection.equals(MultiChoiceParameterType.getChoicesData(mcPluginParameter))){
+                            setFieldValue(selection);
+                        }
                     }
                 }
                 case PROPERTY -> {


### PR DESCRIPTION
<!--

### Requirements

* Filling out the template is required. Any pull request that does not include
enough information to be reviewed in a timely manner may be closed at the
maintainers' discretion.
* All new code requires unit tests to ensure they work as expected and will
continue to work as new code is added in the future (regression testing).
* Make sure your branch name is prefixed by `feature`, `bugfix` or `release`
* Have you read Constellation's Code of Conduct? By filing an issue, you are
expected to comply with it, including treating everyone with respect:
https://github.com/constellation-app/constellation/blob/master/CODE_OF_CONDUCT.md

-->

### Prerequisites

- [x] Reviewed the [checklist](CHECKLIST.md)

- [ ] Reviewed feedback from the "Sonar Cloud" bot. Note that you have to wait
    for the "CI / Unit Tests") to complete first. Failed Unit tests can be 
    debugged by adding the label "verbose logging" to the GitHub PR.

### Description of the Change

Updated the change listener for the multi choice input pane so that a value change event also updates the UI when the options change. Recent code updates meant that the UI only updated on a change of options when a property change event was fired. For a Data Access plugin parameter, this meant that if the options changed that a property change event needed to be explicitly fired, as that kind of change event doesn't fire in that situation otherwise. One change event that does fire though is a value change event.

So rather than have both a property change event and value change event fire trying to handle the same situation, I've simply added the code from the property change event case to the value change event case. That way, data access plugins no longer need to explicitly fire a property change event (a value change event fires in the background).

The property change event case remains for other circumstances where we don't want to fire a value change event.

### Alternate Designs

<!--

Explain what other alternates were considered and why the proposed version was
selected.

-->

### Why Should This Be In Core?

Simplifies construction of data access plugins by not requiring the developer to need to explicitly fire a change event they didn't realise they needed to fire.

### Benefits

Simplifies data access plugin development

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process

<!--

What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (e.g. buttons you clicked, text you typed,
commands you ran, etc.), and describe the results you observed.

-->

### Applicable Issues

<!-- Link any applicable issues here -->
