### PR TITLE
Map view save zoom, location and provider state

### DIFF
--- a/CoreMapView/src/au/gov/asd/tac/constellation/views/mapview/MapViewState.java
+++ b/CoreMapView/src/au/gov/asd/tac/constellation/views/mapview/MapViewState.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2010-2026 Australian Signals Directorate
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package au.gov.asd.tac.constellation.views.mapview;
+
+import au.gov.asd.tac.constellation.views.mapview.providers.MapProvider;
+import de.fhpotsdam.unfolding.geo.Location;
+
+public final class MapViewState {
+    private static final int DEFAULT_ZOOM = 4;
+    private static final Location DEFAULT_LOCATION = new Location(3.0, 126.0);
+    private final MapProvider defaultProvider;
+    private MapProvider provider;
+    private Location center;
+    private int zoomLevel = -1;
+    private boolean valid = false;
+
+    public MapViewState(MapProvider defaultProvider) {
+        this.defaultProvider = defaultProvider;
+    }
+
+    public void update(MapProvider provider, Location center, int zoomLevel) {
+        this.provider = provider;
+        this.center = center;
+        this.zoomLevel = zoomLevel;
+        this.valid = true;
+    }
+
+    public MapProvider getProvider() {
+        return provider;
+    }
+
+    public Location getCenter() {
+        return center;
+    }
+
+    public int getZoomLevel() {
+        return zoomLevel;
+    }
+
+    public Location getCenterOrDefault() {
+        return center != null ? center : DEFAULT_LOCATION;
+    }
+
+    public int getZoomOrDefault() {
+        return zoomLevel >= 0 ? zoomLevel : DEFAULT_ZOOM;
+    }
+
+    public MapProvider getProviderOrDefault() {
+        return provider != null ? provider : defaultProvider;
+    }
+
+    public boolean isValid() {
+        return valid;
+    }
+}

