### PR TITLE
Make milliseconds component optional in Formatter.

### DIFF
--- a/CoreUtilities/src/au/gov/asd/tac/constellation/utilities/temporal/TemporalFormatting.java
+++ b/CoreUtilities/src/au/gov/asd/tac/constellation/utilities/temporal/TemporalFormatting.java
@@ -104,8 +104,11 @@ public class TemporalFormatting {
 
     /**
      * A UTC date time formatter much like DateTimeFormatter.ISO_INSTANT but
-     * with the guarantee that milliseconds will always appear. The format is
-     * yyyy-MM-dd'T'HH:mm:ss.SSS'Z'
+     * with the ability to process milliseconds if present.
+     * Use this formatter when milliseconds are expected in the source data.
+     * Making the milliseconds optional allows for cases where the milliseconds
+     * component may not be present in the source data if it is exactly zero milliseconds.
+     * The format is yyyy-MM-dd'T'HH:mm:ss.SSS'Z'
      */
     public static final DateTimeFormatter UTC_DATE_TIME_WITH_MILLISECONDS_FORMATTER = new DateTimeFormatterBuilder()
             .appendValue(ChronoField.YEAR, 4, 10, SignStyle.EXCEEDS_PAD)
@@ -119,8 +122,10 @@ public class TemporalFormatting {
             .appendValue(ChronoField.MINUTE_OF_HOUR, 2)
             .appendLiteral(SeparatorConstants.COLON)
             .appendValue(ChronoField.SECOND_OF_MINUTE, 2)
+            .optionalStart()
             .appendLiteral(SeparatorConstants.PERIOD)
             .appendValue(ChronoField.MILLI_OF_SECOND, 3)
+            .optionalEnd()
             .appendLiteral("Z")
             .toFormatter()
             .withZone(ZoneOffset.UTC);


### PR DESCRIPTION
<!--

### Requirements

* Filling out the template is required. Any pull request that does not include
enough information to be reviewed in a timely manner may be closed at the
maintainers' discretion.
* All new code requires unit tests to ensure they work as expected and will
continue to work as new code is added in the future (regression testing).
* Make sure your branch name is prefixed by `feature`, `bugfix` or `release`
* Have you read Constellation's Code of Conduct? By filing an issue, you are
expected to comply with it, including treating everyone with respect:
https://github.com/constellation-app/constellation/blob/master/CODE_OF_CONDUCT.md

-->

### Prerequisites

- [ ] Reviewed the [checklist](CHECKLIST.md)

- [ ] Reviewed feedback from the "Sonar Cloud" bot. Note that you have to wait
    for the "CI / Unit Tests") to complete first. Failed Unit tests can be 
    debugged by adding the label "verbose logging" to the GitHub PR.

### Description of the Change

Issues encountered when loading in batches of date data containing milliseconds.
On average, one in one thousand dates will have a value of zero as the milliseconds component.
Some source systems completely omit the milliseconds component when it is exactly zero,
resulting in an error in processing if we unconditionally require a milliseconds component.

The change is to make the milliseconds component optional, so dates with or without milliseconds can be processed.

<!--

We must be able to understand the design of your change from this description.
If we can't get a good idea of what the code will be doing from the description
here, the pull request may be closed at the maintainers' discretion. Keep in
mind that the maintainer reviewing this PR may not be familiar with or have
worked with the code here recently, so please walk us through the concepts.

-->

### Alternate Designs

Could make an additional Formatter with optional milliseconds without modifying the current one ...
But for most (if not all) cases, we would prefer to avoid unnecessary formatting exceptions to be raised 
when it is a valid situation where there was no milliseconds component present in the source data.

<!--

Explain what other alternates were considered and why the proposed version was
selected.

-->

### Why Should This Be In Core?

Core change to be accessible to all plugins
<!--

Explain why this functionality should be in Constellation Core as opposed to a
different module suite. Note that this question is more applicable when adding
new functionality. If this change is a minor update to an existing file then it
is understood that this change has to be to this module suite and a response
and therefore a response to this question is not required.

-->

### Benefits

Avoid unnecessary exceptions with date formatting.

<!-- What benefits will be realized by the code change? -->


### Applicable Issues

<!-- Link any applicable issues here -->
