### PR TITLE
Mapview resize without reinitializing a new renderer each time

### DIFF
--- a/CoreMapView/src/au/gov/asd/tac/constellation/views/mapview/MapViewTileRenderer.java
+++ b/CoreMapView/src/au/gov/asd/tac/constellation/views/mapview/MapViewTileRenderer.java
@@ -40,6 +40,7 @@ import de.fhpotsdam.unfolding.events.ZoomMapEvent;
 import de.fhpotsdam.unfolding.geo.Location;
 import de.fhpotsdam.unfolding.ui.BarScaleUI;
 import de.fhpotsdam.unfolding.utils.MapUtils;
+import de.fhpotsdam.unfolding.utils.ScreenPosition;
 import java.applet.Applet;
 import java.awt.Component;
 import java.io.File;
@@ -97,6 +98,10 @@ public class MapViewTileRenderer extends PApplet {
     private int boxDeltaX;
     private int boxDeltaY;
     private boolean updating = false;
+    private boolean resizePending = false;
+    private int cachedWidth;
+    private int cachedHeight;
+    private float cachedZoom;
 
     public MapViewTileRenderer(final MapViewTopComponent parent) {
         this.parent = parent;
@@ -336,6 +341,11 @@ public class MapViewTileRenderer extends PApplet {
         }
     }
 
+    public void resizeContent(final int width, final int height) {
+        resizePending = true;
+        surface.setSize(width, height);
+    }
+
     @Override
     public void settings() {
         size(parent.getContentWidth(), parent.getContentHeight(), PConstants.P2D);
@@ -353,6 +363,7 @@ public class MapViewTileRenderer extends PApplet {
         markerFactory.setDefaultStrokeColor(MarkerUtilities.DEFAULT_STROKE_COLOR);
         markerFactory.setDefaultStrokeWeight(MarkerUtilities.DEFAULT_STROKE_WEIGHT);
 
+        surface.setResizable(true);
         map = new UnfoldingMap(this, "Map View", currentProvider);
         map.setTweening(true);
 
@@ -371,11 +382,32 @@ public class MapViewTileRenderer extends PApplet {
 
         updateMarkers(parent.getCurrentGraph(), new MarkerState());
         zoomToLocation(null);
+
+        cachedWidth = width;
+        cachedHeight = height;
     }
 
     @Override
     public void draw() {
         assert !SwingUtilities.isEventDispatchThread();
+        float currentZoom = map.getZoomLevel();
+        if (resizePending && (width != cachedWidth || height != cachedHeight) && currentZoom == cachedZoom) {
+            map.mapDisplay.resize(width, height);
+
+            // Adjust the visual center in the NEW window
+            Location anchor = map.getLocation(cachedWidth / 2f, cachedHeight / 2f);
+            ScreenPosition pos = map.getScreenPosition(anchor);
+
+            float targetX = width / 2f;
+            float targetY = height / 2f;
+
+            map.panBy(targetX - pos.x, targetY - pos.y);
+
+            cachedWidth = width;
+            cachedHeight = height;
+            resizePending = false;
+        }
+        cachedZoom = currentZoom;
 
         background(0);
 

--- a/CoreMapView/src/au/gov/asd/tac/constellation/views/mapview/MapViewTopComponent.java
+++ b/CoreMapView/src/au/gov/asd/tac/constellation/views/mapview/MapViewTopComponent.java
@@ -46,7 +46,6 @@ import au.gov.asd.tac.constellation.utilities.gui.JSingleChoiceComboBoxMenu;
 import au.gov.asd.tac.constellation.utilities.gui.NotifyDisplayer;
 import au.gov.asd.tac.constellation.utilities.icon.AnalyticIconProvider;
 import au.gov.asd.tac.constellation.utilities.icon.UserInterfaceIconProvider;
-import au.gov.asd.tac.constellation.utilities.threadpool.ConstellationGlobalThreadPool;
 import au.gov.asd.tac.constellation.views.SwingTopComponent;
 import au.gov.asd.tac.constellation.views.mapview.exporters.MapExporter;
 import au.gov.asd.tac.constellation.views.mapview.exporters.MapExporter.MapExporterWrapper;
@@ -72,8 +71,6 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
-import java.util.concurrent.ScheduledFuture;
-import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -82,6 +79,7 @@ import javax.swing.JToolBar;
 import javax.swing.ScrollPaneConstants;
 import javax.swing.SwingConstants;
 import javax.swing.SwingUtilities;
+import javax.swing.Timer;
 import org.openide.NotifyDescriptor;
 import org.openide.awt.ActionID;
 import org.openide.awt.ActionReference;
@@ -322,23 +320,16 @@ public final class MapViewTopComponent extends SwingTopComponent<Component> {
 
         // top component resize listener
         addComponentListener(new ComponentAdapter() {
-            ScheduledFuture<?> scheduledFuture;
+            private final Timer resizeTimer = new Timer(250, e -> {
+                renderer.resizeContent(getWidth(), getHeight());
+            });
+            {
+                resizeTimer.setRepeats(false);
+            }
 
             @Override
-            //Cancels the previous resize (future) and then performs the latest one every half second
-            public void componentResized(ComponentEvent event) {
-                if (scheduledFuture != null) {
-                    scheduledFuture.cancel(true);
-                }
-                scheduledFuture = ConstellationGlobalThreadPool.getThreadPool().getScheduledExecutorService().schedule(() -> {
-                    if (event.getComponent().getWidth() != cachedWidth
-                            || event.getComponent().getHeight() != cachedHeight) {
-                        cachedWidth = event.getComponent().getWidth();
-                        cachedHeight = event.getComponent().getHeight();
-                        resetContent();
-                    }
-                    return null;
-                }, 500, TimeUnit.MILLISECONDS);
+            public void componentResized(ComponentEvent e) {
+                resizeTimer.restart();
             }
         });
 
@@ -505,13 +496,9 @@ public final class MapViewTopComponent extends SwingTopComponent<Component> {
                 : getHeight() - toolBar.getHeight();
     }
 
-    public void resetContent() {
+    public void initMapView() {
 
         SwingUtilities.invokeLater(() -> {
-            scrollPane.setViewportView(null);
-            if (renderer != null) {
-                renderer.dispose();
-            }
             renderer = new MapViewTileRenderer(this);
             glComponent = renderer.init();
             scrollPane.setViewportView(glComponent);
@@ -534,7 +521,7 @@ public final class MapViewTopComponent extends SwingTopComponent<Component> {
     @Override
     protected void handleComponentOpened() {
         super.handleComponentOpened();
-        resetContent();
+        initMapView();
     }
 
     @Override


### PR DESCRIPTION
<!--

### Requirements

* Filling out the template is required. Any pull request that does not include
enough information to be reviewed in a timely manner may be closed at the
maintainers' discretion.
* All new code requires unit tests to ensure they work as expected and will
continue to work as new code is added in the future (regression testing).
* Make sure your branch name is prefixed by `feature`, `bugfix` or `release`
* Have you read Constellation's Code of Conduct? By filing an issue, you are
expected to comply with it, including treating everyone with respect:
https://github.com/constellation-app/constellation/blob/master/CODE_OF_CONDUCT.md

-->

### Prerequisites

- [ ] Reviewed the [checklist](CHECKLIST.md)

- [ ] Reviewed feedback from the "Sonar Cloud" bot. Note that you have to wait
    for the "CI / Unit Tests") to complete first. Failed Unit tests can be 
    debugged by adding the label "verbose logging" to the GitHub PR.

### Description of the Change
This works perfectly only on certain displays. It works on my monitor but not the laptop screen:

On the smaller screen it doesn't identify the entire space as available for the map, causing a bigger background. When resizing to a smaller size it doesn't clear, leaving parts of the previous map in the background. This could still happen in the Alternate Design but less likely.

Sometimes this can cause issues when moving constellation window between displays with different resolutions. This can move the map to appear displaced and floating when the constellation window is floating. It fixes when the constellation window is docked. 

This appears to be a limitations with AWT/Swing using floating top‑level native windows that can move between monitors with different DPI/scale, and JOGL/NEWT embedding a native OpenGL child window (GLWindow) via native reparenting (NewtCanvasAWT).

Probably we could implement this or similar after https://github.com/constellation-app/constellation/issues/1746
<!--

We must be able to understand the design of your change from this description.
If we can't get a good idea of what the code will be doing from the description
here, the pull request may be closed at the maintainers' discretion. Keep in
mind that the maintainer reviewing this PR may not be familiar with or have
worked with the code here recently, so please walk us through the concepts.

-->

### Alternate Designs
https://github.com/constellation-app/constellation/pull/2490
<!--

Explain what other alternates were considered and why the proposed version was
selected.

-->

### Why Should This Be In Core?

<!--

Explain why this functionality should be in Constellation Core as opposed to a
different module suite. Note that this question is more applicable when adding
new functionality. If this change is a minor update to an existing file then it
is understood that this change has to be to this module suite and a response
and therefore a response to this question is not required.

-->

### Benefits
Better performance when resizing.
<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process
Same as in https://github.com/constellation-app/constellation/pull/2490
<!--

What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (e.g. buttons you clicked, text you typed,
commands you ran, etc.), and describe the results you observed.

-->

### Applicable Issues
https://github.com/constellation-app/constellation/issues/2376
https://github.com/constellation-app/constellation/issues/618
<!-- Link any applicable issues here -->