--- a/CoreMapView/src/au/gov/asd/tac/constellation/views/mapview/MapViewState.java
+++ b/CoreMapView/src/au/gov/asd/tac/constellation/views/mapview/MapViewState.java
@@ -27,11 +27,11 @@ public final class MapViewState {
     private int zoomLevel = -1;
     private boolean valid = false;
 
-    public MapViewState(MapProvider defaultProvider) {
+    public MapViewState(final MapProvider defaultProvider) {
         this.defaultProvider = defaultProvider;
     }
 
-    public void update(MapProvider provider, Location center, int zoomLevel) {
+    public void update(final MapProvider provider, final Location center, final int zoomLevel) {
         this.provider = provider;
         this.center = center;
         this.zoomLevel = zoomLevel;

--- a/CoreMapView/src/au/gov/asd/tac/constellation/views/mapview/MapViewState.java
+++ b/CoreMapView/src/au/gov/asd/tac/constellation/views/mapview/MapViewState.java
@@ -25,17 +25,18 @@ public final class MapViewState {
     private MapProvider provider;
     private Location center;
     private int zoomLevel = -1;
-    private boolean valid = false;
 
     public MapViewState(final MapProvider defaultProvider) {
         this.defaultProvider = defaultProvider;
+        this.provider = defaultProvider;
+        this.center = DEFAULT_LOCATION;
+        this.zoomLevel = DEFAULT_ZOOM;
     }
 
     public void update(final MapProvider provider, final Location center, final int zoomLevel) {
-        this.provider = provider;
-        this.center = center;
-        this.zoomLevel = zoomLevel;
-        this.valid = true;
+        this.provider = provider != null ? provider : defaultProvider;
+        this.center = center != null ? center : DEFAULT_LOCATION;
+        this.zoomLevel = zoomLevel >= 0 ? zoomLevel : DEFAULT_ZOOM;
     }
 
     public MapProvider getProvider() {
@@ -50,19 +51,4 @@ public final class MapViewState {
         return zoomLevel;
     }
 
-    public Location getCenterOrDefault() {
-        return center != null ? center : DEFAULT_LOCATION;
-    }
-
-    public int getZoomOrDefault() {
-        return zoomLevel >= 0 ? zoomLevel : DEFAULT_ZOOM;
-    }
-
-    public MapProvider getProviderOrDefault() {
-        return provider != null ? provider : defaultProvider;
-    }
-
-    public boolean isValid() {
-        return valid;
-    }
 }

--- a/CoreMapView/src/au/gov/asd/tac/constellation/views/mapview/MapViewTileRenderer.java
+++ b/CoreMapView/src/au/gov/asd/tac/constellation/views/mapview/MapViewTileRenderer.java
@@ -76,8 +76,6 @@ public class MapViewTileRenderer extends PApplet {
     private static final Logger LOGGER = Logger.getLogger(MapViewTileRenderer.class.getName());
 
     public static final Object LOCK = new Object();
-    private static final int DEFAULT_ZOOM = 4;
-    private static final Location DEFAULT_LOCATION = new Location(3.0, 126.0);
 
     private final MapViewTopComponent parent;
     private final MarkerCache markerCache;
@@ -101,7 +99,6 @@ public class MapViewTileRenderer extends PApplet {
     public MapViewTileRenderer(final MapViewTopComponent parent) {
         this.parent = parent;
         this.markerCache = MarkerCache.getDefault();
-        this.currentProvider = parent.getDefaultProvider();
 
         this.boxSelectionEnabled = false;
         this.boxZoomEnabled = false;
@@ -109,14 +106,6 @@ public class MapViewTileRenderer extends PApplet {
         this.boxOriginY = -1;
         this.boxDeltaX = -1;
         this.boxDeltaY = -1;
-    }
-
-    public int getDefaultZoom() {
-        return DEFAULT_ZOOM;
-    }
-
-    public Location getDefaultLocation() {
-        return DEFAULT_LOCATION;
     }
 
     public MarkerCache getMarkerCache() {
@@ -149,7 +138,7 @@ public class MapViewTileRenderer extends PApplet {
         }
 
         map.setZoomRange(1, provider.zoomLevels());
-
+        parent.updateMapState(provider, map.getCenter(), map.getZoomLevel());
     }
 
     public void zoomToLocation(final Location location) {
@@ -159,7 +148,8 @@ public class MapViewTileRenderer extends PApplet {
             return;
         }
 
-        map.zoomAndPanTo(getDefaultZoom(), location == null ? getDefaultLocation() : location);
+        map.zoomAndPanTo(parent.getMapState().getZoomOrDefault(), location == null ? parent.getMapState().getCenterOrDefault() : location
+        );
     }
 
     public void zoomToMarkers(final MarkerState markerState) {
@@ -344,6 +334,11 @@ public class MapViewTileRenderer extends PApplet {
     @Override
     public void setup() {
         assert !SwingUtilities.isEventDispatchThread();
+        final MapViewState state = parent.getMapState();
+        if (!state.isValid()) {
+            return;
+        }
+        currentProvider = state.getProviderOrDefault();
 
         markerFactory = new ConstellationMarkerFactory();
         markerFactory.setDefaultColor(MarkerUtilities.DEFAULT_COLOR);
@@ -354,7 +349,7 @@ public class MapViewTileRenderer extends PApplet {
         markerFactory.setDefaultStrokeWeight(MarkerUtilities.DEFAULT_STROKE_WEIGHT);
 
         map = new UnfoldingMap(this, "Map View", currentProvider);
-        map.setTweening(true);
+        map.setTweening(false); //This is required to prevent the Unfolding apply intermediate zoom levels during loading
 
         dispatcher = MapUtils.createDefaultEventDispatcher(this, map);
         // The map library, Unfolding Maps, defaults to a hard-coded left click pan
@@ -370,19 +365,25 @@ public class MapViewTileRenderer extends PApplet {
         barScale = new BarScaleUI(this, map, 10F, this.getComponent().getHeight() - 10F);
 
         updateMarkers(parent.getCurrentGraph(), new MarkerState());
-        zoomToLocation(null);
+
+        map.mapDisplay.setMapProvider(currentProvider);
+        map.setZoomRange(1, currentProvider.zoomLevels());
+        map.zoomAndPanTo(state.getZoomLevel(), state.getCenter());
+        map.setTweening(true);
     }
 
     @Override
     public void draw() {
         assert !SwingUtilities.isEventDispatchThread();
+        if (currentProvider == null || map == null) {
+            return;
+        }
 
         background(0);
 
         if (updating) {
             // TODO: draw loading animation
         } else {
-            map.setZoomRange(0, currentProvider.zoomLevels());
             synchronized (LOCK) {
                 map.draw();
             }
@@ -402,7 +403,19 @@ public class MapViewTileRenderer extends PApplet {
             }
 
             updateClusters(parent.getMarkerState());
+            saveMapState();
         }
+    }
+
+    public void saveMapState() {
+        if (map == null) {
+            return;
+        }
+        parent.updateMapState(
+                currentProvider,
+                map.getCenter(),
+                map.getZoomLevel()
+        );
     }
 
     @Override

--- a/CoreMapView/src/au/gov/asd/tac/constellation/views/mapview/MapViewTileRenderer.java
+++ b/CoreMapView/src/au/gov/asd/tac/constellation/views/mapview/MapViewTileRenderer.java
@@ -148,7 +148,7 @@ public class MapViewTileRenderer extends PApplet {
             return;
         }
 
-        map.zoomAndPanTo(parent.getMapState().getZoomOrDefault(), location == null ? parent.getMapState().getCenterOrDefault() : location
+        map.zoomAndPanTo(parent.getMapState().getZoomLevel(), location == null ? parent.getMapState().getCenter() : location
         );
     }
 
@@ -335,10 +335,7 @@ public class MapViewTileRenderer extends PApplet {
     public void setup() {
         assert !SwingUtilities.isEventDispatchThread();
         final MapViewState state = parent.getMapState();
-        if (!state.isValid()) {
-            return;
-        }
-        currentProvider = state.getProviderOrDefault();
+        currentProvider = state.getProvider();
 
         markerFactory = new ConstellationMarkerFactory();
         markerFactory.setDefaultColor(MarkerUtilities.DEFAULT_COLOR);

--- a/CoreMapView/src/au/gov/asd/tac/constellation/views/mapview/MapViewTopComponent.java
+++ b/CoreMapView/src/au/gov/asd/tac/constellation/views/mapview/MapViewTopComponent.java
@@ -153,7 +153,8 @@ public final class MapViewTopComponent extends SwingTopComponent<Component> {
     private int cachedWidth;
     private int cachedHeight;
     private final Consumer<Graph> updateMarkers;
-    
+    private final MapViewState mapState;
+
     private static final Pattern COMMA_SEPARATED_REGEX = Pattern.compile("[,\\s]+", Pattern.UNICODE_CHARACTER_CLASS);
 
     public MapViewTopComponent() {
@@ -176,6 +177,7 @@ public final class MapViewTopComponent extends SwingTopComponent<Component> {
         this.defaultProvider = Lookup.getDefault().lookup(MapProvider.class);
         this.providers = new ArrayList<>(Lookup.getDefault().lookupAll(MapProvider.class));
         this.exporters = new ArrayList<>(Lookup.getDefault().lookupAll(MapExporter.class));
+        this.mapState = new MapViewState(this.defaultProvider);
 
         // initialise toolbar
         this.toolBar = new JToolBar(SwingConstants.HORIZONTAL);
@@ -335,7 +337,7 @@ public final class MapViewTopComponent extends SwingTopComponent<Component> {
                             || event.getComponent().getHeight() != cachedHeight) {
                         cachedWidth = event.getComponent().getWidth();
                         cachedHeight = event.getComponent().getHeight();
-                        resetContent();
+                        rebuildRenderer();
                     }
                     return null;
                 }, 500, TimeUnit.MILLISECONDS);
@@ -374,6 +376,14 @@ public final class MapViewTopComponent extends SwingTopComponent<Component> {
         if (markerState.getColorScheme().getTransactionAttribute() != null) {
             addAttributeValueChangeHandler(markerState.getColorScheme().getTransactionAttribute(), updateMarkers);
         }
+    }
+
+    public void updateMapState(final MapProvider provider, final Location center, final int zoom) {
+        mapState.update(provider, center, zoom);
+    }
+
+    public MapViewState getMapState() {
+        return mapState;
     }
 
     private void zoomLocationBasedOnGeoType(final String geoType, final String location) throws AssertionError {
@@ -505,19 +515,20 @@ public final class MapViewTopComponent extends SwingTopComponent<Component> {
                 : getHeight() - toolBar.getHeight();
     }
 
-    public void resetContent() {
-
+    public void rebuildRenderer() {
         SwingUtilities.invokeLater(() -> {
             scrollPane.setViewportView(null);
             if (renderer != null) {
+                renderer.saveMapState();
                 renderer.dispose();
             }
             renderer = new MapViewTileRenderer(this);
             glComponent = renderer.init();
             scrollPane.setViewportView(glComponent);
 
-            mapProviderMenu.setSelectedItem(defaultProvider);
-            mapProviderMenu.setText(defaultProvider.getName());
+            MapProvider provider = getMapState().getProviderOrDefault();
+            mapProviderMenu.setSelectedItem(provider);
+            mapProviderMenu.setText(provider.getName());
             markerVisibilityComboBox.setSelectedItems(MARKER_TYPE_POINT, MARKER_TYPE_LINE, MARKER_TYPE_POLYGON, MARKER_TYPE_MULTI);
             markerColorSchemeComboBox.setSelectedItem(MarkerColorScheme.DEFAULT);
             markerLabelComboBox.setSelectedItem(MarkerLabel.DEFAULT);
@@ -534,7 +545,12 @@ public final class MapViewTopComponent extends SwingTopComponent<Component> {
     @Override
     protected void handleComponentOpened() {
         super.handleComponentOpened();
-        resetContent();
+        updateMapState(
+                mapState.getProviderOrDefault(),
+                mapState.getCenterOrDefault(),
+                mapState.getZoomOrDefault()
+        );
+        rebuildRenderer();
     }
 
     @Override

--- a/CoreMapView/src/au/gov/asd/tac/constellation/views/mapview/MapViewTopComponent.java
+++ b/CoreMapView/src/au/gov/asd/tac/constellation/views/mapview/MapViewTopComponent.java
@@ -526,7 +526,7 @@ public final class MapViewTopComponent extends SwingTopComponent<Component> {
             glComponent = renderer.init();
             scrollPane.setViewportView(glComponent);
 
-            MapProvider provider = getMapState().getProviderOrDefault();
+            MapProvider provider = getMapState().getProvider();
             mapProviderMenu.setSelectedItem(provider);
             mapProviderMenu.setText(provider.getName());
             markerVisibilityComboBox.setSelectedItems(MARKER_TYPE_POINT, MARKER_TYPE_LINE, MARKER_TYPE_POLYGON, MARKER_TYPE_MULTI);
@@ -545,11 +545,6 @@ public final class MapViewTopComponent extends SwingTopComponent<Component> {
     @Override
     protected void handleComponentOpened() {
         super.handleComponentOpened();
-        updateMapState(
-                mapState.getProviderOrDefault(),
-                mapState.getCenterOrDefault(),
-                mapState.getZoomOrDefault()
-        );
         rebuildRenderer();
     }
 


### PR DESCRIPTION
<!--

### Requirements

* Filling out the template is required. Any pull request that does not include
enough information to be reviewed in a timely manner may be closed at the
maintainers' discretion.
* All new code requires unit tests to ensure they work as expected and will
continue to work as new code is added in the future (regression testing).
* Make sure your branch name is prefixed by `feature`, `bugfix` or `release`
* Have you read Constellation's Code of Conduct? By filing an issue, you are
expected to comply with it, including treating everyone with respect:
https://github.com/constellation-app/constellation/blob/master/CODE_OF_CONDUCT.md

-->

### Prerequisites

- [ ] Reviewed the [checklist](CHECKLIST.md)

- [ ] Reviewed feedback from the "Sonar Cloud" bot. Note that you have to wait
    for the "CI / Unit Tests") to complete first. Failed Unit tests can be 
    debugged by adding the label "verbose logging" to the GitHub PR.

### Description of the Change
Map view no longer resets to the default map, default location and default zoom level (4) when the window or pane is resized. This fix disposes the renderer and rebuilds it for each resize. 

The Alternate Design eliminates that but it can have issues when moving constellation window  between displays with different resolutions, and when reducing the size of the map on certain displays.
<!--

We must be able to understand the design of your change from this description.
If we can't get a good idea of what the code will be doing from the description
here, the pull request may be closed at the maintainers' discretion. Keep in
mind that the maintainer reviewing this PR may not be familiar with or have
worked with the code here recently, so please walk us through the concepts.

-->

### Alternate Designs
https://github.com/constellation-app/constellation/pull/2491
<!--

Explain what other alternates were considered and why the proposed version was
selected.

-->

### Why Should This Be In Core?
User doesn't have to reselect the map from the drop down again and manually zoom to the required location after resizing.
<!--

Explain why this functionality should be in Constellation Core as opposed to a
different module suite. Note that this question is more applicable when adding
new functionality. If this change is a minor update to an existing file then it
is understood that this change has to be to this module suite and a response
and therefore a response to this question is not required.

-->

### Benefits
Better UX
<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks
Performance limitations if resizing frequently. 
<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process

1. Open Map view and switch to another map from the map that opened by default (Not necessarily the default map). Zoom in or out to any level except 4, in a different location.
2. Resize the Map view pane or the constellation window and notice that it no longer resets to the map that opened by default.
3. Verify the same behavior after you zoom in/out to a different location in the map that opens by default as well.

<!--

What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (e.g. buttons you clicked, text you typed,
commands you ran, etc.), and describe the results you observed.

-->

### Applicable Issues
https://github.com/constellation-app/constellation/issues/2376
https://github.com/constellation-app/constellation/issues/618
