### PR TITLE
removed downloadPythonClient call off the FX thread

### DIFF
--- a/CoreWebServer/src/au/gov/asd/tac/constellation/webserver/WebServer.java
+++ b/CoreWebServer/src/au/gov/asd/tac/constellation/webserver/WebServer.java
@@ -516,7 +516,7 @@ public class WebServer {
                 LOGGER.log(Level.INFO, "Python package was installed!");
             } else {
                 LOGGER.log(Level.INFO, "Could not find python package, copying script to notebook directory...");
-                Platform.runLater(() -> downloadPythonClientNotebookDir());
+                downloadPythonClientNotebookDir();
             }
 
         } catch (final InterruptedException ex) {


### PR DESCRIPTION
<!--

### Requirements

* Filling out the template is required. Any pull request that does not include
enough information to be reviewed in a timely manner may be closed at the
maintainers' discretion.
* All new code requires unit tests to ensure they work as expected and will
continue to work as new code is added in the future (regression testing).
* Make sure your branch name is prefixed by `feature`, `bugfix` or `release`
* Have you read Constellation's Code of Conduct? By filing an issue, you are
expected to comply with it, including treating everyone with respect:
https://github.com/constellation-app/constellation/blob/master/CODE_OF_CONDUCT.md

-->

### Prerequisites

- [x] Reviewed the [checklist](CHECKLIST.md)

- [ ] Reviewed feedback from the "Sonar Cloud" bot. Note that you have to wait
    for the "CI / Unit Tests") to complete first. Failed Unit tests can be 
    debugged by adding the label "verbose logging" to the GitHub PR.

### Description of the Change

Removed the `downloadPythonClientNotebookDir` call in `WebServer` off the FX thread. The function was being called on the FX thread when the python package couldn't be found after a successful install (the else case), but the majority of the code doesn't need to run on it.

### Alternate Designs

<!--

Explain what other alternates were considered and why the proposed version was
selected.

-->

### Why Should This Be In Core?

FX thread should not be running any non-JavaFX related code where possible.

### Benefits

Less code running on the FX thread

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process

<!--

What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (e.g. buttons you clicked, text you typed,
commands you ran, etc.), and describe the results you observed.

-->

### Applicable Issues

<!-- Link any applicable issues here -->
