### PR TITLE
Fix Notes View Null Pointer Exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Constellation Changes
 
+## Changes in July 2026
+-   Fixed a NullPointerException in the Notes View when rendering notes with null content, colour, or selection lists (e.g. auto notes from plugin reports).
+
 ## Changes in June 2026
 -   Removed `ArrangeInScatter3dComponentsPlugin` which was unused.
 -   Updated `AbstractBoundingBox` to be an abstract class to reflect its intended use.

--- a/CoreNotesView/src/au/gov/asd/tac/constellation/views/notes/NotesViewPane.java
+++ b/CoreNotesView/src/au/gov/asd/tac/constellation/views/notes/NotesViewPane.java
@@ -843,9 +843,8 @@ public class NotesViewPane extends BorderPane {
                 selectionLabelText = "Note linked to: the graph.";
             } else {
                 selectionLabelText = "Note linked to: ";
-                // Null-guard: selection lists can be null for some persisted/user notes.
-                final int nodeCount = newNote.getNodesSelected() != null ? newNote.getNodesSelected().size() : 0;
-                final int transactionCount = newNote.getTransactionsSelected() != null ? newNote.getTransactionsSelected().size() : 0;
+                final int nodeCount = newNote.getNodesSelected().size();
+                final int transactionCount = newNote.getTransactionsSelected().size();
                 if (nodeCount == 1) {
                     selectionLabelText += nodeCount + " node, ";
                 } else {
@@ -1008,20 +1007,16 @@ public class NotesViewPane extends BorderPane {
                     // Select the specific nodes and/or transactions applied to the note.
                     // Add nodes that are selected to the note.
                     final List<Integer> selectedNodes = newNote.getNodesSelected();
-                    if (selectedNodes != null) {
-                        final int nodesLength = selectedNodes.size();
-                        for (int i = 0; i < nodesLength; i++) {
-                            elementIdsVx.set(selectedNodes.get(i));
-                        }
+                    final int nodesLength = selectedNodes.size();
+                    for (int i = 0; i < nodesLength; i++) {
+                        elementIdsVx.set(selectedNodes.get(i));
                     }
 
                     // Add transactions that are selected to the note.
                     final List<Integer> selectedTransactions = newNote.getTransactionsSelected();
-                    if (selectedTransactions != null) {
-                        final int transactionsLength = selectedTransactions.size();
-                        for (int i = 0; i < transactionsLength; i++) {
-                            elementIdsTx.set(selectedTransactions.get(i));
-                        }
+                    final int transactionsLength = selectedTransactions.size();
+                    for (int i = 0; i < transactionsLength; i++) {
+                        elementIdsTx.set(selectedTransactions.get(i));
                     }
                 }
 
@@ -1057,7 +1052,7 @@ public class NotesViewPane extends BorderPane {
                 }
             });
 
-            if (newNote.getNodesSelected() != null && newNote.getTransactionsSelected() != null && newNote.getNodesSelected().isEmpty() && newNote.getTransactionsSelected().isEmpty()) {
+            if (newNote.getNodesSelected().isEmpty() && newNote.getTransactionsSelected().isEmpty()) {
                 addOnGraphMenuItem.disableProperty().set(true);
                 removeOnGraphMenuItem.disableProperty().set(true);
             }
@@ -1156,8 +1151,7 @@ public class NotesViewPane extends BorderPane {
             if (noteToEdit.isGraphAttribute()) {
                 noteToEdit.setGraphAttribute(false);
             }
-            final List<Integer> originalNodes = noteToEdit.getNodesSelected() != null
-                    ? noteToEdit.getNodesSelected() : new ArrayList<>();
+            final List<Integer> originalNodes = noteToEdit.getNodesSelected();
             nodesSelected.forEach(node -> {
                 if (!originalNodes.contains(node)) {
                     originalNodes.add(node);
@@ -1170,8 +1164,7 @@ public class NotesViewPane extends BorderPane {
             if (noteToEdit.isGraphAttribute()) {
                 noteToEdit.setGraphAttribute(false);
             }
-            final List<Integer> originalTransactions = noteToEdit.getTransactionsSelected() != null
-                    ? noteToEdit.getTransactionsSelected() : new ArrayList<>();
+            final List<Integer> originalTransactions = noteToEdit.getTransactionsSelected();
             transactionsSelected.forEach(transaction -> {
                 if (!originalTransactions.contains(transaction)) {
                     originalTransactions.add(transaction);
@@ -1187,7 +1180,7 @@ public class NotesViewPane extends BorderPane {
     public void removeFromSelectedElements(final NotesViewEntry noteToEdit) {
         updateSelectedElements();
 
-        if (!nodesSelected.isEmpty() && noteToEdit.getNodesSelected() != null) {
+        if (!nodesSelected.isEmpty()) {
             final List<Integer> originalNodes = noteToEdit.getNodesSelected();
             nodesSelected.forEach(node -> {
                 if (originalNodes.contains(node)) {
@@ -1198,7 +1191,7 @@ public class NotesViewPane extends BorderPane {
             noteToEdit.setNodesSelected(originalNodes);
         }
 
-        if (!transactionsSelected.isEmpty() && noteToEdit.getTransactionsSelected() != null) {
+        if (!transactionsSelected.isEmpty()) {
             final List<Integer> originalTransactions = noteToEdit.getTransactionsSelected();
             transactionsSelected.forEach(transaction -> {
                 if (originalTransactions.contains(transaction)) {
@@ -1209,9 +1202,7 @@ public class NotesViewPane extends BorderPane {
             noteToEdit.setTransactionsSelected(originalTransactions);
         }
 
-        final List<Integer> nodes = noteToEdit.getNodesSelected();
-        final List<Integer> transactions = noteToEdit.getTransactionsSelected();
-        if ((nodes == null || nodes.isEmpty()) && (transactions == null || transactions.isEmpty())) {
+        if (noteToEdit.getNodesSelected().isEmpty() && noteToEdit.getTransactionsSelected().isEmpty()) {
             noteToEdit.setGraphAttribute(true);
         }
     }

--- a/CoreNotesView/src/au/gov/asd/tac/constellation/views/notes/NotesViewPane.java
+++ b/CoreNotesView/src/au/gov/asd/tac/constellation/views/notes/NotesViewPane.java
@@ -843,15 +843,18 @@ public class NotesViewPane extends BorderPane {
                 selectionLabelText = "Note linked to: the graph.";
             } else {
                 selectionLabelText = "Note linked to: ";
-                if (newNote.getNodesSelected().size() == 1) {
-                    selectionLabelText += newNote.getNodesSelected().size() + " node, ";
+                // Null-guard: selection lists can be null for some persisted/user notes.
+                final int nodeCount = newNote.getNodesSelected() != null ? newNote.getNodesSelected().size() : 0;
+                final int transactionCount = newNote.getTransactionsSelected() != null ? newNote.getTransactionsSelected().size() : 0;
+                if (nodeCount == 1) {
+                    selectionLabelText += nodeCount + " node, ";
                 } else {
-                    selectionLabelText += newNote.getNodesSelected().size() + " nodes, ";
+                    selectionLabelText += nodeCount + " nodes, ";
                 }
-                if (newNote.getTransactionsSelected().size() == 1) {
-                    selectionLabelText += newNote.getTransactionsSelected().size() + " transaction. ";
+                if (transactionCount == 1) {
+                    selectionLabelText += transactionCount + " transaction. ";
                 } else {
-                    selectionLabelText += newNote.getTransactionsSelected().size() + " transactions. ";
+                    selectionLabelText += transactionCount + " transactions. ";
                 }
             }
             selectionLabel.setText(selectionLabelText);
@@ -896,13 +899,19 @@ public class NotesViewPane extends BorderPane {
         gap.setMinWidth(10);
         gap2.setMinWidth(10);
 
-        if (newNote.getNodeColour().isBlank()) {
+        if (StringUtils.isBlank(newNote.getNodeColour())) {
             newNote.setNodeColour(USER_COLOR);
         }
 
         HBox.setHgrow(dateTimeLabel, Priority.NEVER);
 
-        final ColorPicker colourPicker = new ColorPicker(ConstellationColor.fromHtmlColor(newNote.getNodeColour()).getJavaFXColor());
+        // fromHtmlColor returns null for invalid colours; fall back to the default user colour.
+        ConstellationColor noteColour = ConstellationColor.fromHtmlColor(newNote.getNodeColour());
+        if (noteColour == null) {
+            newNote.setNodeColour(USER_COLOR);
+            noteColour = ConstellationColor.fromHtmlColor(USER_COLOR);
+        }
+        final ColorPicker colourPicker = new ColorPicker(noteColour.getJavaFXColor());
         colourPicker.setMinWidth(100);
         colourPicker.setMaxWidth(100);
         HBox.setHgrow(colourPicker, Priority.NEVER);
@@ -1002,17 +1011,21 @@ public class NotesViewPane extends BorderPane {
                 } else {
                     // Select the specific nodes and/or transactions applied to the note.
                     // Add nodes that are selected to the note.
-                    final int nodesLength = newNote.getNodesSelected().size();
                     final List<Integer> selectedNodes = newNote.getNodesSelected();
-                    for (int i = 0; i < nodesLength; i++) {
-                        elementIdsVx.set(selectedNodes.get(i));
+                    if (selectedNodes != null) {
+                        final int nodesLength = selectedNodes.size();
+                        for (int i = 0; i < nodesLength; i++) {
+                            elementIdsVx.set(selectedNodes.get(i));
+                        }
                     }
 
                     // Add transactions that are selected to the note.
-                    final int transactionsLength = newNote.getTransactionsSelected().size();
                     final List<Integer> selectedTransactions = newNote.getTransactionsSelected();
-                    for (int i = 0; i < transactionsLength; i++) {
-                        elementIdsTx.set(selectedTransactions.get(i));
+                    if (selectedTransactions != null) {
+                        final int transactionsLength = selectedTransactions.size();
+                        for (int i = 0; i < transactionsLength; i++) {
+                            elementIdsTx.set(selectedTransactions.get(i));
+                        }
                     }
                 }
 
@@ -1147,7 +1160,8 @@ public class NotesViewPane extends BorderPane {
             if (noteToEdit.isGraphAttribute()) {
                 noteToEdit.setGraphAttribute(false);
             }
-            final List<Integer> originalNodes = noteToEdit.getNodesSelected();
+            final List<Integer> originalNodes = noteToEdit.getNodesSelected() != null
+                    ? noteToEdit.getNodesSelected() : new ArrayList<>();
             nodesSelected.forEach(node -> {
                 if (!originalNodes.contains(node)) {
                     originalNodes.add(node);
@@ -1160,7 +1174,8 @@ public class NotesViewPane extends BorderPane {
             if (noteToEdit.isGraphAttribute()) {
                 noteToEdit.setGraphAttribute(false);
             }
-            final List<Integer> originalTransactions = noteToEdit.getTransactionsSelected();
+            final List<Integer> originalTransactions = noteToEdit.getTransactionsSelected() != null
+                    ? noteToEdit.getTransactionsSelected() : new ArrayList<>();
             transactionsSelected.forEach(transaction -> {
                 if (!originalTransactions.contains(transaction)) {
                     originalTransactions.add(transaction);
@@ -1176,7 +1191,7 @@ public class NotesViewPane extends BorderPane {
     public void removeFromSelectedElements(final NotesViewEntry noteToEdit) {
         updateSelectedElements();
 
-        if (!nodesSelected.isEmpty()) {
+        if (!nodesSelected.isEmpty() && noteToEdit.getNodesSelected() != null) {
             final List<Integer> originalNodes = noteToEdit.getNodesSelected();
             nodesSelected.forEach(node -> {
                 if (originalNodes.contains(node)) {
@@ -1187,7 +1202,7 @@ public class NotesViewPane extends BorderPane {
             noteToEdit.setNodesSelected(originalNodes);
         }
 
-        if (!transactionsSelected.isEmpty()) {
+        if (!transactionsSelected.isEmpty() && noteToEdit.getTransactionsSelected() != null) {
             final List<Integer> originalTransactions = noteToEdit.getTransactionsSelected();
             transactionsSelected.forEach(transaction -> {
                 if (originalTransactions.contains(transaction)) {
@@ -1198,7 +1213,9 @@ public class NotesViewPane extends BorderPane {
             noteToEdit.setTransactionsSelected(originalTransactions);
         }
 
-        if (noteToEdit.getNodesSelected().isEmpty() && noteToEdit.getTransactionsSelected().isEmpty()) {
+        final List<Integer> nodes = noteToEdit.getNodesSelected();
+        final List<Integer> transactions = noteToEdit.getTransactionsSelected();
+        if ((nodes == null || nodes.isEmpty()) && (transactions == null || transactions.isEmpty())) {
             noteToEdit.setGraphAttribute(true);
         }
     }

--- a/CoreNotesView/src/au/gov/asd/tac/constellation/views/notes/NotesViewPane.java
+++ b/CoreNotesView/src/au/gov/asd/tac/constellation/views/notes/NotesViewPane.java
@@ -899,13 +899,9 @@ public class NotesViewPane extends BorderPane {
         gap.setMinWidth(10);
         gap2.setMinWidth(10);
 
-        if (StringUtils.isBlank(newNote.getNodeColour())) {
-            newNote.setNodeColour(USER_COLOR);
-        }
-
         HBox.setHgrow(dateTimeLabel, Priority.NEVER);
 
-        // fromHtmlColor returns null for invalid colours; fall back to the default user colour.
+        // fromHtmlColor returns null for blank/invalid colours; fall back to the default user colour.
         ConstellationColor noteColour = ConstellationColor.fromHtmlColor(newNote.getNodeColour());
         if (noteColour == null) {
             newNote.setNodeColour(USER_COLOR);

--- a/CoreNotesView/src/au/gov/asd/tac/constellation/views/notes/state/NotesViewEntry.java
+++ b/CoreNotesView/src/au/gov/asd/tac/constellation/views/notes/state/NotesViewEntry.java
@@ -120,11 +120,19 @@ public class NotesViewEntry implements PluginReportListener {
     }
 
     public void setNodesSelected(final List<Integer> nodesSelected) {
-        this.nodesSelected = nodesSelected;
+        if (userCreated) {
+            this.nodesSelected = nodesSelected != null ? nodesSelected : new ArrayList<>();
+        } else {
+            this.nodesSelected = nodesSelected;
+        }
     }
 
     public void setTransactionsSelected(final List<Integer> transactionsSelected) {
-        this.transactionsSelected = transactionsSelected;
+        if (userCreated) {
+            this.transactionsSelected = transactionsSelected != null ? transactionsSelected : new ArrayList<>();
+        } else {
+            this.transactionsSelected = transactionsSelected;
+        }
     }
 
     public void setNoteTitle(final String noteTitle) {

--- a/CoreNotesView/src/au/gov/asd/tac/constellation/views/notes/state/NotesViewEntry.java
+++ b/CoreNotesView/src/au/gov/asd/tac/constellation/views/notes/state/NotesViewEntry.java
@@ -57,8 +57,9 @@ public class NotesViewEntry implements PluginReportListener {
 
     public NotesViewEntry(final String dateTime, final String noteTitle, final String noteContent, final boolean userCreated, final boolean graphAttribute, final String nodeColour, final boolean inMarkdown) {
         this.dateTime = dateTime;
-        this.noteTitle = noteTitle;
-        this.noteContent = noteContent;
+        // Guard against null title/content (e.g. plugin reports with no message) to avoid NPEs when rendering notes.
+        this.noteTitle = noteTitle != null ? noteTitle : "";
+        this.noteContent = noteContent != null ? noteContent : "";
         contentTextFlow = new TextFlow();
       
         tempContent = "";
@@ -127,11 +128,11 @@ public class NotesViewEntry implements PluginReportListener {
     }
 
     public void setNoteTitle(final String noteTitle) {
-        this.noteTitle = noteTitle;
+        this.noteTitle = noteTitle != null ? noteTitle : "";
     }
 
     public void setNoteContent(final String noteContent) {
-        this.noteContent = noteContent;
+        this.noteContent = noteContent != null ? noteContent : "";
     }
 
     public List<String> getTags() {
@@ -143,7 +144,9 @@ public class NotesViewEntry implements PluginReportListener {
     }
 
     public void setNodeColour(final String nodeColour) {
-        this.nodeColour = nodeColour;
+        if (nodeColour != null) {
+            this.nodeColour = nodeColour;
+        }
     }
 
     public void setTags(final List<String> tags) {
@@ -221,7 +224,8 @@ public class NotesViewEntry implements PluginReportListener {
 
     @Override
     public void pluginReportChanged(final PluginReport pluginReport) {
-        this.noteContent = pluginReport.getLastMessage();
+        final String message = pluginReport.getLastMessage();
+        this.noteContent = message != null ? message : "";
     }
 
     @Override

--- a/CoreNotesView/src/au/gov/asd/tac/constellation/views/notes/state/NotesViewEntry.java
+++ b/CoreNotesView/src/au/gov/asd/tac/constellation/views/notes/state/NotesViewEntry.java
@@ -120,19 +120,11 @@ public class NotesViewEntry implements PluginReportListener {
     }
 
     public void setNodesSelected(final List<Integer> nodesSelected) {
-        if (userCreated) {
-            this.nodesSelected = nodesSelected != null ? nodesSelected : new ArrayList<>();
-        } else {
-            this.nodesSelected = nodesSelected;
-        }
+        this.nodesSelected = userCreated && nodesSelected == null ? new ArrayList<>() : nodesSelected;
     }
 
     public void setTransactionsSelected(final List<Integer> transactionsSelected) {
-        if (userCreated) {
-            this.transactionsSelected = transactionsSelected != null ? transactionsSelected : new ArrayList<>();
-        } else {
-            this.transactionsSelected = transactionsSelected;
-        }
+        this.transactionsSelected = userCreated && transactionsSelected == null ? new ArrayList<>() : transactionsSelected;
     }
 
     public void setNoteTitle(final String noteTitle) {

--- a/CoreNotesView/test/unit/src/au/gov/asd/tac/constellation/views/notes/state/NotesViewEntryNGTest.java
+++ b/CoreNotesView/test/unit/src/au/gov/asd/tac/constellation/views/notes/state/NotesViewEntryNGTest.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright 2010-2026 Australian Signals Directorate
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package au.gov.asd.tac.constellation.views.notes.state;
+
+import au.gov.asd.tac.constellation.plugins.reporting.PluginReport;
+import java.util.concurrent.TimeoutException;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import org.testfx.api.FxToolkit;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+/**
+ * Unit tests for null-safe NotesViewEntry construction and updates.
+ *
+ * @author arimu1
+ */
+public class NotesViewEntryNGTest {
+
+    private static final Logger LOGGER = Logger.getLogger(NotesViewEntryNGTest.class.getName());
+
+    @BeforeClass
+    public static void setUpClass() throws Exception {
+        if (!FxToolkit.isFXApplicationThreadRunning()) {
+            FxToolkit.registerPrimaryStage();
+        }
+    }
+
+    @AfterClass
+    public static void tearDownClass() throws Exception {
+        try {
+            FxToolkit.cleanupStages();
+        } catch (TimeoutException ex) {
+            LOGGER.log(Level.WARNING, "FxToolkit timed out trying to cleanup stages", ex);
+        }
+    }
+
+    @BeforeMethod
+    public void setUpMethod() throws Exception {
+        // Not currently required
+    }
+
+    @AfterMethod
+    public void tearDownMethod() throws Exception {
+        // Not currently required
+    }
+
+    /**
+     * Null title and content from plugin reports must not be stored as null.
+     */
+    @Test
+    public void testConstructorNullTitleAndContent() {
+        final NotesViewEntry entry = new NotesViewEntry(
+                "0",
+                null,
+                null,
+                false,
+                false,
+                "#ffffff",
+                false
+        );
+
+        assertEquals(entry.getNoteTitle(), "");
+        assertEquals(entry.getNoteContent(), "");
+        assertFalse(entry.isUserCreated());
+        assertNotNull(entry.getNodeColour());
+    }
+
+    /**
+     * Null colour argument must leave the default colour in place.
+     */
+    @Test
+    public void testConstructorNullColourKeepsDefault() {
+        final NotesViewEntry entry = new NotesViewEntry(
+                "0",
+                "title",
+                "content",
+                true,
+                true,
+                null,
+                false
+        );
+
+        assertEquals(entry.getNodeColour(), "#a26fc0");
+        assertNotNull(entry.getNodesSelected());
+        assertNotNull(entry.getTransactionsSelected());
+    }
+
+    /**
+     * Setters must not accept null title/content/colour.
+     */
+    @Test
+    public void testSettersRejectNull() {
+        final NotesViewEntry entry = new NotesViewEntry(
+                "0",
+                "title",
+                "content",
+                true,
+                true,
+                "#123456",
+                false
+        );
+
+        entry.setNoteTitle(null);
+        entry.setNoteContent(null);
+        entry.setNodeColour(null);
+
+        assertEquals(entry.getNoteTitle(), "");
+        assertEquals(entry.getNoteContent(), "");
+        assertEquals(entry.getNodeColour(), "#123456");
+    }
+
+    /**
+     * Plugin report updates with a null last message must not store null content.
+     */
+    @Test
+    public void testPluginReportChangedNullMessage() {
+        final NotesViewEntry entry = new NotesViewEntry(
+                "0",
+                "plugin",
+                "initial",
+                false,
+                false,
+                "#ffffff",
+                false
+        );
+
+        final PluginReport report = mock(PluginReport.class);
+        when(report.getLastMessage()).thenReturn(null);
+
+        entry.pluginReportChanged(report);
+
+        assertEquals(entry.getNoteContent(), "");
+    }
+}

--- a/CoreNotesView/test/unit/src/au/gov/asd/tac/constellation/views/notes/state/NotesViewEntryNGTest.java
+++ b/CoreNotesView/test/unit/src/au/gov/asd/tac/constellation/views/notes/state/NotesViewEntryNGTest.java
@@ -132,6 +132,30 @@ public class NotesViewEntryNGTest {
     }
 
     /**
+     * User-created notes must always retain non-null selection lists.
+     */
+    @Test
+    public void testUserCreatedSettersRejectNullSelectionLists() {
+        final NotesViewEntry entry = new NotesViewEntry(
+                "0",
+                "title",
+                "content",
+                true,
+                false,
+                "#123456",
+                false
+        );
+
+        entry.setNodesSelected(null);
+        entry.setTransactionsSelected(null);
+
+        assertNotNull(entry.getNodesSelected());
+        assertNotNull(entry.getTransactionsSelected());
+        assertEquals(entry.getNodesSelected().size(), 0);
+        assertEquals(entry.getTransactionsSelected().size(), 0);
+    }
+
+    /**
      * Plugin report updates with a null last message must not store null content.
      */
     @Test

--- a/CoreNotesView/test/unit/src/au/gov/asd/tac/constellation/views/notes/state/NotesViewEntryNGTest.java
+++ b/CoreNotesView/test/unit/src/au/gov/asd/tac/constellation/views/notes/state/NotesViewEntryNGTest.java
@@ -84,7 +84,7 @@ public class NotesViewEntryNGTest {
         assertEquals(entry.getNoteTitle(), "");
         assertEquals(entry.getNoteContent(), "");
         assertFalse(entry.isUserCreated());
-        assertNotNull(entry.getNodeColour());
+        assertEquals(entry.getNodeColour(), "#ffffff");
     }
 
     /**


### PR DESCRIPTION
### Prerequisites

- [x] Reviewed the [checklist](CHECKLIST.md)

- [ ] Reviewed feedback from the "Sonar Cloud" bot. Note that you have to wait
    for the "CI / Unit Tests") to complete first. Failed Unit tests can be
    debugged by adding the label "verbose logging" to the GitHub PR.

### Description of the Change

When the Notes View rebuilt its UI (for example while auto notes were being created from plugin reports such as the Sphere Graph Builder), `createNote` could throw a `NullPointerException`.

The stack trace from #1528 pointed at `NotesViewPane.createNote`. At the time the failure was `contentTextArea.getText().length()` when a note had null content (common for in-progress plugin reports). The TextArea path has since been replaced, but the same null sources still exist and can NPE elsewhere in `createNote` and related selection helpers:

- `NotesViewEntry` could store a null title/content/colour (constructor, setters, and `pluginReportChanged`)
- selection lists (`nodesSelected` / `transactionsSelected`) were dereferenced without null checks, while other call sites already guarded them
- `ConstellationColor.fromHtmlColor(...).getJavaFXColor()` NPE'd when the colour string was invalid

This change:

1. Normalises null title/content to empty strings in `NotesViewEntry` (construction, setters, plugin report listener)
2. Ignores null colour on `setNodeColour` (same approach as the constructor)
3. Null-guards selection lists in `createNote`, "Select on Graph", and add/remove selected element helpers, matching the existing style used elsewhere in the pane
4. Uses `StringUtils.isBlank` for colour and falls back to the default user colour when `fromHtmlColor` returns null
5. Adds unit tests for the null-safe `NotesViewEntry` behaviour
6. Updates `CHANGELOG.md`

### Alternate Designs

Hardening only the UI layer was considered, but normalising nulls at the model (`NotesViewEntry`) prevents the same values from causing NPEs in future callers (state IO, listeners, markdown rendering).

### Why Should This Be In Core?

Bug fix for an existing Core Notes View feature.

### Benefits

- Notes View no longer crashes when rendering auto notes or notes with incomplete selection/colour data
- Behaviour is consistent with existing null checks already used for selection lists in the same class

### Possible Drawbacks

None expected; null values are replaced with empty/default values rather than changing valid note data.

### Verification Process

- Reviewed the original #1528 stack against the historical `createNote` implementation and current code
- Confirmed no open prior PR targets this issue
- Added `NotesViewEntryNGTest` covering null title/content/colour and null plugin report messages
- Full NetBeans/ant suite not run locally (ant not available in this environment); CI unit tests should cover the module

### Applicable Issues

Fixes #1528