### PR TITLE
#1458 - Improve authorization using security scheme

### DIFF
--- a/CoreWebServer/src/au/gov/asd/tac/constellation/webserver/api/SwaggerServlet.java
+++ b/CoreWebServer/src/au/gov/asd/tac/constellation/webserver/api/SwaggerServlet.java
@@ -22,7 +22,6 @@ import au.gov.asd.tac.constellation.webserver.WebServer.ConstellationHttpServlet
 import au.gov.asd.tac.constellation.webserver.restapi.RestService;
 import au.gov.asd.tac.constellation.webserver.restapi.RestServiceRegistry;
 import au.gov.asd.tac.constellation.webserver.restapi.RestServiceUtilities;
-import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
@@ -161,18 +160,14 @@ public class SwaggerServlet extends ConstellationHttpServlet {
                         responses.setAll((ObjectNode) root.at(String.format(exampleResponsesPath, "defaultResponses")));                        
                     }
 
-                    // Add the required CONSTELLATION secret header parameter.
-                    final ObjectNode secretParam = params.addObject();
-                    secretParam.put("name", "X-CONSTELLATION-SECRET");
-                    secretParam.put("in", "header");
-                    secretParam.put(REQUIRED, true);
-                    secretParam.put(DESCRIPTION, "CONSTELLATION secret");
-                    final ObjectNode secretSchema = secretParam.putObject(SCHEMA);
-                    secretSchema.put("type", "string");
-                   
+                    // Add the required CONSTELLATION secret header.
+                    final ArrayNode security = httpMethod.putArray("security");
+                    final ObjectNode apiKeyAuth = security.addObject();
+                    apiKeyAuth.putArray("ConstellationSecret");
+
                 });
 
-                final OutputStream out = response.getOutputStream();
+                final OutputStream out = response.getOutputStream();                
                 mapper.writeValue(out, root);
             } else {
                 if (fileName.endsWith(FileExtensionConstants.JAVASCRIPT)) {

--- a/CoreWebServer/src/au/gov/asd/tac/constellation/webserver/api/swagger-ui/index.html
+++ b/CoreWebServer/src/au/gov/asd/tac/constellation/webserver/api/swagger-ui/index.html
@@ -53,30 +53,55 @@
                   //clear any existing auth errors
                   err.clear({ source: "auth" });
                   if(payload && payload.ConstellationSecret && payload.ConstellationSecret.value) {
-                      //call any example endpoint to check authorization with entered secret
-                      fetch(`${currServer}/v2/service/reflect_json`, {
-                        method: 'POST',
-                        headers: {
-                          'Content-Type': 'application/json',                      
-                          'accept': '*/*',
-                          'X-CONSTELLATION-SECRET':payload.ConstellationSecret.value
-                        }
-                      }).then(response => {
-                          // Check if the response was successful (e.g., status code 200-299)
-                          if (!response.ok) {
-                              err.newAuthErr( {
-                                authId: "ConstellationSecret",
-                                source: "auth",
-                                level: "error",
-                                message: `HTTP error! status: ${response.status} ${response.statusText}`
+                      if ( payload.ConstellationSecret.value.trim().length > 0) {
+                          //call any example endpoint to check authorization with entered secret
+                            fetch(`${currServer}/v2/service/reflect_json`, {
+                              method: 'POST',
+                              headers: {
+                                'Content-Type': 'application/json',                      
+                                'accept': '*/*',
+                                'X-CONSTELLATION-SECRET':payload.ConstellationSecret.value
+                              }
+                            }).then(response => {
+                                // Check if the response was successful (e.g., status code 200-299)
+                                if (!response.ok) {
+                                    err.newAuthErr( {
+                                      authId: "ConstellationSecret",
+                                      source: "auth",
+                                      level: "error",
+                                      message: `HTTP error! status: ${response.status} ${response.statusText}`
+                                    });
+                                  return;
+                                }
+                                // Parse the response body as JSON
+                                return oriAction(payload);
+                              }) .catch(error => {
+                                  err.newAuthErr( {
+                                        authId: "ConstellationSecret",
+                                        source: "auth",
+                                        level: "error",
+                                        message: `Error connecting to the rest server`
+                                    });                                    
+                                  return;
                               });
-                            return;
-                          }
-                          // Parse the response body as JSON
-                          return oriAction(payload);
-                        })                        
+                      } else {
+                          err.newAuthErr( {
+                              authId: "ConstellationSecret",
+                              source: "auth",
+                              level: "error",
+                              message: `ConstellationSecret can not be empty`
+                          });
+                          return;
+                      }
+                      
                   } else {
-                      return oriAction(payload);
+                     err.newAuthErr( {
+                              authId: "ConstellationSecret",
+                              source: "auth",
+                              level: "error",
+                              message: `ConstellationSecret can not be empty`
+                          });
+                          return;
                   }     
                 }
               }

--- a/CoreWebServer/src/au/gov/asd/tac/constellation/webserver/api/swagger-ui/index.html
+++ b/CoreWebServer/src/au/gov/asd/tac/constellation/webserver/api/swagger-ui/index.html
@@ -74,13 +74,9 @@
                           }
                           // Parse the response body as JSON
                           return oriAction(payload);
-                        })
-                        .catch(error => {
-                          // Handle any errors during the fetch operation
-                          return;
-                        });
+                        })                        
                   } else {
-                      oriAction(payload);
+                      return oriAction(payload);
                   }     
                 }
               }

--- a/CoreWebServer/src/au/gov/asd/tac/constellation/webserver/api/swagger-ui/index.html
+++ b/CoreWebServer/src/au/gov/asd/tac/constellation/webserver/api/swagger-ui/index.html
@@ -34,21 +34,76 @@
     <div id="swagger-ui"></div>
 
     <script src="./swagger-ui-bundle.js"> </script>
