### PR TITLE
Fixed Named Selections spacing

### DIFF
--- a/CoreNamedSelectionView/src/au/gov/asd/tac/constellation/views/namedselection/NamedSelectionTopComponent.form
+++ b/CoreNamedSelectionView/src/au/gov/asd/tac/constellation/views/namedselection/NamedSelectionTopComponent.form
@@ -292,6 +292,9 @@
             <Property name="model" type="javax.swing.ListModel" editor="org.netbeans.modules.form.editors2.ListModelEditor">
               <StringArray count="0"/>
             </Property>
+            <Property name="fixedCellHeight" type="int" editor="org.netbeans.modules.form.RADConnectionPropertyEditor">
+              <Connection code="(int) Math.ceil(fontsize * 1.5)" type="code"/>
+            </Property>
             <Property name="inheritsPopupMenu" type="boolean" value="true"/>
           </Properties>
           <AuxValues>

--- a/CoreNamedSelectionView/src/au/gov/asd/tac/constellation/views/namedselection/NamedSelectionTopComponent.java
+++ b/CoreNamedSelectionView/src/au/gov/asd/tac/constellation/views/namedselection/NamedSelectionTopComponent.java
@@ -40,6 +40,7 @@ import javax.swing.JPanel;
 import javax.swing.ListCellRenderer;
 import javax.swing.SwingUtilities;
 import javax.swing.ToolTipManager;
+import javax.swing.UIManager;
 import org.netbeans.api.settings.ConvertAsProperties;
 import org.openide.DialogDescriptor;
 import org.openide.DialogDisplayer;
@@ -88,7 +89,8 @@ public final class NamedSelectionTopComponent extends SwingTopComponent<JPanel> 
     // Labels used to mask UI in the event of having no active graph:
 
     private final JLabel lblNoGraph = new JLabel(Bundle.No_Active_Graph());
-    private final JPanel panelNoGraph = new JPanel();
+    private final JPanel panelNoGraph = new JPanel(); 
+    private final int fontsize = UIManager.getFont("controlFont") != null ? UIManager.getFont("controlFont").getSize() : 12;
     /**
      * Uses an overloaded MouseAdapter class to intercept mouse interactions on
      * the <code>lstNamedSelections</code>.
@@ -461,6 +463,7 @@ public final class NamedSelectionTopComponent extends SwingTopComponent<JPanel> 
 
         scrlContent.setAutoscrolls(true);
 
+        lstNamedSelections.setFixedCellHeight((int) Math.ceil(fontsize * 1.5));
         lstNamedSelections.setInheritsPopupMenu(true);
         scrlContent.setViewportView(lstNamedSelections);
 


### PR DESCRIPTION
<!--

### Requirements

* Filling out the template is required. Any pull request that does not include
enough information to be reviewed in a timely manner may be closed at the
maintainers' discretion.
* All new code requires unit tests to ensure they work as expected and will
continue to work as new code is added in the future (regression testing).
* Make sure your branch name is prefixed by `feature`, `bugfix` or `release`
* Have you read Constellation's Code of Conduct? By filing an issue, you are
expected to comply with it, including treating everyone with respect:
https://github.com/constellation-app/constellation/blob/master/CODE_OF_CONDUCT.md

-->

### Prerequisites

- [x] Reviewed the [checklist](CHECKLIST.md)

- [ ] Reviewed feedback from the "Sonar Cloud" bot. Note that you have to wait
    for the "CI / Unit Tests") to complete first. Failed Unit tests can be 
    debugged by adding the label "verbose logging" to the GitHub PR.

### Description of the Change
When the fontsize of Constellation is increased, it causes the text in the Named Selections View to be cut off and hard to read.
<!--

We must be able to understand the design of your change from this description.
If we can't get a good idea of what the code will be doing from the description
here, the pull request may be closed at the maintainers' discretion. Keep in
mind that the maintainer reviewing this PR may not be familiar with or have
worked with the code here recently, so please walk us through the concepts.

-->

### Alternate Designs

<!--

Explain what other alternates were considered and why the proposed version was
selected.

-->

### Why Should This Be In Core?
Fixes an issue in Core 
Makes the text easier to read
<!--

Explain why this functionality should be in Constellation Core as opposed to a
different module suite. Note that this question is more applicable when adding
new functionality. If this change is a minor update to an existing file then it
is understood that this change has to be to this module suite and a response
and therefore a response to this question is not required.

-->

### Benefits

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process
Devs:

1. If running from netbeans, in Constellation project.properties, add --fontsize 20 after the line "-J--add-exports=javafx.base/com.sun.javafx.event=ALL-UNNAMED" (don't forget to add a backslash after this line)
2. Restart netbeans
3. Run Constellation. Text should be fontsize 20.
4. Open Named Selections View and create a few Named Selections 
5. The Named Selections should be easy to read and not cut off 

With executable:

1. Navigate to where executable is and open command line in that folder.
2. Type "constellation64.exe --fontsize 20" in the commandline and Constellation should open with a larger font.
3. Open Named Selections View and create a few Named Selections 
4. The Named Selections should be easy to read and not cut off 

<!--

What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (e.g. buttons you clicked, text you typed,
commands you ran, etc.), and describe the results you observed.

-->

### Applicable Issues
#2390 
<!-- Link any applicable issues here -->
