### PR TITLE
Only use runLater when not already on the FX thread

### DIFF
--- a/CoreUtilities/src/au/gov/asd/tac/constellation/utilities/gui/field/SingleChoiceInput.java
+++ b/CoreUtilities/src/au/gov/asd/tac/constellation/utilities/gui/field/SingleChoiceInput.java
@@ -161,7 +161,11 @@ public class SingleChoiceInput<C extends Object> extends ChoiceInputField<C, C> 
 
     @Override
     public void setValue(final C value) {
-        Platform.runLater(() -> setChoice(value));
+        if (Platform.isFxApplicationThread()) {
+            setChoice(value);
+        } else {
+            Platform.runLater(() -> setChoice(value));            
+        }
     }
 
     @Override


### PR DESCRIPTION
<!--

### Requirements

* Filling out the template is required. Any pull request that does not include
enough information to be reviewed in a timely manner may be closed at the
maintainers' discretion.
* All new code requires unit tests to ensure they work as expected and will
continue to work as new code is added in the future (regression testing).
* Make sure your branch name is prefixed by `feature`, `bugfix` or `release`
* Have you read Constellation's Code of Conduct? By filing an issue, you are
expected to comply with it, including treating everyone with respect:
https://github.com/constellation-app/constellation/blob/master/CODE_OF_CONDUCT.md

-->

### Prerequisites

- [ ] Reviewed the [checklist](CHECKLIST.md)

- [ ] Reviewed feedback from the "Sonar Cloud" bot. Note that you have to wait
    for the "CI / Unit Tests") to complete first. Failed Unit tests can be 
    debugged by adding the label "verbose logging" to the GitHub PR.

### Description of the Change

An infinite loop was occurring in some Views where a SingleChoiceParameter was constantly switching between a new set value and a blank value.
Issue was due to validation processes (that are already on the FX thread) not seeing an immediate change in the single choice value.

The code now only calls runLater() when not already on the FX Thread.

### Alternate Designs

N/A

### Why Should This Be In Core?

Avoid infinite loop which causes some components to be unusable.

### Benefits

Correct functionality and usability of the Single Choice plugin parameter

### Possible Drawbacks

There may be other situations which don't function properly when the runLater() is actually called.

### Verification Process

Open the Word Cloud View
Set the Element Type to Transaction (may need to initially switch to Node type, then back to Transaction type)
Confirm the Attribute parameter is not flickering/switching between different values,
and confirm you can select an Attribute value correctly.