-    <script src="./swagger-ui-standalone-preset.js"> </script>
+    <script src="./swagger-ui-standalone-preset.js"> </script>    
+    
     <script>
-    window.onload = function() {
+    
+    window.onload = function() {        
+        //experiment components wrapping       
+        
+        const MyApiKeyAuthPlugin = function() {
+        return {
+          statePlugins: {
+            auth: {
+              wrapActions: {
+                  authorize: (oriAction, system) => (payload) => {
+                      //get currently running server:port
+                  let currServer = system.oas3Selectors.selectedServer();                  
+                  let err = system.errActions;
+                  //clear any existing auth errors
+                  err.clear({ source: "auth" });
+                  if(payload && payload.ConstellationSecret && payload.ConstellationSecret.value) {
+                      //call any example endpoint to check authorization with entered secret
+                      fetch(`${currServer}/v2/service/reflect_json`, {
+                        method: 'POST',
+                        headers: {
+                          'Content-Type': 'application/json',                      
+                          'accept': '*/*',
+                          'X-CONSTELLATION-SECRET':payload.ConstellationSecret.value
+                        }
+                      }).then(response => {
+                          // Check if the response was successful (e.g., status code 200-299)
+                          if (!response.ok) {
+                              err.newAuthErr( {
+                                authId: "ConstellationSecret",
+                                source: "auth",
+                                level: "error",
+                                message: `HTTP error! status: ${response.status} ${response.statusText}`
+                              });
+                            return;
+                          }
+                          // Parse the response body as JSON
+                          return oriAction(payload);
+                        })
+                        .catch(error => {
+                          // Handle any errors during the fetch operation
+                          return;
+                        });
+                  } else {
+                      oriAction(payload);
+                  }     
+                }
+              }
+            }
+          }
+        };
+      };    
+
       // Begin Swagger UI call region
       const ui = SwaggerUIBundle({
         url: "/swagger/constellation.json",
         dom_id: '#swagger-ui',
         deepLinking: true,
-        presets: [
+        presets: [            
           SwaggerUIBundle.presets.apis,
           SwaggerUIStandalonePreset
-        ],
+        ],        
         plugins: [
-          SwaggerUIBundle.plugins.DownloadUrl
-        ],
+          SwaggerUIBundle.plugins.DownloadUrl,
+          //ApiKeyAuthWrapperPlugin,
+          MyApiKeyAuthPlugin
+          //MyAuthReducersPlugin
+        ],        
         layout: "StandaloneLayout"
       })
       // End Swagger UI call region

--- a/CoreWebServer/src/au/gov/asd/tac/constellation/webserver/api/swagger-ui/index.html
+++ b/CoreWebServer/src/au/gov/asd/tac/constellation/webserver/api/swagger-ui/index.html
@@ -99,10 +99,8 @@
           SwaggerUIStandalonePreset
         ],        
         plugins: [
-          SwaggerUIBundle.plugins.DownloadUrl,
-          //ApiKeyAuthWrapperPlugin,
-          MyApiKeyAuthPlugin
-          //MyAuthReducersPlugin
+          SwaggerUIBundle.plugins.DownloadUrl,          
+          MyApiKeyAuthPlugin          
         ],        
         layout: "StandaloneLayout"
       })

--- a/CoreWebServer/src/au/gov/asd/tac/constellation/webserver/api/swagger/constellation.json
+++ b/CoreWebServer/src/au/gov/asd/tac/constellation/webserver/api/swagger/constellation.json
@@ -7,7 +7,14 @@
     },
     "paths": {      
     },
-    "components":{        
+    "components":{
+        "securitySchemes": {
+            "ConstellationSecret": {
+                "type": "apiKey",
+                "name": "X-CONSTELLATION-SECRET",
+                "in": "header"
+            }
+        },
         "examples":{
             "runPluginExample": {
                 "request": {


### PR DESCRIPTION
Improve authorization using security scheme

<!--

### Requirements

* Filling out the template is required. Any pull request that does not include
enough information to be reviewed in a timely manner may be closed at the
maintainers' discretion.
* All new code requires unit tests to ensure they work as expected and will
continue to work as new code is added in the future (regression testing).
* Make sure your branch name is prefixed by `feature`, `bugfix` or `release`
* Have you read Constellation's Code of Conduct? By filing an issue, you are
expected to comply with it, including treating everyone with respect:
https://github.com/constellation-app/constellation/blob/master/CODE_OF_CONDUCT.md

-->

### Prerequisites

- [ ] Reviewed the [checklist](CHECKLIST.md)

- [ ] Reviewed feedback from the "Sonar Cloud" bot. Note that you have to wait
    for the "CI / Unit Tests") to complete first. Failed Unit tests can be 
    debugged by adding the label "verbose logging" to the GitHub PR.

### Description of the Change
Improve authorization using security scheme.
Authentication to be handled in with securitySchemes instead of adding secret as parameter in each end point.

<img width="824" height="378" alt="image" src="https://github.com/user-attachments/assets/8d1d3e45-c588-445f-be49-6d06a1240987" />


### Benefits
Constellation secret is now added only once to authorize with all api endpoints.

<!-- What benefits will be realized by the code change? -->


### Verification Process

1. Open Swagger (Run constellation and Tools->Start Rest Server then Display Rest Server Documentation).
2. Grab constellation secret from  $HOME/.ipython/rest.json  to Authorize api endpoints

<img width="811" height="378" alt="image" src="https://github.com/user-attachments/assets/19ccd6ac-3d0b-476c-b716-20ac2f786d24" />

3. Check the Endpoints. It should not ask to enter constellation secret as a parameter.
    All api endpoints should be able to use provided constellation secret for authorization.

### Applicable Issues
#1458 
