### PR TITLE
Extract Words from Text Content Attribute dropdown

### DIFF
--- a/CoreDataAccessView/src/au/gov/asd/tac/constellation/views/dataaccess/plugins/importing/ExtractWordsFromTextPlugin.java
+++ b/CoreDataAccessView/src/au/gov/asd/tac/constellation/views/dataaccess/plugins/importing/ExtractWordsFromTextPlugin.java
@@ -251,15 +251,14 @@ public class ExtractWordsFromTextPlugin extends SimpleQueryPlugin implements Dat
 
             @SuppressWarnings("unchecked") //ATTRIBUTE_PARAMETER will always be of type SingleChoiceParameter
             final PluginParameter<SingleChoiceParameterValue> contentAttribute = (PluginParameter<SingleChoiceParameterValue>) parameters.getParameters().get(ATTRIBUTE_PARAMETER_ID);
-
-            SingleChoiceParameterType.setOptions(contentAttribute, attributes);
             contentAttribute.suppressEvent(true, new ArrayList<>());
+            SingleChoiceParameterType.setOptions(contentAttribute, attributes);
+            contentAttribute.suppressEvent(false, new ArrayList<>());
             if (!attributes.isEmpty() && contentAttribute.getSingleChoice() == null) {
                 final String contentAttributeName = ContentConcept.TransactionAttribute.CONTENT.getName();
                 // set the attribute to the Content attribute if it exists and the first option otherwise
                 SingleChoiceParameterType.setChoice(contentAttribute, attributes.contains(contentAttributeName) ? contentAttributeName : attributes.get(0));
             }
-            contentAttribute.suppressEvent(false, new ArrayList<>());
             contentAttribute.setObjectValue(parameters.getObjectValue(ATTRIBUTE_PARAMETER_ID));
         }
     }


### PR DESCRIPTION
<!--

### Requirements

* Filling out the template is required. Any pull request that does not include
enough information to be reviewed in a timely manner may be closed at the
maintainers' discretion.
* All new code requires unit tests to ensure they work as expected and will
continue to work as new code is added in the future (regression testing).
* Make sure your branch name is prefixed by `feature`, `bugfix` or `release`
* Have you read Constellation's Code of Conduct? By filing an issue, you are
expected to comply with it, including treating everyone with respect:
https://github.com/constellation-app/constellation/blob/master/CODE_OF_CONDUCT.md

-->

### Prerequisites

- [ ] Reviewed the [checklist](CHECKLIST.md)

- [ ] Reviewed feedback from the "Sonar Cloud" bot. Note that you have to wait
    for the "CI / Unit Tests") to complete first. Failed Unit tests can be 
    debugged by adding the label "verbose logging" to the GitHub PR.

### Description of the Change
It looks like the dropdown list was not populated with the options but it actually was.
It seems that suppressEvents has an effect when setting options, setChoice and setObjectValue in updateParameters so that the appropriate fireEvent is not triggering the updates.
Moved setOptions to between suppressEvents setting to true and turning if off (by setting to false) and it seems to work.

<!--

We must be able to understand the design of your change from this description.
If we can't get a good idea of what the code will be doing from the description
here, the pull request may be closed at the maintainers' discretion. Keep in
mind that the maintainer reviewing this PR may not be familiar with or have
worked with the code here recently, so please walk us through the concepts.

-->

### Alternate Designs
You can also remove the suppressEvent.
But the setOptions method calls the following 2 methods which does not need to fire:
1)  setObjectValue - this calls a fireChangeEvent for a null value
2) setProperty - this calls a fireChangeEvent for a new empty object

The objectValue will be set to the first option or to Content attribute after the call to the setOptions, which is when fireChangeEvent is needed. So the suppressEvent will prevent extra events from being fired => decided to leave it in.

<!--

Explain what other alternates were considered and why the proposed version was
selected.

-->

### Why Should This Be In Core?


<!--

Explain why this functionality should be in Constellation Core as opposed to a
different module suite. Note that this question is more applicable when adding
new functionality. If this change is a minor update to an existing file then it
is understood that this change has to be to this module suite and a response
and therefore a response to this question is not required.

-->

### Benefits
To fix a bug to populate the Content Attribute dropdown list.

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process

1. Open any graph
2. Open the Data Access View
3. Go to the "Extract words from Text"
4. Click on the Content Attribute - there should be options to select.
5. Close DAV. 
6. Open a graph with transactions containing Content attribute.
7. Open DAV and the Content Attribute should have Content selected.


<!--

What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (e.g. buttons you clicked, text you typed,
commands you ran, etc.), and describe the results you observed.

-->

### Applicable Issues
#2546 
<!-- Link any applicable issues here -->
