### PR TITLE
Fix for extact words trigger and content being set to empty string on…

### DIFF
--- a/CoreDataAccessView/src/au/gov/asd/tac/constellation/views/dataaccess/plugins/importing/ExtractWordsFromTextPlugin.java
+++ b/CoreDataAccessView/src/au/gov/asd/tac/constellation/views/dataaccess/plugins/importing/ExtractWordsFromTextPlugin.java
@@ -251,9 +251,7 @@ public class ExtractWordsFromTextPlugin extends SimpleQueryPlugin implements Dat
 
             @SuppressWarnings("unchecked") //ATTRIBUTE_PARAMETER will always be of type SingleChoiceParameter
             final PluginParameter<SingleChoiceParameterValue> contentAttribute = (PluginParameter<SingleChoiceParameterValue>) parameters.getParameters().get(ATTRIBUTE_PARAMETER_ID);
-            contentAttribute.suppressEvent(true, new ArrayList<>());
             SingleChoiceParameterType.setOptions(contentAttribute, attributes);
-            contentAttribute.suppressEvent(false, new ArrayList<>());
             if (!attributes.isEmpty() && contentAttribute.getSingleChoice() == null) {
                 final String contentAttributeName = ContentConcept.TransactionAttribute.CONTENT.getName();
                 // set the attribute to the Content attribute if it exists and the first option otherwise

--- a/CoreWordCloudView/src/au/gov/asd/tac/constellation/views/wordcloud/ui/WordCloudParametersPane.java
+++ b/CoreWordCloudView/src/au/gov/asd/tac/constellation/views/wordcloud/ui/WordCloudParametersPane.java
@@ -38,6 +38,7 @@ import javafx.scene.control.TitledPane;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.VBox;
 import javafx.stage.FileChooser;
+import org.apache.commons.lang3.StringUtils;
 
 /**
  *
@@ -173,7 +174,9 @@ public class WordCloudParametersPane extends TitledPane implements PluginParamet
         if ("transaction".equals(elParam.getStringValue())) {
             SingleChoiceParameterType.setOptions(attrParam, this.transAttributes);
             if (transAttributes.contains(PhrasiphyContentParameters.ATTRIBUTE_TO_ANALYSE_DEFAULT_TRANSACTIONS)) {
-                attrParam.setStringValue(PhrasiphyContentParameters.ATTRIBUTE_TO_ANALYSE_DEFAULT_TRANSACTIONS);
+                if (StringUtils.isBlank(attrParam.getStringValue()) || (StringUtils.isNotBlank(attrParam.getStringValue()) && !transAttributes.contains(attrParam.getStringValue()))) {
+                    attrParam.setStringValue(PhrasiphyContentParameters.ATTRIBUTE_TO_ANALYSE_DEFAULT_TRANSACTIONS);
+                }
             } else {
                 if (!transAttributes.contains(attrParam.getStringValue())) {
                     attrParam.setStringValue(EMPTY_STRING);
@@ -182,7 +185,9 @@ public class WordCloudParametersPane extends TitledPane implements PluginParamet
         } else if ("node".equals(elParam.getStringValue())) {
             SingleChoiceParameterType.setOptions(attrParam, this.nodeAttributes);
             if (nodeAttributes.contains(PhrasiphyContentParameters.ATTRIBUTE_TO_ANALYSE_DEFAULT_NODES)) {
-                attrParam.setStringValue(PhrasiphyContentParameters.ATTRIBUTE_TO_ANALYSE_DEFAULT_NODES);
+                if (StringUtils.isBlank(attrParam.getStringValue()) || (StringUtils.isNotBlank(attrParam.getStringValue()) && !nodeAttributes.contains(attrParam.getStringValue()))) {
+                    attrParam.setStringValue(PhrasiphyContentParameters.ATTRIBUTE_TO_ANALYSE_DEFAULT_NODES);
+                }
             } else {
                 if (!nodeAttributes.contains(attrParam.getStringValue())) {
                     attrParam.setStringValue(EMPTY_STRING);

--- a/CoreWordCloudView/src/au/gov/asd/tac/constellation/views/wordcloud/ui/WordCloudParametersPane.java
+++ b/CoreWordCloudView/src/au/gov/asd/tac/constellation/views/wordcloud/ui/WordCloudParametersPane.java
@@ -174,7 +174,7 @@ public class WordCloudParametersPane extends TitledPane implements PluginParamet
         if ("transaction".equals(elParam.getStringValue())) {
             SingleChoiceParameterType.setOptions(attrParam, this.transAttributes);
             if (transAttributes.contains(PhrasiphyContentParameters.ATTRIBUTE_TO_ANALYSE_DEFAULT_TRANSACTIONS)) {
-                if (StringUtils.isBlank(attrParam.getStringValue()) || (StringUtils.isNotBlank(attrParam.getStringValue()) && !transAttributes.contains(attrParam.getStringValue()))) {
+                if (StringUtils.isBlank(attrParam.getStringValue()) || !transAttributes.contains(attrParam.getStringValue())) {
                     attrParam.setStringValue(PhrasiphyContentParameters.ATTRIBUTE_TO_ANALYSE_DEFAULT_TRANSACTIONS);
                 }
             } else {
@@ -185,7 +185,7 @@ public class WordCloudParametersPane extends TitledPane implements PluginParamet
         } else if ("node".equals(elParam.getStringValue())) {
             SingleChoiceParameterType.setOptions(attrParam, this.nodeAttributes);
             if (nodeAttributes.contains(PhrasiphyContentParameters.ATTRIBUTE_TO_ANALYSE_DEFAULT_NODES)) {
-                if (StringUtils.isBlank(attrParam.getStringValue()) || (StringUtils.isNotBlank(attrParam.getStringValue()) && !nodeAttributes.contains(attrParam.getStringValue()))) {
+                if (StringUtils.isBlank(attrParam.getStringValue()) || !nodeAttributes.contains(attrParam.getStringValue())) {
                     attrParam.setStringValue(PhrasiphyContentParameters.ATTRIBUTE_TO_ANALYSE_DEFAULT_NODES);
                 }
             } else {

--- a/CoreWordCloudView/src/au/gov/asd/tac/constellation/views/wordcloud/ui/WordCloudParametersPane.java
+++ b/CoreWordCloudView/src/au/gov/asd/tac/constellation/views/wordcloud/ui/WordCloudParametersPane.java
@@ -171,23 +171,23 @@ public class WordCloudParametersPane extends TitledPane implements PluginParamet
         final PluginParameter<SingleChoiceParameterValue> attrParam = (PluginParameter<SingleChoiceParameterValue>) params.getParameters().get(PhrasiphyContentParameters.ATTRIBUTE_TO_ANALYSE_PARAMETER_ID);
 
         if ("transaction".equals(elParam.getStringValue())) {
+            SingleChoiceParameterType.setOptions(attrParam, this.transAttributes);
             if (transAttributes.contains(PhrasiphyContentParameters.ATTRIBUTE_TO_ANALYSE_DEFAULT_TRANSACTIONS)) {
                 attrParam.setStringValue(PhrasiphyContentParameters.ATTRIBUTE_TO_ANALYSE_DEFAULT_TRANSACTIONS);
             } else {
                 if (!transAttributes.contains(attrParam.getStringValue())) {
                     attrParam.setStringValue(EMPTY_STRING);
                 }
-            }
-            SingleChoiceParameterType.setOptions(attrParam, this.transAttributes);
+            }            
         } else if ("node".equals(elParam.getStringValue())) {
+            SingleChoiceParameterType.setOptions(attrParam, this.nodeAttributes);
             if (nodeAttributes.contains(PhrasiphyContentParameters.ATTRIBUTE_TO_ANALYSE_DEFAULT_NODES)) {
                 attrParam.setStringValue(PhrasiphyContentParameters.ATTRIBUTE_TO_ANALYSE_DEFAULT_NODES);
             } else {
                 if (!nodeAttributes.contains(attrParam.getStringValue())) {
                     attrParam.setStringValue(EMPTY_STRING);
                 }
-            }
-            SingleChoiceParameterType.setOptions(attrParam, this.nodeAttributes);
+            }            
         }
     }
     


### PR DESCRIPTION
… selection

<!--

### Requirements

* Filling out the template is required. Any pull request that does not include
enough information to be reviewed in a timely manner may be closed at the
maintainers' discretion.
* All new code requires unit tests to ensure they work as expected and will
continue to work as new code is added in the future (regression testing).
* Make sure your branch name is prefixed by `feature`, `bugfix` or `release`
* Have you read Constellation's Code of Conduct? By filing an issue, you are
expected to comply with it, including treating everyone with respect:
https://github.com/constellation-app/constellation/blob/master/CODE_OF_CONDUCT.md

-->

### Prerequisites

- [ ] Reviewed the [checklist](CHECKLIST.md)

- [ ] Reviewed feedback from the "Sonar Cloud" bot. Note that you have to wait
    for the "CI / Unit Tests") to complete first. Failed Unit tests can be 
    debugged by adding the label "verbose logging" to the GitHub PR.

### Description of the Change
1) Extract Words from Text suppressEvent was suppressing the fireChangeEvent in the Choices property which sets the choice in setFieldValue. Remove the SuppressEvent to allow the choice to be set in the dropdown list.

2) When switching between graphs where Content attribute does and does not exist on graph, the choice selected is set to empty string/null for when the Content attribute is available. This is because the options for that graph had not been set before setStringValue is called. Moved the setOptions to above setStringValue call.


<!--

We must be able to understand the design of your change from this description.
If we can't get a good idea of what the code will be doing from the description
here, the pull request may be closed at the maintainers' discretion. Keep in
mind that the maintainer reviewing this PR may not be familiar with or have
worked with the code here recently, so please walk us through the concepts.

-->

### Alternate Designs

<!--

Explain what other alternates were considered and why the proposed version was
selected.

-->

### Why Should This Be In Core?

<!--

Explain why this functionality should be in Constellation Core as opposed to a
different module suite. Note that this question is more applicable when adding
new functionality. If this change is a minor update to an existing file then it
is understood that this change has to be to this module suite and a response
and therefore a response to this question is not required.

-->

### Benefits

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process


1. Open Consty. 
2. Open a graph with no content attribute in any of the transactions.
3. Open a graph with content attribute in any of the transactions.

For Extract Words from Text verification:

1. Open Data Access View -> Extract Words from Text
2. Content Attribute should default to Activity (first in the list)
3. Switch to graph with content. Activity should still be selected in Content Attribute.
4. Check the Content Attribute drop down list, drop down list should list Content. 

For Word Cloud View verification:

1. Open Word Cloud view
2. Select Element Type = transaction. Select Attribute = Activity.
3. Switch to graph with content attribute. Attribute selection should not change. Dropdown list should list content.
4. Switch to graph with no content. Attribute selection should not change.  Drop down list does not list content.
5. Clear the Attribute selection (select the blank option). Switch to graph with Content. The Word Cloud View should auto-select Content in the Attribute dropdown.
6. Switch back to the graph with no content and the Word Cloud Attribute should be cleared.

<!--

What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (e.g. buttons you clicked, text you typed,
commands you ran, etc.), and describe the results you observed.

-->

### Applicable Issues
#2546 #2547 
<!-- Link any applicable issues here -->
