### PR TITLE
Fix Single Choice Parameter issues seen in the Word Cloud View.

### DIFF
--- a/CoreDataAccessView/test/unit/src/au/gov/asd/tac/constellation/views/dataaccess/panes/DataAccessPaneNGTest.java
+++ b/CoreDataAccessView/test/unit/src/au/gov/asd/tac/constellation/views/dataaccess/panes/DataAccessPaneNGTest.java
@@ -25,10 +25,12 @@ import au.gov.asd.tac.constellation.views.dataaccess.components.ButtonToolbar;
 import au.gov.asd.tac.constellation.views.dataaccess.components.DataAccessTabPane;
 import au.gov.asd.tac.constellation.views.dataaccess.components.OptionsMenuBar;
 import java.util.List;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeoutException;
 import java.util.function.Consumer;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import javafx.application.Platform;
 import javafx.scene.Node;
 import javafx.scene.control.ContextMenu;
 import javafx.scene.control.MenuBar;
@@ -88,8 +90,11 @@ public class DataAccessPaneNGTest {
     @AfterClass
     public static void tearDownClass() throws Exception {
         try {
+            CountDownLatch cdl = new CountDownLatch(1);
+            Platform.runLater(() -> cdl.countDown());
+            cdl.await();
             FxToolkit.cleanupStages();
-        } catch (TimeoutException ex) {
+        } catch (final TimeoutException ex) {
             LOGGER.log(Level.WARNING, "FxToolkit timedout trying to cleanup stages", ex);
         }
     }

--- a/CorePluginFramework/src/au/gov/asd/tac/constellation/plugins/gui/SingleChoiceInputPane.java
+++ b/CorePluginFramework/src/au/gov/asd/tac/constellation/plugins/gui/SingleChoiceInputPane.java
@@ -68,31 +68,32 @@ public class SingleChoiceInputPane extends ParameterInputPane<SingleChoiceParame
         // The listener needs to be assigned and then returned otherwise it doesn't update as intended
         final PluginParameterListener listener = (final PluginParameter<?> parameter, final ParameterChange change) -> {
             final PluginParameter<SingleChoiceParameterValue> scParameterValue = (PluginParameter<SingleChoiceParameterValue>) parameter;
+            final ParameterValue choice = SingleChoiceParameterType.getChoiceData(scParameterValue);
             switch (change) {
                 case VALUE -> {
                     final List<ParameterValue> paramOptions = SingleChoiceParameterType.getOptionsData(scParameterValue);
                     ((SingleChoiceInput) input).setOptions(paramOptions);
 
                     // Only keep the value if its in the new choices
-                    if (paramOptions.stream().anyMatch(paramOptions::contains)) {
-                        setFieldValue(SingleChoiceParameterType.getChoiceData(scParameterValue));
-                    } else {
-                        setFieldValue(null);
-                    }
-                    // Don't change the value if it isn't necessary 
                     final ParameterValue selection = getFieldValue();
-                    if (selection != null && !selection.equals(SingleChoiceParameterType.getChoiceData(scParameterValue))) {
-                        setFieldValue(selection);
+                    if (selection != null && choice != null) {
+                        // Don't change the value if it isn't necessary 
+                        if (!selection.equals(choice)) {                                
+                            setFieldValue(choice);
+                        }
+                    } else {
+                        // Accept current choice value (including null)
+                        setFieldValue(choice);
                     }
                 }
 
                 case PROPERTY -> {
                     // Update the pane if the options have changed 
-                    final List<ParameterValue> paramOptions = (List<ParameterValue>) SingleChoiceParameterType.getChoiceData(scParameterValue);
+                    final List<ParameterValue> paramOptions = SingleChoiceParameterType.getOptionsData(scParameterValue);
                     if (paramOptions != null) {
                         ((SingleChoiceInput) input).setOptions(paramOptions);
-                        if (paramOptions.contains(SingleChoiceParameterType.getChoiceData(scParameterValue))) {
-                            setFieldValue(SingleChoiceParameterType.getChoiceData(scParameterValue));
+                        if (paramOptions.contains(choice)) {
+                            setFieldValue(choice);
                         } else {
                             setFieldValue(null);
                         }

--- a/CorePluginFramework/src/au/gov/asd/tac/constellation/plugins/parameters/types/SingleChoiceParameterType.java
+++ b/CorePluginFramework/src/au/gov/asd/tac/constellation/plugins/parameters/types/SingleChoiceParameterType.java
@@ -135,10 +135,18 @@ public class SingleChoiceParameterType extends PluginParameterType<SingleChoiceP
         if (optionsChanged(parameter, options)) {
             final SingleChoiceParameterValue parameterValue = parameter.getParameterValue();
 
-            //Clear the existing selection
-            parameter.setObjectValue(null);
+            // Clear the selection if it's not valid for the new options
+            final ParameterValue choice = SingleChoiceParameterType.getChoiceData(parameter);
+            final boolean keepSelection;
+            if (choice instanceof StringParameterValue strChoice && options.contains(strChoice.toString())) {
+                // Keep the existing value
+                keepSelection = true;
+            } else {
+                parameter.setObjectValue(null);
+                keepSelection = false;
+            }
 
-            parameterValue.setOptions(options);
+            parameterValue.setOptions(options, keepSelection);
             parameter.setProperty(CHOICES, new Object());
         }
     }
@@ -352,16 +360,28 @@ public class SingleChoiceParameterType extends PluginParameterType<SingleChoiceP
         /**
          * Set the collection of options from a list of Strings.
          *
-         * @param options A list of Strings to set the collection of options
-         * from.
+         * @param options A list of Strings to set the collection of options from.
+         * @param keepChoice determines whether to clear or keep the current choice
          */
-        public void setOptions(final Iterable<String> options) {
+        public void setOptions(final Iterable<String> options, final boolean keepChoice) {
             this.options.clear();
             for (final String option : options) {
                 final StringParameterValue doOption = new StringParameterValue(option);
                 this.options.add(doOption);
             }
-            choice = null;
+            if (!keepChoice) {
+                choice = null;
+            }
+        }
+
+        /**
+         * Set the collection of options from a list of Strings, clearing current selection.
+         *
+         * @param options A list of Strings to set the collection of options
+         * from.
+         */
+        public void setOptions(final Iterable<String> options) {
+            setOptions(options, false);
         }
         
         /**

--- a/CoreUtilities/test/unit/src/au/gov/asd/tac/constellation/utilities/gui/field/SingleChoiceInputNGTest.java
+++ b/CoreUtilities/test/unit/src/au/gov/asd/tac/constellation/utilities/gui/field/SingleChoiceInputNGTest.java
@@ -21,9 +21,11 @@ import au.gov.asd.tac.constellation.utilities.gui.field.framework.LeftButtonSupp
 import au.gov.asd.tac.constellation.utilities.gui.field.framework.RightButtonSupport;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeoutException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import javafx.application.Platform;
 import javafx.scene.control.MenuItem;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import org.mockito.Mockito;
@@ -33,6 +35,7 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import org.testfx.api.FxToolkit;
+import static org.testng.Assert.fail;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
@@ -104,6 +107,14 @@ public class SingleChoiceInputNGTest {
         options.add(choice);
         instance.setOptions(options);
         instance.setValue(choice);
+        CountDownLatch cdl = new CountDownLatch(1);
+        Platform.runLater(() -> cdl.countDown());
+        try {
+            cdl.await();
+        } catch (final InterruptedException ex) {
+            fail("FAILED set and get on SingleChoiceInput");
+        }
+        
         final Object result = instance.getValue();
         assertEquals(result, choice);
     }

--- a/CoreWordCloudView/src/au/gov/asd/tac/constellation/views/wordcloud/ui/WordCloudParametersPane.java
+++ b/CoreWordCloudView/src/au/gov/asd/tac/constellation/views/wordcloud/ui/WordCloudParametersPane.java
@@ -174,14 +174,18 @@ public class WordCloudParametersPane extends TitledPane implements PluginParamet
             if (transAttributes.contains(PhrasiphyContentParameters.ATTRIBUTE_TO_ANALYSE_DEFAULT_TRANSACTIONS)) {
                 attrParam.setStringValue(PhrasiphyContentParameters.ATTRIBUTE_TO_ANALYSE_DEFAULT_TRANSACTIONS);
             } else {
-                attrParam.setStringValue(EMPTY_STRING);
+                if (!transAttributes.contains(attrParam.getStringValue())) {
+                    attrParam.setStringValue(EMPTY_STRING);
+                }
             }
             SingleChoiceParameterType.setOptions(attrParam, this.transAttributes);
         } else if ("node".equals(elParam.getStringValue())) {
             if (nodeAttributes.contains(PhrasiphyContentParameters.ATTRIBUTE_TO_ANALYSE_DEFAULT_NODES)) {
                 attrParam.setStringValue(PhrasiphyContentParameters.ATTRIBUTE_TO_ANALYSE_DEFAULT_NODES);
             } else {
-                attrParam.setStringValue(EMPTY_STRING);
+                if (!nodeAttributes.contains(attrParam.getStringValue())) {
+                    attrParam.setStringValue(EMPTY_STRING);
+                }
             }
             SingleChoiceParameterType.setOptions(attrParam, this.nodeAttributes);
         }


### PR DESCRIPTION
<!--

### Requirements

* Filling out the template is required. Any pull request that does not include
enough information to be reviewed in a timely manner may be closed at the
maintainers' discretion.
* All new code requires unit tests to ensure they work as expected and will
continue to work as new code is added in the future (regression testing).
* Make sure your branch name is prefixed by `feature`, `bugfix` or `release`
* Have you read Constellation's Code of Conduct? By filing an issue, you are
expected to comply with it, including treating everyone with respect:
https://github.com/constellation-app/constellation/blob/master/CODE_OF_CONDUCT.md

-->

### Prerequisites

- [ ] Reviewed the [checklist](CHECKLIST.md)

- [ ] Reviewed feedback from the "Sonar Cloud" bot. Note that you have to wait
    for the "CI / Unit Tests") to complete first. Failed Unit tests can be 
    debugged by adding the label "verbose logging" to the GitHub PR.

### Description of the Change

Single Choice parameters were not being updated/refreshed correctly.
Some instances were found where no options were being presented.
In those cases it was incorrectly using an empty set of selections as the data for the options list.


### Why Should This Be In Core?

Bug Fix

### Benefits

Bug Fix

### Possible Drawbacks

-

### Verification Process

Launch Constellation, open the Word Cloud View, THEN open a new or existing graph and confirm that the Attributes dropdown in the Word Cloud View is correctly listing all available attributes (and not an empty list).
Select the Label attribute and open another graph.
Confirm the selected attribute is still set to Label.
Add the Content.Author attribute to one of the graphs and set the Word Cloud View Attribute field to Content.Author.
Select a different graph and confirm the Word Cloud View Attribute field has been cleared (since Content.Author is not valid for the new graph)

Recommend testing in other areas of the product that use a SingleChoiceInputParameter

### Applicable Issues

#2547
